### PR TITLE
Ability to switch between Go Routine and K8S Jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,7 @@ containers: gen_grpc						## Build Docker containers for Minikube
 	minikube image build -f ./metadata/Dockerfile . -t local/metadata:stable & \
 	minikube image build -f ./metadata/dashboard/Dockerfile . -t local/metadata-dashboard:stable & \
 	minikube image build -f ./newserving/Dockerfile . -t local/serving:stable & \
+	minikube image build -f ./runner/Dockerfile . -t local/worker:stable & \
 	wait; \
 	echo "Build Complete"
 

--- a/charts/featureform/charts/coodinator/templates/deployment.yaml
+++ b/charts/featureform/charts/coodinator/templates/deployment.yaml
@@ -47,6 +47,11 @@ spec:
               value: "8080"
             - name: METADATA_HOST
               value: featureform-metadata-server
+            - name: K8S_RUNNER_ENABLE
+              value: {{ .Values.global.k8s_runner_enable | quote }}
+            - name: WORKER_IMAGE
+              value: "{{ .Values.global.repo | default .Values.image.repository }}/worker:{{ .Values.global.version | default .Chart.AppVersion }}"
+
           ports:
             - name: http
               containerPort: 80

--- a/charts/featureform/values.yaml
+++ b/charts/featureform/values.yaml
@@ -84,6 +84,7 @@ global:
   repo: "featureformcom"
   pullPolicy: "Always"
   publicCert: false
+  k8s_runner_enable: false
 
 
 metadata:

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	help "github.com/featureform/helpers"
 	"os"
 	"strings"
 	"time"
@@ -137,7 +138,7 @@ func (k *KubernetesJobSpawner) GetJobRunner(jobName string, config runner.Config
 	}
 	kubeConfig := runner.KubernetesRunnerConfig{
 		EnvVars:  map[string]string{"NAME": jobName, "CONFIG": string(config), "ETCD_CONFIG": string(serializedETCD)},
-		Image:    os.Getenv("WORKER_IMAGE"),
+		Image:    help.GetEnv("WORKER_IMAGE", "local/worker:stable"),
 		NumTasks: 1,
 		Resource: id,
 	}


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adds an environment variable into the helm chart that allows the ability to switch between kubernetes runners and go routine runners

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
