### PR TITLE
Remove error for fetch with no return

### DIFF
--- a/client/src/featureform/sqlite_metadata.py
+++ b/client/src/featureform/sqlite_metadata.py
@@ -202,7 +202,7 @@ class SQLiteMetadata:
         self.__conn.commit()
         variant_data_list = variant_data.fetchall()
         if len(variant_data_list) == 0:
-          raise ValueError(f"{type} with name: {name} and variant: {variant} not found")
+          return []
         return variant_data_list
 
     def get_user(self, name):

--- a/client/src/featureform/sqlite_metadata.py
+++ b/client/src/featureform/sqlite_metadata.py
@@ -202,6 +202,14 @@ class SQLiteMetadata:
         self.__conn.commit()
         variant_data_list = variant_data.fetchall()
         if len(variant_data_list) == 0:
+          raise ValueError(f"{type} with name: {name} and variant: {variant} not found")
+        return variant_data_list
+
+    def fetch_data_safe(self, query, type, name, variant):
+        variant_data = self.__conn.execute(query)
+        self.__conn.commit()
+        variant_data_list = variant_data.fetchall()
+        if len(variant_data_list) == 0:
           return []
         return variant_data_list
 
@@ -238,7 +246,7 @@ class SQLiteMetadata:
 
     def get_feature_variants_from_source(self, name, variant):
         query = f"SELECT * FROM feature_variant WHERE source_name = '{name}' AND source_variant = '{variant}';"
-        return self.fetch_data(query, "feature_variant", name, variant)
+        return self.fetch_data_safe(query, "feature_variant", name, variant)
 
     def get_feature_variants_from_feature(self, name):
       return self.query_resource("feature_variant", "name", name)
@@ -252,7 +260,7 @@ class SQLiteMetadata:
     
     def get_training_set_variant_from_label(self, name, variant):
         query = f"SELECT * FROM training_set_variant WHERE label_name = '{name}' AND label_variant = '{variant}';"
-        return self.fetch_data(query, "training_set_variant", name, variant)
+        return self.fetch_data_safe(query, "training_set_variant", name, variant)
     
     def get_label_variant(self, name, variant):
         query = f"SELECT * FROM label_variant WHERE name = '{name}' AND variant = '{variant}';"
@@ -267,7 +275,7 @@ class SQLiteMetadata:
     
     def get_label_variants_from_source(self, name, variant):
         query = f"SELECT * FROM label_variant WHERE source_name = '{name}' AND source_variant = '{variant}';"
-        return self.fetch_data(query, "label_variant", name, variant)
+        return self.fetch_data_safe(query, "label_variant", name, variant)
 
     def get_source_variant(self, name, variant):
         query = f"SELECT * FROM source_variant WHERE name = '{name}' AND variant = '{variant}';"
@@ -278,11 +286,11 @@ class SQLiteMetadata:
 
     def get_training_set_from_features(self, name, variant):
         query = f"SELECT * FROM training_set_features WHERE feature_name = '{name}' AND feature_variant = '{variant}';"
-        return self.fetch_data(query, "training_set_features", name, variant)
+        return self.fetch_data_safe(query, "training_set_features", name, variant)
 
     def get_training_set_from_labels(self, name, variant):
         query = f"SELECT * FROM training_set_variant WHERE label_name = '{name}' AND label_variant = '{variant}';"
-        return self.fetch_data(query, "training_set_variant", name, variant)
+        return self.fetch_data_safe(query, "training_set_variant", name, variant)
 
     def get_training_set_features(self, name, variant):
         query = f"SELECT * FROM training_set_features WHERE training_set_name = '{name}' AND training_set_variant = '{variant}';"


### PR DESCRIPTION
# Description

The 500 page and three dots issue are caused by localmode triggering a valueerror when trying to fetch nonexistent derived resources from the main resource on a page (searching training sets connected to features, labels, etc). This value error, even though the client swallows it when it catches the exception, is still sent to the frontend as a 500 error by Flask, causing the dashboard to follow the 500 error guidelines even though data is returned. 

To avoid this, whenever it may be expected that no data is returned on a fetch, the fetch should not trigger an error in Flask.

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
https://github.com/featureform/featureform/issues/449
https://github.com/featureform/featureform/issues/448
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
