### PR TITLE
Adding pre-commit functionality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,3 @@ repos:
     hooks:
     -   id: detect-secrets
         args: []
-        exclude: .*/tests/.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+-   repo: https://github.com/Yelp/detect-secrets
+    rev: v1.2.0
+    hooks:
+    -   id: detect-secrets
+        args: []
+        exclude: .*/tests/.*

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -15,7 +15,7 @@ brew install pre-commit
 
 ## Using pre-commit
 1. Inside the root level of the repository, run `pre-commit install`. 
-2. Commit a change to the repository. The commit will trigger the hooks to be executed. Upon the passing all the hooks, the commit will be achieved. If any hooks, the commit will not go through. 
+2. Commit a change to the repository. The commit will trigger the hooks to be executed. Upon the passing all the hooks, the commit will be achieved. If any hook fails, the commit will not go through. 
 
 Example of successful message:
 

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -1,0 +1,25 @@
+# pre-Commit
+
+[pre-commit](https://pre-commit.com/) is a tool that allows users to add hooks before you can commit any changes to the repository.
+
+## Install pre-commit
+### Using Python
+```
+pip install pre-commit
+```
+### Using Homebrew
+```
+brew install pre-commit
+```
+<br /> 
+
+## Using pre-commit
+1. Inside the root level of the repository, run `pre-commit install`. 
+2. Commit a change to the repository. The commit will trigger the hooks to be executed. Upon the passing all the hooks, the commit will be achieved. If any hooks, the commit will not go through. 
+
+<br /> 
+
+## Currently Installed Hooks
+
+- **[Yelp's detect-secrets](https://github.com/Yelp/detect-secrets)**: this detects secrets within the repository. For more information including how to ignore false positives, check their GitHub repository.
+

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -1,4 +1,4 @@
-# pre-Commit
+# pre-commit
 
 [pre-commit](https://pre-commit.com/) is a tool that allows users to add hooks before you can commit any changes to the repository.
 
@@ -17,9 +17,18 @@ brew install pre-commit
 1. Inside the root level of the repository, run `pre-commit install`. 
 2. Commit a change to the repository. The commit will trigger the hooks to be executed. Upon the passing all the hooks, the commit will be achieved. If any hooks, the commit will not go through. 
 
+Example of successful message:
+
+```
+$ git commit -m "adding pre-commit docs"
+Detect secrets...........................................................Passed
+[feature/precommit 96fa97c] adding pre-commit docs
+ 1 file changed, 25 insertions(+)
+ create mode 100644 docs/pre-commit.md
+```
+
 <br /> 
 
 ## Currently Installed Hooks
 
 - **[Yelp's detect-secrets](https://github.com/Yelp/detect-secrets)**: this detects secrets within the repository. For more information including how to ignore false positives, check their GitHub repository.
-


### PR DESCRIPTION
This PR is adding the pre-commit functionality with detect-secrets hook. [pre-commit](https://pre-commit.com/) is a tool to run some hooks prior to committing changes to the repository locally. This PR is just adding [Yelp's detect-secrets](https://github.com/Yelp/detect-secrets) hook but there are other hooks that we can look into and add as well. 