### PR TITLE
Stop Codecov From Failing Before Complete

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,10 @@ coverage:
     project:
       default:
         target: 0
+    patch:
+      default:
+        target: 0
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes it so that codecov diff waits until the entire run is complete before giving a diff. Also sets patch to threshold to 0 until further configuration is made since it measures the diff in coverage for a PR, which can be 0 when non-code related changes are made

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->
No

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
