### PR TITLE
add source mapping condition for spark transformation

### DIFF
--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -273,7 +273,7 @@ class SparkAWSConfig:
         return "spark"
 
     def type(self) -> str:
-        return "SPARK_AWS_OFFLINE"
+        return "SPARK_OFFLINE"
 
     def serialize(self) -> bytes:
         config = {

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -271,7 +271,11 @@ func (c *Coordinator) mapNameVariantsToTables(sources []metadata.NameVariant) (m
 		}
 		providerResourceID := provider.ResourceID{Name: source.Name(), Variant: source.Variant()}
 		var tableName string
-		if source.IsSQLTransformation() {
+		sourceProvider, err := source.FetchProvider(c.Metadata, context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("Could not fetch source provider: %v", err)
+		}
+		if sourceProvider.Type() == "SPARK_OFFLINE" && source.IsSQLTransformation() {
 			tableName, err = provider.GetTransformationTableName(providerResourceID)
 			if err != nil {
 				return nil, err

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -322,14 +322,9 @@ func (c *Coordinator) runSQLTransformationJob(transformSource *metadata.SourceVa
 		return fmt.Errorf("getSourceMapping replace: %w source map: %v, template: %s", err, sourceMap, templateString)
 	}
 	var query string
-	if sourceProvider.Type() != "SPARK_OFFLINE" {
-		query, err = templateReplace(templateString, sourceMap, offlineStore)
-		if err != nil {
-			return fmt.Errorf("template replace: %w source map: %v, template: %s", err, sourceMap, templateString)
-		}
-	} else {
-		// spark offline store replaces source names after the config is passed to the store
-		query = templateString
+	query, err = templateReplace(templateString, sourceMap, offlineStore)
+	if err != nil {
+		return fmt.Errorf("template replace: %w source map: %v, template: %s", err, sourceMap, templateString)
 	}
 	c.Logger.Debugw("Created transformation query", "query", query)
 	providerResourceID := provider.ResourceID{Name: resID.Name, Variant: resID.Variant, Type: provider.Transformation}

--- a/provider/spark.go
+++ b/provider/spark.go
@@ -910,16 +910,15 @@ func (spark *SparkOfflineStore) updateQuery(query string, mapping []SourceMappin
 
 func (spark *SparkOfflineStore) getSourcePath(path string) (string, error) {
 	fileType, fileName, fileVariant := spark.getResourceInformationFromFilePath(path)
-
 	var filePath string
-	if fileType == "Primary" {
+	if fileType == "primary" {
 		fileResourceId := ResourceID{Name: fileName, Variant: fileVariant, Type: Primary}
 		fileTable, err := spark.GetPrimaryTable(fileResourceId)
 		if err != nil {
 			return "", fmt.Errorf("could not get the primary table for {%v} because %s", fileResourceId, err)
 		}
 		filePath = fmt.Sprintf("%s%s", spark.Store.BucketPrefix(), fileTable.GetName())
-	} else if fileType == "Transformation" {
+	} else if fileType == "transformation" {
 		fileResourceId := ResourceID{Name: fileName, Variant: fileVariant, Type: Transformation}
 		transformationPath, err := spark.Store.ResourceKey(fileResourceId)
 
@@ -933,7 +932,7 @@ func (spark *SparkOfflineStore) getSourcePath(path string) (string, error) {
 }
 
 func (spark *SparkOfflineStore) getResourceInformationFromFilePath(path string) (string, string, string) {
-	filePaths := strings.Split(path[len("s3://"):], "/")
+	filePaths := strings.Split(path[len("featureform_"):], "__")
 	if len(filePaths) <= 4 {
 		return "", "", ""
 	}

--- a/provider/spark.go
+++ b/provider/spark.go
@@ -933,11 +933,11 @@ func (spark *SparkOfflineStore) getSourcePath(path string) (string, error) {
 
 func (spark *SparkOfflineStore) getResourceInformationFromFilePath(path string) (string, string, string) {
 	filePaths := strings.Split(path[len("featureform_"):], "__")
-	if len(filePaths) <= 4 {
+	if len(filePaths) <= 2 {
 		return "", "", ""
 	}
 
-	fileType, fileName, fileVariant := filePaths[2], filePaths[3], filePaths[4]
+	fileType, fileName, fileVariant := filePaths[0], filePaths[1], filePaths[2]
 
 	return fileType, fileName, fileVariant
 }

--- a/provider/sql.go
+++ b/provider/sql.go
@@ -126,7 +126,14 @@ func GetPrimaryTableName(id ResourceID) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("featureform_primary_%s__%s", id.Name, id.Variant), nil
+	return fmt.Sprintf("featureform_primary__%s__%s", id.Name, id.Variant), nil
+}
+
+func GetTransformationTableName(id ResourceID) (string, error) {
+	if err := checkName(id); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("featureform_transformation__%s__%s", id.Name, id.Variant), nil
 }
 
 func (store *sqlOfflineStore) tableExists(id ResourceID) (bool, error) {


### PR DESCRIPTION
# Description

Currently the transformation definition is passed to the coordinator like so:

`SELECT * FROM {{name.variant}}`

before spark, the coordinator would look up the SQL table name for each name.variant in the transformation and replace them, in the coordinator, with their SQL table name. So the above becomes, in the coordinator

`SELECT * FROM featureform_primary_name_variant`

Originally it was simple to convert the {{name.variant}} to `featureform_primary_name_variant` since this mapping was the same for every provider. There was a minor issue in this case in Bigquery where the table names needed an extra prefix that Ahmad was able to solve.

However for Spark, the table names are stored as S3 file paths. While the prefix of the file path is deterministic based on the resourceID, there is also a random file name that the ResourceKey method in spark.go resolves.

spark.go can't use just a formatted SQL query, it needs the query and a separate source list. However, it is still being passed this:

`SELECT * FROM featureform_primary_name_variant`

And since spark stores primary tables and transformations in a different way, if passed this, the spark store has no idea what to do at this point, we need to distinguish primary tables and transformation tables and let the replacement function reverse the templating in the coordinator

`SELECT * FROM featureform_primary_name_variant`

Source mapping: featureform_primary_name_variant: featureform_primary_name_variant

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
