### PR TITLE
Bugfix: Github pages domain for docs change. Causing tests to fail

### DIFF
--- a/client/docs/CNAME
+++ b/client/docs/CNAME
@@ -1,0 +1,1 @@
+sdk.featureform.com


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Github Pages requires a CNAME file to use a custom domain name. 
Currently the CNAME file isn't included, which is causing the link to docs to break on each update. 

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->
No

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [-] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
