### PR TITLE
Update client code in local getting started guide to reflect API change

### DIFF
--- a/docs/quickstart-local.md
+++ b/docs/quickstart-local.md
@@ -134,8 +134,8 @@ We can serve features in production once we deploy our trained model as well.
 ```python
 import featureform as ff
 
-client = ff.ServingLocalClient()
-fpf = client.features([("avg_transactions", "quickstart")], ("CustomerID", "C1410926"))
+client = ff.ServingClient(local=True)
+fpf = client.features([("avg_transactions", "quickstart")], {"CustomerID": "C1410926"})
 # Run features through model
 ```
 


### PR DESCRIPTION
# Description

This fix fixes the two things I noticed needed changing to get the client code to work for local serving:

1. Change user entity from tuple to dict. (Note, this is a duplicate of #342 but fixes an error in that fix)
2. Calls the `ServingClient` with `local=True` instead of `ServingLocalClient`, which apparently does not exist now.

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [-] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [-] New and existing unit tests pass locally with my changes
- [-] I have fixed any merge conflicts
