### PR TITLE
Add wait condition for training set's dependent features and label

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -105,7 +105,7 @@ func (c *Coordinator) AwaitPendingSource(sourceNameVariant metadata.NameVariant)
 		}
 		sourceStatus := source.Status()
 		if sourceStatus == metadata.FAILED {
-			return nil, fmt.Errorf("source of feature not ready: name: %s, variant: %s", sourceNameVariant.Name, sourceNameVariant.Variant)
+			return nil, fmt.Errorf("source registration failed: name: %s, variant: %s", sourceNameVariant.Name, sourceNameVariant.Variant)
 		}
 		if sourceStatus == metadata.READY {
 			return source, nil
@@ -124,7 +124,7 @@ func (c *Coordinator) AwaitPendingFeature(featureNameVariant metadata.NameVarian
 		}
 		featureStatus := feature.Status()
 		if featureStatus == metadata.FAILED {
-			return nil, fmt.Errorf("source of feature not ready: name: %s, variant: %s", featureNameVariant.Name, featureNameVariant.Variant)
+			return nil, fmt.Errorf("feature registration failed: name: %s, variant: %s", featureNameVariant.Name, featureNameVariant.Variant)
 		}
 		if featureStatus == metadata.READY {
 			return feature, nil
@@ -143,7 +143,7 @@ func (c *Coordinator) AwaitPendingLabel(labelNameVariant metadata.NameVariant) (
 		}
 		labelStatus := label.Status()
 		if labelStatus == metadata.FAILED {
-			return nil, fmt.Errorf("source of label not ready: name: %s, variant: %s", labelNameVariant.Name, labelNameVariant.Variant)
+			return nil, fmt.Errorf("label registration failed: name: %s, variant: %s", labelNameVariant.Name, labelNameVariant.Variant)
 		}
 		if labelStatus == metadata.READY {
 			return label, nil

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -1230,13 +1230,6 @@ func testCoordinatorTrainingSet(addr string) error {
 		return fmt.Errorf("could not get provider as offline store: %v", err)
 	}
 	offline_feature := provider.ResourceID{Name: featureName, Variant: "", Type: provider.Feature}
-	schemaInt := provider.TableSchema{
-		Columns: []provider.TableColumn{
-			{Name: "entity", ValueType: provider.String},
-			{Name: "value", ValueType: provider.Int},
-			{Name: "ts", ValueType: provider.Timestamp},
-		},
-	}
 	originalTableName := createSafeUUID()
 	if err := CreateOriginalPostgresTable(originalTableName); err != nil {
 		return err

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -1237,25 +1237,6 @@ func testCoordinatorTrainingSet(addr string) error {
 			{Name: "ts", ValueType: provider.Timestamp},
 		},
 	}
-	featureTable, err := my_offline.CreateResourceTable(offline_feature, schemaInt)
-	if err != nil {
-		return fmt.Errorf("could not create feature table: %v", err)
-	}
-	for _, value := range testOfflineTableValues {
-		if err := featureTable.Write(value); err != nil {
-			return fmt.Errorf("could not write to offline feature table")
-		}
-	}
-	offline_label := provider.ResourceID{Name: labelName, Variant: "", Type: provider.Label}
-	labelTable, err := my_offline.CreateResourceTable(offline_label, schemaInt)
-	if err != nil {
-		return fmt.Errorf("could not create label table: %v", err)
-	}
-	for _, value := range testOfflineTableValues {
-		if err := labelTable.Write(value); err != nil {
-			return fmt.Errorf("could not write to offline label table")
-		}
-	}
 	originalTableName := createSafeUUID()
 	if err := CreateOriginalPostgresTable(originalTableName); err != nil {
 		return err
@@ -1289,6 +1270,25 @@ func testCoordinatorTrainingSet(addr string) error {
 	labelID := metadata.ResourceID{Name: labelName, Variant: "", Type: metadata.LABEL_VARIANT}
 	if err := coord.ExecuteJob(metadata.GetJobKey(labelID)); err != nil {
 		return err
+	}
+	featureTable, err := my_offline.GetResourceTable(offline_feature)
+	if err != nil {
+		return fmt.Errorf("could not create feature table: %v", err)
+	}
+	for _, value := range testOfflineTableValues {
+		if err := featureTable.Write(value); err != nil {
+			return fmt.Errorf("could not write to offline feature table")
+		}
+	}
+	offline_label := provider.ResourceID{Name: labelName, Variant: "", Type: provider.Label}
+	labelTable, err := my_offline.GetResourceTable(offline_label)
+	if err != nil {
+		return fmt.Errorf("could not create label table: %v", err)
+	}
+	for _, value := range testOfflineTableValues {
+		if err := labelTable.Write(value); err != nil {
+			return fmt.Errorf("could not write to offline label table")
+		}
 	}
 	if err := coord.ExecuteJob(metadata.GetJobKey(tsID)); err != nil {
 		return err

--- a/coordinator/coordinator_test.go
+++ b/coordinator/coordinator_test.go
@@ -1282,6 +1282,14 @@ func testCoordinatorTrainingSet(addr string) error {
 	if err := coord.ExecuteJob(metadata.GetJobKey(sourceID)); err != nil {
 		return err
 	}
+	featureID := metadata.ResourceID{Name: featureName, Variant: "", Type: metadata.FEATURE_VARIANT}
+	if err := coord.ExecuteJob(metadata.GetJobKey(featureID)); err != nil {
+		return err
+	}
+	labelID := metadata.ResourceID{Name: labelName, Variant: "", Type: metadata.LABEL_VARIANT}
+	if err := coord.ExecuteJob(metadata.GetJobKey(labelID)); err != nil {
+		return err
+	}
 	if err := coord.ExecuteJob(metadata.GetJobKey(tsID)); err != nil {
 		return err
 	}

--- a/coordinator/scheduletest/main.go
+++ b/coordinator/scheduletest/main.go
@@ -171,18 +171,25 @@ func testScheduleTrainingSet() error {
 	if err := CreateOriginalPostgresTable(originalTableName); err != nil {
 		return fmt.Errorf("Could not create table in postgres: %v", err)
 	}
-	// create original feature and label tables for training set with original data
-	featureTable, labelTable, err := initializeResourceTablesForTrainingSet(featureName, labelName)
-	if err != nil {
-		return fmt.Errorf("Could not initialize resource tables: %v", err)
-	}
-	// initialize training set in metadata
 	if err := createTrainingSetWithProvider(sourceName, featureName, labelName, tsName, originalTableName, updateEveryMinuteSchedule); err != nil {
 		return fmt.Errorf("could not create training set %v", err)
 	}
 	// initialize source in offline store via provider
 	if err := coord.ExecuteJob(metadata.GetJobKey(sourceID)); err != nil {
 		return err
+	}
+	featureID := metadata.ResourceID{Name: featureName, Variant: "", Type: metadata.FEATURE_VARIANT}
+	if err := coord.ExecuteJob(metadata.GetJobKey(featureID)); err != nil {
+		return err
+	}
+	labelID := metadata.ResourceID{Name: labelName, Variant: "", Type: metadata.LABEL_VARIANT}
+	if err := coord.ExecuteJob(metadata.GetJobKey(labelID)); err != nil {
+		return err
+	}
+	// create original feature and label tables for training set with original data
+	featureTable, labelTable, err := initializeResourceTablesForTrainingSet(featureName, labelName)
+	if err != nil {
+		return fmt.Errorf("Could not initialize resource tables: %v", err)
 	}
 	// initialize traiining set in offline store via coordinator
 	if err := coord.ExecuteJob(metadata.GetJobKey(tsID)); err != nil {

--- a/coordinator/scheduletest/main.go
+++ b/coordinator/scheduletest/main.go
@@ -234,16 +234,9 @@ func testScheduleTrainingSet() error {
 
 func initializeResourceTablesForTrainingSet(featureName string, labelName string) (provider.OfflineTable, provider.OfflineTable, error) {
 	offlineFeature := provider.ResourceID{Name: featureName, Variant: "", Type: provider.Feature}
-	schemaInt := provider.TableSchema{
-		Columns: []provider.TableColumn{
-			{Name: "entity", ValueType: provider.String},
-			{Name: "value", ValueType: provider.Int},
-			{Name: "ts", ValueType: provider.Timestamp},
-		},
-	}
-	featureTable, err := offlinePostgresStore.CreateResourceTable(offlineFeature, schemaInt)
+	featureTable, err := offlinePostgresStore.GetResourceTable(offlineFeature)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not create feature table: %v", err)
+		return nil, nil, fmt.Errorf("could not fetch feature table: %v", err)
 	}
 	for _, value := range testOfflineTableValues {
 		if err := featureTable.Write(value); err != nil {
@@ -251,9 +244,9 @@ func initializeResourceTablesForTrainingSet(featureName string, labelName string
 		}
 	}
 	offlineLabel := provider.ResourceID{Name: labelName, Variant: "", Type: provider.Label}
-	labelTable, err := offlinePostgresStore.CreateResourceTable(offlineLabel, schemaInt)
+	labelTable, err := offlinePostgresStore.GetResourceTable(offlineLabel)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not create label table: %v", err)
+		return nil, nil, fmt.Errorf("could not fetch label table: %v", err)
 	}
 	for _, value := range testOfflineTableValues {
 		if err := labelTable.Write(value); err != nil {


### PR DESCRIPTION
# Description

Solves issue where training set attempts to execute without waiting for its dependent features/labels to be ready

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
