### PR TITLE
Changed Job Search Error To Info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY proto/ proto/
 COPY coordinator/ coordinator/
 COPY provider/ provider/
 COPY runner/ runner/
-COPY newserving/ newserving/
+COPY serving/ serving/
 COPY nginx.conf/ /etc/nginx/nginx.conf
 
 RUN apt install protobuf-compiler -y
@@ -43,7 +43,7 @@ RUN go build coordinator/main/main.go
 RUN mv main execs/coordinator
 RUN go build metadata/dashboard/dashboard_metadata.go
 RUN mv dashboard_metadata execs/dashboard_metadata
-RUN go build newserving/main/main.go
+RUN go build serving/main/main.go
 RUN mv main execs/serving
 
 RUN git clone -b v3.4.16 https://github.com/etcd-io/etcd.git

--- a/coordinator/errors.go
+++ b/coordinator/errors.go
@@ -1,0 +1,11 @@
+package coordinator
+
+import "fmt"
+
+type JobDoesNotExistError struct {
+	key string
+}
+
+func (m *JobDoesNotExistError) Error() string {
+	return fmt.Sprintf("Coordinator Job No Longer Exists: %s", m.key)
+}


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently when the coordinator completes a job, it deletes the job listing. Other coordinator instances look at the job listing will error, even though the job has successfully completed. Changed this error to INFO to prevent confusion

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
