### PR TITLE
remove hard pinnings of install_requires

### DIFF
--- a/client/setup.cfg
+++ b/client/setup.cfg
@@ -25,14 +25,14 @@ install_requires =
     click>=7.1.2
     protobuf>=3.17.3
     typeguard>=2.7.1
-    grpcio==1.47.0
-    numpy==1.21.6
-    pandas==1.3.5
+    grpcio>=1.47.0
+    numpy>=1.21.6
+    pandas>=1.3.5
     pandasql>=0.7.3
     typing_extensions>=4.1.1
-    dataclasses==0.6
-    flask==2.2.1
-    Flask-Cors==3.0.10
+    dataclasses>=0.6
+    flask>=2.2.1
+    Flask-Cors>=3.0.10
     pyspark>=3.3.0
 
 [options.packages.find]


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Remove hard pins on dependencies so that it becomes more flexible for conda to resolve the environment and install it in a conda-env. The purpose is to include this package in conda-forge. The related PR to forge this package is here:

https://github.com/conda-forge/staged-recipes/pull/20400

We believe the hard pins are the cause of this [CI error](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=567107&view=logs&j=6f142865-96c3-535c-b7ea-873d86b887bd&t=22b0682d-ab9e-55d7-9c79-49f3c3ba4823&l=858).

## Type of change

### Does this correspond to an open issue?
No.

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Not exactly a bug fix in the source, rather it is to fix something downstream.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
