### PR TITLE
use pip3 and python3 instead of pip and python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ pytest:
 	pytest client/tests/local_test.py
 	pytest client/tests/serving_test.py
 	pytest client/tests/localmode_quickstart_test.py
-	pip install jupyter nbconvert matplotlib pandas scikit-learn requests
+	pip3 install jupyter nbconvert matplotlib pandas scikit-learn requests
 	jupyter nbconvert --to notebook --execute notebooks/Fraud_Detection_Example.ipynb
 	-rm -r .featureform
 
@@ -49,10 +49,10 @@ gen_grpc:						## Generates GRPC Dependencies
 	cp proto/serving.proto client/src/featureform/proto/serving.proto
 
 	protoc --go_out=. --go_opt=paths=source_relative     --go-grpc_out=. --go-grpc_opt=paths=source_relative     ./proto/serving.proto
-	python -m grpc_tools.protoc -I ./client/src --python_out=./client/src --grpc_python_out=./client/src/ ./client/src/featureform/proto/serving.proto
+	python3 -m grpc_tools.protoc -I ./client/src --python_out=./client/src --grpc_python_out=./client/src/ ./client/src/featureform/proto/serving.proto
 
 	protoc --go_out=. --go_opt=paths=source_relative     --go-grpc_out=. --go-grpc_opt=paths=source_relative     ./metadata/proto/metadata.proto
-	python -m grpc_tools.protoc -I ./client/src --python_out=./client/src/ --grpc_python_out=./client/src/ ./client/src/featureform/proto/metadata.proto
+	python3 -m grpc_tools.protoc -I ./client/src --python_out=./client/src/ --grpc_python_out=./client/src/ ./client/src/featureform/proto/metadata.proto
 
 update_python: gen_grpc 			## Updates the python package locally
 	pip3 install pytest
@@ -115,5 +115,3 @@ reset_e2e: etcd						## Resets Cluster. Requires install_etcd
 	while ! echo exit | nc localhost 2379; do sleep 10; done
 	etcdctl --user=root:secretpassword del "" --prefix
 	-helm uninstall quickstart
-
-

--- a/gen_grpc.sh
+++ b/gen_grpc.sh
@@ -8,7 +8,7 @@ cp metadata/proto/metadata.proto client/src/featureform/proto/metadata.proto
 cp proto/serving.proto client/src/featureform/proto/serving.proto
 
 protoc --go_out=. --go_opt=paths=source_relative     --go-grpc_out=. --go-grpc_opt=paths=source_relative     ./proto/serving.proto
-python -m grpc_tools.protoc -I ./client/src --python_out=./client/src --grpc_python_out=./client/src/ ./client/src/featureform/proto/serving.proto
+python3 -m grpc_tools.protoc -I ./client/src --python_out=./client/src --grpc_python_out=./client/src/ ./client/src/featureform/proto/serving.proto
 
 protoc --go_out=. --go_opt=paths=source_relative     --go-grpc_out=. --go-grpc_opt=paths=source_relative     ./metadata/proto/metadata.proto
-python -m grpc_tools.protoc -I ./client/src --python_out=./client/src/ --grpc_python_out=./client/src/ ./client/src/featureform/proto/metadata.proto
+python3 -m grpc_tools.protoc -I ./client/src --python_out=./client/src/ --grpc_python_out=./client/src/ ./client/src/featureform/proto/metadata.proto

--- a/pip_update.sh
+++ b/pip_update.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-pip uninstall featureform -y
+pip3 uninstall featureform -y
 rm -r client/dist/*
 cd dashboard && npm run build
 cd ../
 mkdir -p client/src/featureform/dashboard/
 cp -r dashboard/out client/src/featureform/dashboard/
 python3 -m build ./client/
-pip install client/dist/*.whl
+pip3 install client/dist/*.whl


### PR DESCRIPTION
# Description
Modifying the script files to leverage `python3` and `pip3` because `python` and `pip` might point to `python2` and `pip2` respectively. 
<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue? 
No
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have fixed any merge conflicts
