### PR TITLE
Fixed issue with batch() in hosted serving

### DIFF
--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -608,10 +608,10 @@ class Row:
         self._row = np.append(features, self._label)
 
     def features(self):
-        return self._row[:-1]
+        return [self._row[:-1]]
 
     def label(self):
-        return self._label
+        return [self._label]
 
     def to_numpy(self):
         return self._row()


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The format of hosted serving batch was not updated when local serving batch was updated causing batch to attempt to look for an index that didn't exist

Makes batch training set : 
features: [ [f1, f2, f3, f4], ... [ ] ]
labels: [ l1, l2, l3, l4 ]


## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->
No

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
