### PR TITLE
Feature/include label timestamp for training set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ pytest:
 	pytest client/tests/localmode_quickstart_test.py
 	pytest client/tests/register_test.py
 	pytest client/tests/test_spark_provider.py
+	pytest client/tests/test_localmode_include_label_ts.py
 	-rm -r .featureform
 
 jupyter: update_python

--- a/client/tests/test_localmode_include_label_ts.py
+++ b/client/tests/test_localmode_include_label_ts.py
@@ -1,0 +1,100 @@
+import featureform as ff
+from featureform import local
+import pandas as pd
+import pytest
+
+
+def setup():
+    transactions = local.register_file(
+        name="transactions",
+        variant="quickstart",
+        description="A dataset of fraudulent transactions",
+        path="transactions.csv"
+    )
+
+    @local.df_transformation(variant="quickstart",
+                                inputs=[("transactions", "quickstart")])
+    def average_user_transaction(transactions):
+        """the average transaction amount for a user """
+        return transactions.groupby("CustomerID")["TransactionAmount"].mean()
+
+    @local.sql_transformation(variant="quickstart")
+    def sql_average_user_transaction():
+        """the average transaction amount for a user """
+        return "SELECT CustomerID as user_id, avg(TransactionAmount) " \
+            "as avg_transaction_amt from {{transactions.kaggle}} GROUP BY user_id"
+
+    user = ff.register_entity("user")
+
+    # Register a column from our transformation as a feature
+    average_user_transaction.register_resources(
+        entity=user,
+        entity_column="CustomerID",
+        inference_store=local,
+        features=[
+            {"name": "avg_transactions", "variant": "quickstart", "column": "TransactionAmount", "type": "float32"},
+        ],
+    )
+
+    sql_average_user_transaction.register_resources(
+        entity=user,
+        entity_column="CustomerID",
+        inference_store=local,
+        features=[
+            {"name": "avg_transactions", "variant": "sql", "column": "TransactionAmount", "type": "float32"},
+        ],
+    )
+
+    # Register label from our base Transactions table
+    transactions.register_resources(
+        entity=user,
+        entity_column="CustomerID",
+        timestamp_column="Timestamp",
+        labels=[
+            {"name": "fraudulent", "variant": "quickstart", "column": "IsFraud", "type": "bool"},
+        ],
+    )
+
+    # Register label from our base Transactions table
+    transactions.register_resources(
+        entity=user,
+        entity_column="CustomerID",
+        labels=[
+            {"name": "fraudulent", "variant": "quickstart-no-ts", "column": "IsFraud", "type": "bool"},
+        ],
+    )
+
+    ff.register_training_set(
+        "fraud_training", "quickstart",
+        label=("fraudulent", "quickstart"),
+        features=[("avg_transactions", "quickstart")],
+    )
+
+    ff.register_training_set(
+        "fraud_training", "quickstart-no-ts",
+        label=("fraudulent", "quickstart-no-ts"),
+        features=[("avg_transactions", "quickstart")],
+    )
+
+    resource_client = ff.ResourceClient(local=True)
+    resource_client.apply()
+
+
+@pytest.mark.parametrize(
+    "training_set_variant, include_label_timestamp, expected_in_keys",
+    [
+        ("quickstart", True, True),
+        ("quickstart", False, False),
+        ("quickstart-no-ts", True, False),
+        ("quickstart-no-ts", False, False),
+    ]
+)
+def test_include_label_timestamp(training_set_variant, include_label_timestamp, expected_in_keys):
+
+    serving_client = ff.ServingClient(local=True)
+    dataset = serving_client.training_set('fraud_training', training_set_variant, include_label_timestamp=include_label_timestamp)
+    dataset_pandas = dataset.pandas()
+    
+    result = "label_timestamp" in dataset_pandas.keys()
+
+    assert result == expected_in_keys


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
The goal of this feature is to give users the ability to include the label timestamp in the training set. Currently, the label does not include any timestamps when being served in the training set. The expected behavior is that we exclude the timestamp by default but if users provide a flag then we will include it.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
