### PR TITLE
Make register_file consistent with registering other resources

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -129,12 +129,7 @@ class LocalProvider:
         if owner == "":
             owner = self.__registrar.must_get_default_owner()
         # Store the file as a source
-        time_created = str(time.time())
-        self.sqldb.insert("sources", "Source", variant, name)
-        self.sqldb.insert("source_variant", time_created, description, name,
-                          "Source", owner, self.name(), variant, "ready", 0, "", path)
-        # Where the definition = path
-
+        self.__registrar.register_primary_data(name, variant, SQLTable(path), self.__provider.name, owner, description)
         return LocalSource(self.__registrar, name, owner, variant, self.name(), path, description)
 
     def insert_provider(self):

--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -357,6 +357,9 @@ class PrimaryData:
                     name=self.location.name, ), ),
         }
 
+    def name(self):
+        return self.location.name
+
 
 class Transformation:
     pass
@@ -440,7 +443,8 @@ class Source:
             self.is_transformation = 1
             self.inputs = self.definition.inputs
             self.definition = self.definition.query
-
+        if type(self.definition) == PrimaryData:
+            self.definition = self.definition.name()
         db.insert_source("source_variant",
                          str(time.time()),
                          self.description,

--- a/client/tests/redefined_test.py
+++ b/client/tests/redefined_test.py
@@ -16,13 +16,6 @@ class TestResourcesRedefined:
             path="transactions.csv"
         )
 
-        transactions = local.register_file(
-            name="transactions",
-            variant="quickstart",
-            description="A dataset of fraudulent transactions",
-            path="transactions.csv"
-        )
-
         user = ff.register_entity("user")
         user = ff.register_entity("user")
 
@@ -88,7 +81,7 @@ class TestResourcesRedefined:
         local = ff.register_local()
 
         transactions = local.register_file(
-            name="transactions",
+            name="transaction",
             variant="quickstart",
             description="A dataset of fraudulent transactions",
             path="transactions.csv"
@@ -99,7 +92,7 @@ class TestResourcesRedefined:
         client.apply()
 
         @local.df_transformation(variant="quickstart",
-                                 inputs=[("transactions", "quickstart")])
+                                 inputs=[("transaction", "quickstart")])
         def average_user_transaction(transactions):
             """the average transaction amount for a user """
             return transactions.groupby("CustomerID")["TransactionAmount"].mean()

--- a/client/tests/redefined_test.py
+++ b/client/tests/redefined_test.py
@@ -16,6 +16,13 @@ class TestResourcesRedefined:
             path="transactions.csv"
         )
 
+        transactions = local.register_file(
+            name="transactions",
+            variant="quickstart",
+            description="A dataset of fraudulent transactions",
+            path="transactions.csv"
+        )
+
         user = ff.register_entity("user")
         user = ff.register_entity("user")
 
@@ -87,9 +94,17 @@ class TestResourcesRedefined:
             path="transactions.csv"
         )
 
-        user = ff.register_entity("user")
+        transactions = local.register_file(
+            name="transaction",
+            variant="quickstart",
+            description="A dataset of fraudulent transaction",
+            path="transaction.csv"
+        )
 
-        client.apply()
+        with pytest.raises(ResourceRedefinedError):
+            client.apply()
+
+        user = ff.register_entity("user")
 
         @local.df_transformation(variant="quickstart",
                                  inputs=[("transaction", "quickstart")])


### PR DESCRIPTION
When a file is registered, it will now be added to the __resources list just like all other resources. It will also be added to the metadata table in the same way that other resources are.