### PR TITLE
set host to FEATUREFORM_HOST if not passed when creating a `ServingClient`

### DIFF
--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -24,6 +24,12 @@ class Client:
                 raise ValueError("Cannot be local and have a host")
             self.sqldb = SQLiteMetadata()
         else:
+            host = host or os.getenv('FEATUREFORM_HOST')
+            if host is None:
+                raise RuntimeError(
+                    'If not in local mode then `host` must be passed or the environment'
+                    ' variable FEATUREFORM_HOST must be set.'
+                )
             env_cert_path = os.getenv('FEATUREFORM_CERT')
             if tls_verify:
                 credentials = grpc.ssl_channel_credentials()


### PR DESCRIPTION
Right now instantiating `ServingClient` without any arguments (such as in the quickstart here: https://docs.featureform.com/quickstart-kubernetes), even if the environment variable `FEATUREFORM_HOST` is set, results in the error that looks like the following:

```
File ~/anaconda3/envs/structured/lib/python3.8/site-packages/grpc/_channel.py:1479, in Channel.__init__(self, target, options, credentials, compression)
   1476 self._single_threaded_unary_stream = _DEFAULT_SINGLE_THREADED_UNARY_STREAM
   1477 self._process_python_options(python_options)
   1478 self._channel = cygrpc.Channel(
-> 1479     _common.encode(target), _augment_options(core_options, compression),
   1480     credentials)
   1481 self._call_state = _ChannelCallState(self._channel)
   1482 self._connectivity_state = _ChannelConnectivityState(self._channel)

File ~/anaconda3/envs/structured/lib/python3.8/site-packages/grpc/_common.py:72, in encode(s)
     70     return s
     71 else:
---> 72     return s.encode('utf8')

AttributeError: 'NoneType' object has no attribute 'encode'
```

This MR will set host to the environment variable `FEATUREFORM_HOST` if host was not explicitly passed. In the case host isn't passed and `FEATUREFORM_HOST` isn't set, a `RuntimeError` is raised.