### PR TITLE
Fix Helm Chart Deployment

### DIFF
--- a/charts/featureform/values.yaml
+++ b/charts/featureform/values.yaml
@@ -80,7 +80,7 @@ global:
   port: 3001
   metadata:
     port: 8080
-  version: "1.1.0-rc"
+  version: "0.0.0"
   repo: "featureformcom"
   pullPolicy: "Always"
   publicCert: false

--- a/update_helm.sh
+++ b/update_helm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 gsutil cp -r gs://featureform-helm ./
+sed -i -e "s/0.0.0/$1/g" ./charts/featureform/values.yaml
 helm package ./charts/featureform -d featureform-helm --app-version $1 --version $1
 helm repo index ./featureform-helm
 gsutil cp ./featureform-helm/* gs://featureform-helm

--- a/update_helm.sh
+++ b/update_helm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 gsutil cp -r gs://featureform-helm ./
-sed -i -e "s/0.0.0/$1/g" ./charts/featureform/values.yaml
+sed -i -e "s/0.0.0/$1/g" ./charts/featureform/values.yaml # Sets the default image tag value in the chart
 helm package ./charts/featureform -d featureform-helm --app-version $1 --version $1
 helm repo index ./featureform-helm
 gsutil cp ./featureform-helm/* gs://featureform-helm


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The helm chart needs the variable global.version to changed to the associated docker image tag since the --version build tag does not work for nested charts. 

The better way to do this would be to flatten the chart or the build the subcharts separately. This fix is a quicker solution since the others will take more time and are not essential at the moment.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
