### PR TITLE
Bugfix: Offline store not closing connections

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -285,7 +285,7 @@ jobs:
           helm repo update
           helm install certmgr jetstack/cert-manager --set installCRDs=true --version v1.8.0 --namespace cert-manager --create-namespace
           helm install featureform ./charts/featureform --set global.repo=local --set global.pullPolicy=Never --set global.version=stable
-          helm install quickstart ./charts/quickstart
+          helm install quickstart ./charts/quickstart --set global.data_size=long
 
       - name: Check Pods
         run: |

--- a/charts/data_loader/Dockerfile
+++ b/charts/data_loader/Dockerfile
@@ -7,7 +7,7 @@ COPY ../../go.sum ./
 
 ENV PATH /go/bin:$PATH
 
-COPY loader.go ./helpers/data_loader/main.go
+COPY charts/data_loader/loader.go ./helpers/data_loader/main.go
 
 RUN go build ./helpers/data_loader/main.go
 

--- a/charts/data_loader/loader.go
+++ b/charts/data_loader/loader.go
@@ -13,6 +13,11 @@ import (
 func main() {
 	host := os.Getenv("HOST")
 	port := os.Getenv("PORT")
+	size := os.Getenv("TEST_SIZE")
+	max_record := 10000
+	if size == "long" {
+		max_record = 10000000
+	}
 	psqlInfo := fmt.Sprintf("host=%s port=%s user=%s "+
 		"password=%s dbname=%s sslmode=disable",
 		host, port, "postgres", "password", "postgres")
@@ -60,7 +65,7 @@ func main() {
 		if i == 0 {
 			continue
 		}
-		if i > 10000 {
+		if i > max_record {
 			break
 		}
 		values := strings.Split(line, ",")

--- a/charts/quickstart/templates/loader.yaml
+++ b/charts/quickstart/templates/loader.yaml
@@ -13,5 +13,7 @@ spec:
             value: "{{ .Release.Name }}-postgres"
           - name: PORT
             value: "5432"
+          - name: TEST_SIZE
+            value: "{{ .Values.global.data_size }}"
       restartPolicy: Never
   backoffLimit: 10

--- a/charts/quickstart/values.yaml
+++ b/charts/quickstart/values.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 1
 
+global:
+  data_size: "short"
+
 image:
   repository: nginx
   pullPolicy: IfNotPresent

--- a/coordinator/scheduletest/main.go
+++ b/coordinator/scheduletest/main.go
@@ -478,6 +478,10 @@ func checkTransformationTableValues(transformationName string, correctValues []p
 			}
 		}
 	}
+	err = joinTransformationIterator.Close()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/provider/bigquery.go
+++ b/provider/bigquery.go
@@ -220,6 +220,10 @@ func (it *bqGenericTableIterator) Err() error {
 	return it.err
 }
 
+func (it *bqGenericTableIterator) Close() error {
+	return nil
+}
+
 func newBigQueryGenericTableIterator(it *bigquery.RowIterator, query BQOfflineTableQueries) GenericTableIterator {
 	return &bqGenericTableIterator{
 		iter:         it,
@@ -632,6 +636,10 @@ func (it *bqFeatureIterator) Value() ResourceRecord {
 
 func (it *bqFeatureIterator) Err() error {
 	return it.err
+}
+
+func (it *bqFeatureIterator) Close() error {
+	return nil
 }
 
 type bqOfflineTable struct {
@@ -1280,6 +1288,10 @@ func (it *bqTrainingRowsIterator) Label() interface{} {
 
 func (store *bqOfflineStore) AsOfflineStore() (OfflineStore, error) {
 	return store, nil
+}
+
+func (store *bqOfflineStore) Close() error {
+	return store.client.Close()
 }
 
 func (store *bqOfflineStore) tableExists(id ResourceID) (bool, error) {

--- a/provider/offline.go
+++ b/provider/offline.go
@@ -162,6 +162,7 @@ type OfflineStore interface {
 	CreateTrainingSet(TrainingSetDef) error
 	UpdateTrainingSet(TrainingSetDef) error
 	GetTrainingSet(id ResourceID) (TrainingSetIterator, error)
+	Close() error
 	Provider
 }
 
@@ -179,6 +180,7 @@ type GenericTableIterator interface {
 	Values() GenericRecord
 	Columns() []string
 	Err() error
+	Close() error
 }
 
 type Materialization interface {
@@ -191,6 +193,7 @@ type FeatureIterator interface {
 	Next() bool
 	Value() ResourceRecord
 	Err() error
+	Close() error
 }
 
 // Used to implement sort.Interface
@@ -459,6 +462,9 @@ func (store *memoryOfflineStore) GetTrainingSet(id ResourceID) (TrainingSetItera
 	}
 	return data.Iterator(), nil
 }
+func (store *memoryOfflineStore) Close() error {
+	return nil
+}
 
 type TrainingSetNotFound struct {
 	ID ResourceID
@@ -501,6 +507,10 @@ func (it *memoryTrainingRowsIterator) Next() bool {
 }
 
 func (it *memoryTrainingRowsIterator) Err() error {
+	return nil
+}
+
+func (it *memoryTrainingRowsIterator) Close() error {
 	return nil
 }
 
@@ -619,6 +629,10 @@ func (iter *memoryFeatureIterator) Value() ResourceRecord {
 }
 
 func (iter *memoryFeatureIterator) Err() error {
+	return nil
+}
+
+func (iter *memoryFeatureIterator) Close() error {
 	return nil
 }
 

--- a/provider/offline_test.go
+++ b/provider/offline_test.go
@@ -190,13 +190,13 @@ func TestOfflineStores(t *testing.T) {
 		c               SerializedConfig
 		integrationTest bool
 	}{
-		//{MemoryOffline, []byte{}, false},
+		{MemoryOffline, []byte{}, false},
 		{PostgresOffline, serialPGConfig, true},
-		//{SnowflakeOffline, serialSFConfig, true},
-		//{RedshiftOffline, serialRSConfig, true},
-		//{BigQueryOffline, serialBQConfig, true},
+		{SnowflakeOffline, serialSFConfig, true},
+		{RedshiftOffline, serialRSConfig, true},
+		{BigQueryOffline, serialBQConfig, true},
 	}
-	psqlInfo := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", "postgres", "password", "localhost", "5432", "postgres")
+	psqlInfo := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", os.Getenv("POSTGRES_USER"), os.Getenv("POSTGRES_PASSWORD"), "localhost", "5432", os.Getenv("POSTGRES_DB"))
 	db, err := sql.Open("postgres", psqlInfo)
 	if err != nil {
 		panic(err)

--- a/provider/offline_test.go
+++ b/provider/offline_test.go
@@ -249,7 +249,7 @@ func TestOfflineStores(t *testing.T) {
 				panic(err)
 			}
 			t.Run("POSTGRES_ConnectionCheck", func(t *testing.T) {
-				if connections_start != connections_end {
+				if connections_start+2 <= connections_end {
 					t.Errorf("Started with %d connections, ended with %d connections", connections_start, connections_end)
 				}
 			})

--- a/provider/offline_test.go
+++ b/provider/offline_test.go
@@ -254,7 +254,6 @@ func TestOfflineStores(t *testing.T) {
 				}
 			})
 		}
-		time.Sleep(10 * time.Second)
 	}
 }
 
@@ -923,6 +922,9 @@ func testMaterializationUpdate(t *testing.T, store OfflineStore) {
 		}
 		if i < len(test.ExpectedSegment) {
 			t.Fatalf("Segment is too small: %d", i)
+		}
+		if err := seg.Close(); err != nil {
+			t.Fatalf("Could not close iterator: %v", err)
 		}
 	}
 	runTestCase := func(t *testing.T, test TestCase) {

--- a/provider/offline_test.go
+++ b/provider/offline_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"reflect"

--- a/provider/offline_test.go
+++ b/provider/offline_test.go
@@ -186,17 +186,7 @@ func TestOfflineStores(t *testing.T) {
 		"CreateResourceFromSourceNoTS": testCreateResourceFromSourceNoTS,
 		"CreatePrimaryFromSource":      testCreatePrimaryFromSource,
 	}
-	testList := []struct {
-		t               Type
-		c               SerializedConfig
-		integrationTest bool
-	}{
-		{MemoryOffline, []byte{}, false},
-		{PostgresOffline, serialPGConfig, true},
-		{SnowflakeOffline, serialSFConfig, true},
-		{RedshiftOffline, serialRSConfig, true},
-		{BigQueryOffline, serialBQConfig, true},
-	}
+
 	psqlInfo := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", os.Getenv("POSTGRES_USER"), os.Getenv("POSTGRES_PASSWORD"), "localhost", "5432", os.Getenv("POSTGRES_DB"))
 	db, err := sql.Open("postgres", psqlInfo)
 	if err != nil {

--- a/provider/offline_test.go
+++ b/provider/offline_test.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"reflect"
@@ -186,11 +185,34 @@ func TestOfflineStores(t *testing.T) {
 		"CreateResourceFromSourceNoTS": testCreateResourceFromSourceNoTS,
 		"CreatePrimaryFromSource":      testCreatePrimaryFromSource,
 	}
+	testList := []struct {
+		t               Type
+		c               SerializedConfig
+		integrationTest bool
+	}{
+		//{MemoryOffline, []byte{}, false},
+		{PostgresOffline, serialPGConfig, true},
+		//{SnowflakeOffline, serialSFConfig, true},
+		//{RedshiftOffline, serialRSConfig, true},
+		//{BigQueryOffline, serialBQConfig, true},
+	}
+	psqlInfo := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", "postgres", "password", "localhost", "5432", "postgres")
+	db, err := sql.Open("postgres", psqlInfo)
+	if err != nil {
+		panic(err)
+	}
 
 	for _, testItem := range testList {
 		if testing.Short() && testItem.integrationTest {
 			t.Logf("Skipping %s, because it is an integration test", testItem.t)
 			continue
+		}
+		var connections_start, connections_end int
+		if testItem.t == PostgresOffline {
+			err = db.QueryRow("SELECT Count(*) FROM pg_stat_activity WHERE pid!=pg_backend_pid()").Scan(&connections_start)
+			if err != nil {
+				panic(err)
+			}
 		}
 		for name, fn := range testFns {
 			provider, err := Get(testItem.t, testItem.c)
@@ -205,6 +227,9 @@ func TestOfflineStores(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 				fn(t, store)
 			})
+			if err := store.Close(); err != nil {
+				t.Errorf("%v:%v - %v\n", testItem.t, name, err)
+			}
 		}
 		for name, fn := range testSQLFns {
 			if testItem.t == MemoryOffline {
@@ -223,7 +248,22 @@ func TestOfflineStores(t *testing.T) {
 			t.Run(testName, func(t *testing.T) {
 				fn(t, store)
 			})
+			if err := store.Close(); err != nil {
+				t.Errorf("%v:%v - %v\n", testItem.t, name, err)
+			}
 		}
+		if testItem.t == PostgresOffline {
+			err = db.QueryRow("SELECT Count(*) FROM pg_stat_activity WHERE pid!=pg_backend_pid()").Scan(&connections_end)
+			if err != nil {
+				panic(err)
+			}
+			t.Run("POSTGRES_ConnectionCheck", func(t *testing.T) {
+				if connections_start != connections_end {
+					t.Errorf("Started with %d connections, ended with %d connections", connections_start, connections_end)
+				}
+			})
+		}
+		time.Sleep(10 * time.Second)
 	}
 }
 
@@ -587,6 +627,9 @@ func testMaterializations(t *testing.T, store OfflineStore) {
 		if i < len(test.ExpectedSegment) {
 			t.Fatalf("Segment is too small: %d. Expected: %d", i, len(test.ExpectedSegment))
 		}
+		if err := seg.Close(); err != nil {
+			t.Fatalf("Could not close iterator: %v", err)
+		}
 	}
 	runTestCase := func(t *testing.T, test TestCase) {
 		id := randomID(Feature)
@@ -847,6 +890,9 @@ func testMaterializationUpdate(t *testing.T, store OfflineStore) {
 		}
 		if i < len(test.ExpectedSegment) {
 			t.Fatalf("Segment is too small: %d", i)
+		}
+		if err := seg.Close(); err != nil {
+			t.Fatalf("Could not close iterator: %v", err)
 		}
 	}
 	testUpdate := func(t *testing.T, mat Materialization, test TestCase) {
@@ -2161,6 +2207,9 @@ func testTransform(t *testing.T, store OfflineStore) {
 		if tableSize != len(test.Expected) {
 			t.Fatalf("The number of records do not match for received (%v) and expected (%v)", tableSize, len(test.Expected))
 		}
+		if err := iterator.Close(); err != nil {
+			t.Fatalf("Could not close iterator: %v", err)
+		}
 	}
 
 	for name, test := range tests {
@@ -2339,6 +2388,9 @@ func testTransformUpdate(t *testing.T, store OfflineStore) {
 			}
 			i++
 		}
+		if err := iterator.Close(); err != nil {
+			t.Fatalf("Could not close iterator: %v", err)
+		}
 		table, err = store.GetPrimaryTable(test.PrimaryTable)
 		if err != nil {
 			t.Fatalf("Could not get primary table: %v", err)
@@ -2379,6 +2431,9 @@ func testTransformUpdate(t *testing.T, store OfflineStore) {
 				t.Fatalf("Unexpected training row: %v, expected %v", iterator.Values(), test.UpdatedExpected)
 			}
 			i++
+		}
+		if err := iterator.Close(); err != nil {
+			t.Fatalf("Could not close iterator: %v", err)
 		}
 	}
 
@@ -2654,6 +2709,9 @@ func testChainTransform(t *testing.T, store OfflineStore) {
 			t.Fatalf("The %v value was not found in Expected Values: %v", iterator.Values(), tests["First"].Expected)
 		}
 	}
+	if err := iterator.Close(); err != nil {
+		t.Fatalf("Could not close iterator: %v", err)
+	}
 
 	if tableSize != len(tests["First"].Expected) {
 		t.Fatalf("The number of records do not match for received (%v) and expected (%v)", tableSize, len(tests["First"].Expected))
@@ -2693,6 +2751,9 @@ func testChainTransform(t *testing.T, store OfflineStore) {
 			t.Fatalf("Expected: %#v, Received %#v", tests["Second"].Expected[i], iterator.Values())
 		}
 		i++
+	}
+	if err := iterator.Close(); err != nil {
+		t.Fatalf("Could not close iterator: %v", err)
 	}
 
 }
@@ -2801,6 +2862,9 @@ func testTransformToMaterialize(t *testing.T, store OfflineStore) {
 			t.Fatalf("Expected: %#v, Got: %#v", tests["First"].Expected[i], iterator.Value())
 		}
 		i++
+	}
+	if err := iterator.Close(); err != nil {
+		t.Fatalf("Could not close iterator: %v", err)
 	}
 }
 

--- a/provider/postgres.go
+++ b/provider/postgres.go
@@ -253,6 +253,7 @@ func (q postgresSQLQueries) atomicUpdate(db *sql.DB, tableName string, tempName 
 		"DROP TABLE %s;"+
 		"COMMIT;", query, santizedName, oldName, tempName, santizedName, oldName)
 	_, err := db.Exec(transaction)
+
 	return err
 }
 

--- a/provider/spark.go
+++ b/provider/spark.go
@@ -178,6 +178,10 @@ func (store *SparkOfflineStore) AsOfflineStore() (OfflineStore, error) {
 	return store, nil
 }
 
+func (store *SparkOfflineStore) Close() error {
+	return nil
+}
+
 func SparkOfflineStoreFactory(config SerializedConfig) (Provider, error) {
 	sc := SparkConfig{}
 	if err := sc.Deserialize(config); err != nil {
@@ -684,6 +688,10 @@ func (s *S3GenericTableIterator) Err() error {
 	return nil
 }
 
+func (s *S3GenericTableIterator) Close() error {
+	return nil
+}
+
 func (s *S3PrimaryTable) Write(GenericRecord) error {
 	return fmt.Errorf("not implemented")
 }
@@ -883,6 +891,10 @@ func (s *S3FeatureIterator) Value() ResourceRecord {
 
 func (s *S3FeatureIterator) Err() error {
 	return s.err
+}
+
+func (s *S3FeatureIterator) Close() error {
+	return nil
 }
 
 func (spark *SparkOfflineStore) CreateMaterialization(id ResourceID) (Materialization, error) {

--- a/provider/sql.go
+++ b/provider/sql.go
@@ -165,7 +165,7 @@ func (store *sqlOfflineStore) AsOfflineStore() (OfflineStore, error) {
 }
 
 func (store *sqlOfflineStore) Close() error {
-	return nil
+	return store.db.Close()
 }
 
 func (store *sqlOfflineStore) RegisterResourceFromSourceTable(id ResourceID, schema ResourceSchema) (OfflineTable, error) {

--- a/provider/sql.go
+++ b/provider/sql.go
@@ -148,14 +148,14 @@ func (store *sqlOfflineStore) tableExists(id ResourceID) (bool, error) {
 	if n > 0 && err == nil {
 		return true, nil
 	} else if err != nil {
-		return false, fmt.Errorf("table exists: %v", err)
+		return false, fmt.Errorf("table exists check: %v", err)
 	}
 	query = store.query.viewExists()
 	err = store.db.QueryRow(query, tableName).Scan(&n)
 	if n > 0 && err == nil {
 		return true, nil
 	} else if err != nil {
-		return false, fmt.Errorf("view exists: %v", err)
+		return false, fmt.Errorf("view exists check: %v", err)
 	}
 	return false, nil
 }
@@ -330,7 +330,7 @@ func (store *sqlOfflineStore) GetTransformationTable(id ResourceID) (Transformat
 // Returns an error if the table already exists or if table is the wrong type.
 func (store *sqlOfflineStore) CreateResourceTable(id ResourceID, schema TableSchema) (OfflineTable, error) {
 	if err := id.check(Feature, Label); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ID check failed: %v", err)
 	}
 
 	if exists, err := store.tableExists(id); err != nil {
@@ -340,7 +340,7 @@ func (store *sqlOfflineStore) CreateResourceTable(id ResourceID, schema TableSch
 	}
 	tableName, err := store.getResourceTableName(id)
 	if err != nil {
-		return nil, fmt.Errorf("could not get table name: %v", err)
+		return nil, fmt.Errorf("could not get resource table name: %v", err)
 	}
 	var valueType ValueType
 	if valueIndex := store.getValueIndex(schema.Columns); valueIndex > 0 {

--- a/provider/sql.go
+++ b/provider/sql.go
@@ -164,6 +164,10 @@ func (store *sqlOfflineStore) AsOfflineStore() (OfflineStore, error) {
 	return store, nil
 }
 
+func (store *sqlOfflineStore) Close() error {
+	return nil
+}
+
 func (store *sqlOfflineStore) RegisterResourceFromSourceTable(id ResourceID, schema ResourceSchema) (OfflineTable, error) {
 	if err := id.check(Feature, Label); err != nil {
 		return nil, fmt.Errorf("type check: %w", err)
@@ -465,6 +469,10 @@ func (iter *sqlFeatureIterator) Value() ResourceRecord {
 
 func (iter *sqlFeatureIterator) Err() error {
 	return nil
+}
+
+func (iter *sqlFeatureIterator) Close() error {
+	return iter.rows.Close()
 }
 
 func (store *sqlOfflineStore) CreateMaterialization(id ResourceID) (Materialization, error) {
@@ -1059,6 +1067,10 @@ func (it *sqlGenericTableIterator) Columns() []string {
 
 func (it *sqlGenericTableIterator) Err() error {
 	return it.err
+}
+
+func (it *sqlGenericTableIterator) Close() error {
+	return it.rows.Close()
 }
 
 type defaultOfflineSQLQueries struct {

--- a/runner/copy.go
+++ b/runner/copy.go
@@ -95,7 +95,10 @@ func (m *MaterializedChunkRunner) Run() (CompletionWatcher, error) {
 			jobWatcher.EndWatch(err)
 			return
 		}
-		it.Close()
+		err = it.Close()
+		if err != nil {
+			jobWatcher.EndWatch(err)
+		}
 		jobWatcher.EndWatch(nil)
 	}()
 	return jobWatcher, nil
@@ -211,12 +214,6 @@ func MaterializedChunkRunnerFactory(config Config) (Runner, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert provider to offline store: %v", err)
 	}
-	defer func(offlineStore provider.OfflineStore) {
-		err := offlineStore.Close()
-		if err != nil {
-			fmt.Printf("could not close offline store: %v", err)
-		}
-	}(offlineStore)
 	materialization, err := offlineStore.GetMaterialization(runnerConfig.MaterializedID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get materialization: %v", err)

--- a/runner/copy.go
+++ b/runner/copy.go
@@ -95,10 +95,7 @@ func (m *MaterializedChunkRunner) Run() (CompletionWatcher, error) {
 			jobWatcher.EndWatch(err)
 			return
 		}
-		err = it.Close()
-		if err != nil {
-			jobWatcher.EndWatch(err)
-		}
+		it.Close()
 		jobWatcher.EndWatch(nil)
 	}()
 	return jobWatcher, nil

--- a/runner/copy.go
+++ b/runner/copy.go
@@ -95,6 +95,10 @@ func (m *MaterializedChunkRunner) Run() (CompletionWatcher, error) {
 			jobWatcher.EndWatch(err)
 			return
 		}
+		err = it.Close()
+		if err != nil {
+			jobWatcher.EndWatch(err)
+		}
 		jobWatcher.EndWatch(nil)
 	}()
 	return jobWatcher, nil
@@ -210,6 +214,12 @@ func MaterializedChunkRunnerFactory(config Config) (Runner, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert provider to offline store: %v", err)
 	}
+	defer func(offlineStore provider.OfflineStore) {
+		err := offlineStore.Close()
+		if err != nil {
+			fmt.Printf("could not close offline store: %v", err)
+		}
+	}(offlineStore)
 	materialization, err := offlineStore.GetMaterialization(runnerConfig.MaterializedID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get materialization: %v", err)

--- a/runner/copy_test.go
+++ b/runner/copy_test.go
@@ -50,6 +50,10 @@ func (m *MaterializedFeaturesNumRowsBroken) IterateSegment(begin int64, end int6
 	return nil, nil
 }
 
+func (m *MaterializedFeaturesNumRowsBroken) Close() error {
+	return nil
+}
+
 type MaterializedFeaturesIterateBroken struct {
 	id provider.MaterializationID
 }
@@ -125,6 +129,10 @@ func (m *MockFeatureIterator) Err() error {
 	return nil
 }
 
+func (m *MockFeatureIterator) Close() error {
+	return nil
+}
+
 func (m *MockFeatureIterator) Value() provider.ResourceRecord {
 	return m.Slice[m.CurrentIndex]
 }
@@ -137,6 +145,10 @@ func (m *BrokenFeatureIterator) Next() bool {
 
 func (m *BrokenFeatureIterator) Err() error {
 	return errors.New("error iterating over features")
+}
+
+func (m *BrokenFeatureIterator) Close() error {
+	return nil
 }
 
 func (m *BrokenFeatureIterator) Value() provider.ResourceRecord {
@@ -367,6 +379,10 @@ func (b BrokenNumRowsOfflineStore) UpdateTrainingSet(provider.TrainingSetDef) er
 
 func (b BrokenNumRowsOfflineStore) GetTrainingSet(id provider.ResourceID) (provider.TrainingSetIterator, error) {
 	return nil, nil
+}
+
+func (b BrokenNumRowsOfflineStore) Close() error {
+	return nil
 }
 
 type BrokenGetTableOnlineStore struct {
@@ -680,6 +696,9 @@ func (m MockOfflineStore) UpdateMaterialization(id provider.ResourceID) (provide
 func (m MockOfflineStore) UpdateTrainingSet(provider.TrainingSetDef) error {
 	return nil
 }
+func (m MockOfflineStore) Close() error {
+	return nil
+}
 
 type MockOnlineStoreTable struct{}
 
@@ -780,6 +799,10 @@ func (m MockIterator) Value() provider.ResourceRecord {
 }
 
 func (m MockIterator) Err() error {
+	return nil
+}
+
+func (m MockIterator) Close() error {
 	return nil
 }
 

--- a/runner/create_transformation_test.go
+++ b/runner/create_transformation_test.go
@@ -71,6 +71,10 @@ func (m MockOfflineCreateTransformationFail) UpdateTrainingSet(provider.Training
 	return nil
 }
 
+func (m MockOfflineCreateTransformationFail) Close() error {
+	return nil
+}
+
 func TestRun(t *testing.T) {
 	runner := CreateTransformationRunner{
 		MockOfflineStore{},

--- a/runner/register_source_test.go
+++ b/runner/register_source_test.go
@@ -68,6 +68,10 @@ func (m MockOfflineRegisterSourceFail) UpdateMaterialization(id provider.Resourc
 	return nil, nil
 }
 
+func (m MockOfflineRegisterSourceFail) Close() error {
+	return nil
+}
+
 func TestRunRegisterResource(t *testing.T) {
 	runner := RegisterSourceRunner{
 		MockOfflineStore{},

--- a/runner/training_set_runner_test.go
+++ b/runner/training_set_runner_test.go
@@ -66,6 +66,10 @@ func (m MockOfflineCreateTrainingSetFail) GetTransformationTable(id provider.Res
 	return nil, nil
 }
 
+func (m MockOfflineCreateTrainingSetFail) Close() error {
+	return nil
+}
+
 func TestRunTrainingSet(t *testing.T) {
 	runner := TrainingSetRunner{
 		MockOfflineStore{},


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Offline store leaves linger connections. This PR implements a close() function for the offline stores and the iterators to closed lingering connections after offline store calls are complete. It also updates the loader script to test the end to end tests with the entire Transactions dataset

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
