### PR TITLE
Seperate offline and online feature registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ rm.**
 *.pb.go
 **pb**
 venv/
+venv/**
 terraform.tfstate
 .venv
 

--- a/client/src/featureform/proto/metadata.proto
+++ b/client/src/featureform/proto/metadata.proto
@@ -86,6 +86,7 @@ message ResourceStatus {
         PENDING = 2;
         READY = 3;
         FAILED = 4;
+        READY_ONLINE = 5;
       }
     Status status = 1;
     string error_message = 2;

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -635,7 +635,7 @@ func (c *Coordinator) runFeatureMaterializeJob(resID metadata.ResourceID, schedu
 	if err := completionWatcher.Wait(); err != nil {
 		return fmt.Errorf("completion watcher running: %w", err)
 	}
-	if err := c.Metadata.SetStatus(context.Background(), resID, metadata.READY, ""); err != nil {
+	if err := c.Metadata.SetStatus(context.Background(), resID, metadata.READY_ONLINE, ""); err != nil {
 		return fmt.Errorf("materialize set success: %w", err)
 	}
 	if schedule != "" {

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -1318,7 +1318,7 @@ func testCoordinatorMaterializeFeature(addr string) error {
 	if err != nil {
 		return fmt.Errorf("could not get feature variant")
 	}
-	if metadata.READY != featureComplete.Status() {
+	if metadata.READY_ONLINE != featureComplete.Status() {
 		return fmt.Errorf("Feature not set to ready once job completes")
 	}
 	resourceTable, err := onlineStore.GetTable(featureName, "")

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -642,7 +642,7 @@ func TestRunPrimaryTableJobError(t *testing.T) {
 		t.Fatalf("could not get provider as offline store: %v", err)
 	}
 	sourceResourceID := metadata.ResourceID{sourceNoPrimaryNameSet, "", metadata.SOURCE_VARIANT}
-	if err := coord.runPrimaryTableJob(transformSource, sourceResourceID, offlineProvider, ""); err == nil {
+	if err := coord.runPrimaryTableJob(transformSource, sourceResourceID, offlineProvider); err == nil {
 		t.Fatalf("did not catch error trying to run primary table job with no source table set")
 	}
 	sourceNoActualPrimaryTable := createSafeUUID()
@@ -682,7 +682,7 @@ func TestRunPrimaryTableJobError(t *testing.T) {
 		t.Fatalf("could not fetch created source variant: %v", err)
 	}
 	newSourceResourceID := metadata.ResourceID{sourceNoActualPrimaryTable, "", metadata.SOURCE_VARIANT}
-	if err := coord.runPrimaryTableJob(newTransformSource, newSourceResourceID, offlineProvider, ""); err == nil {
+	if err := coord.runPrimaryTableJob(newTransformSource, newSourceResourceID, offlineProvider); err == nil {
 		t.Fatalf("did not catch error trying to create primary table when no source table exists in database")
 	}
 }

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -58,11 +58,12 @@ func (r ResourceType) Serialized() pb.ResourceType {
 type ResourceStatus int32
 
 const (
-	NO_STATUS ResourceStatus = ResourceStatus(pb.ResourceStatus_NO_STATUS)
-	CREATED                  = ResourceStatus(pb.ResourceStatus_CREATED)
-	PENDING                  = ResourceStatus(pb.ResourceStatus_PENDING)
-	READY                    = ResourceStatus(pb.ResourceStatus_READY)
-	FAILED                   = ResourceStatus(pb.ResourceStatus_FAILED)
+	NO_STATUS    ResourceStatus = ResourceStatus(pb.ResourceStatus_NO_STATUS)
+	CREATED                     = ResourceStatus(pb.ResourceStatus_CREATED)
+	PENDING                     = ResourceStatus(pb.ResourceStatus_PENDING)
+	READY                       = ResourceStatus(pb.ResourceStatus_READY)
+	FAILED                      = ResourceStatus(pb.ResourceStatus_FAILED)
+	READY_ONLINE                = ResourceStatus(pb.ResourceStatus_READY_ONLINE)
 )
 
 func (r ResourceStatus) String() string {

--- a/metadata/proto/metadata.proto
+++ b/metadata/proto/metadata.proto
@@ -86,6 +86,7 @@ message ResourceStatus {
         PENDING = 2;
         READY = 3;
         FAILED = 4;
+        READY_ONLINE = 5;
       }
     Status status = 1;
     string error_message = 2;


### PR DESCRIPTION
If a feature is registered without a provider, it defaults to registering it in the offline store. With an online provider (only online is valid and makes sense) it will register offline if not registered so far, and then registers it online.

Also for some reason the pb file was commited, then i deleted it, so it interpets it as a big delete when it's generated with testing anyway