### PR TITLE
implement blob online store for azure blob store

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -177,6 +177,10 @@ jobs:
           DYNAMO_SECRET_KEY: ${{ secrets.DYNAMO_SECRET_KEY }}
           FIRESTORE_CRED: "firestore_credentials.json"
           FIRESTORE_PROJECT: ${{ secrets.FIRESTORE_PROJECT }}
+          AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
+          AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
+          AZURE_CONTAINER_NAME: ${{ secrets.AZURE_CONTAINER_NAME }}
+
         working-directory: ./
         run: make test_online
 

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -333,7 +333,7 @@ class OnlineProvider:
         return self.__provider.name
 
 class StoreProvider:
-    def __init__(self, registrary, provider, config, store_type):
+    def __init__(self, registrar, provider, config, store_type):
         self.__registrar = registrar
         self.__provider = provider
         self.__config = config

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -558,7 +558,7 @@ class LocalSource:
             entity: Union[str, EntityRegistrar],
             entity_column: str,
             owner: Union[str, UserRegistrar] = "",
-            inference_store: Union[str, OnlineProvider, BlobProvider] = "",
+            inference_store: Union[str, OnlineProvider, StoreProvider] = "",
             features: List[ColumnMapping] = None,
             labels: List[ColumnMapping] = None,
             timestamp_column: str = ""
@@ -582,7 +582,7 @@ class LocalSource:
             entity (Union[str, EntityRegistrar]): The name to reference the entity by when serving features
             entity_column (str): The name of the column in the source to be used as the entity
             owner (Union[str, UserRegistrar]): The owner of the resource(s)
-            inference_store (Union[str, OnlineProvider, BlobProvider]): Where to store the materialized feature for serving. (Use the local provider in Localmode)
+            inference_store (Union[str, OnlineProvider, StoreProvider]): Where to store the materialized feature for serving. (Use the local provider in Localmode)
             features (List[ColumnMapping]): A list of column mappings to define the features
             labels (List[ColumnMapping]): A list of column mappings to define the labels
             timestamp_column: (str): The name of an optional timestamp column in the dataset. Will be used to match the features and labels with point-in-time correctness
@@ -656,7 +656,7 @@ class SQLTransformationDecorator:
             entity: Union[str, EntityRegistrar],
             entity_column: str,
             owner: Union[str, UserRegistrar] = "",
-            inference_store: Union[str, OnlineProvider, BlobProvider] = "",
+            inference_store: Union[str, OnlineProvider, StoreProvider] = "",
             features: List[ColumnMapping] = None,
             labels: List[ColumnMapping] = None,
             timestamp_column: str = "",
@@ -727,7 +727,7 @@ class DFTransformationDecorator:
             entity: Union[str, EntityRegistrar],
             entity_column: str,
             owner: Union[str, UserRegistrar] = "",
-            inference_store: Union[str, OnlineProvider, BlobProvider] = "",
+            inference_store: Union[str, OnlineProvider, StoreProvider] = "",
             features: List[ColumnMapping] = None,
             labels: List[ColumnMapping] = None,
             timestamp_column: str = "",
@@ -753,7 +753,7 @@ class ColumnSourceRegistrar(SourceRegistrar):
             entity: Union[str, EntityRegistrar],
             entity_column: str,
             owner: Union[str, UserRegistrar] = "",
-            inference_store: Union[str, OnlineProvider, BlobProvider] = "",
+            inference_store: Union[str, OnlineProvider, StoreProvider] = "",
             features: List[ColumnMapping] = None,
             labels: List[ColumnMapping] = None,
             timestamp_column: str = "",
@@ -779,7 +779,7 @@ class ColumnSourceRegistrar(SourceRegistrar):
             entity (Union[str, EntityRegistrar]): The name to reference the entity by when serving features
             entity_column (str): The name of the column in the source to be used as the entity
             owner (Union[str, UserRegistrar]): The owner of the resource(s)
-            inference_store (Union[str, OnlineProvider, BlobProvider]): Where to store the materialized feature for serving. (Use the local provider in Localmode)
+            inference_store (Union[str, OnlineProvider, StoreProvider]): Where to store the materialized feature for serving. (Use the local provider in Localmode)
             features (List[ColumnMapping]): A list of column mappings to define the features
             labels (List[ColumnMapping]): A list of column mappings to define the labels
             timestamp_column: (str): The name of an optional timestamp column in the dataset. Will be used to match the features and labels with point-in-time correctness
@@ -1018,7 +1018,7 @@ class Registrar:
             name (str): Name of Azure blob provider to be retrieved
 
         Returns:
-            azure_blob (BlobProvider): Provider
+            azure_blob (StoreProvider): Provider
             bm22
         """
 
@@ -1035,7 +1035,7 @@ class Registrar:
         fake_azure_config = AzureBlobConfig(account_name="", account_key="",container_name="",root_path="")
         fake_config = OnlineBlobConfig(store_type="AZURE",store_config=azure_config.serialize())
         fakeProvider = Provider(name=name, function="ONLINE", description="", team="", config=fakeConfig)
-        return BlobProvider(self, fakeProvider, fake_config)
+        return StoreProvider(self, fakeProvider, fake_config)
     
     def get_postgres(self, name):
         """Get a Postgres provider. The returned object can be used to register additional resources.
@@ -1296,7 +1296,7 @@ class Registrar:
                             team=team,
                             config=config)
         self.__resources.append(provider)
-        return BlobProvider(self, provider, config)
+        return StoreProvider(self, provider, config)
 
     def register_firestore(self,
                            name: str,
@@ -1884,7 +1884,7 @@ class Registrar:
             entity: Union[str, EntityRegistrar],
             entity_column: str,
             owner: Union[str, UserRegistrar] = "",
-            inference_store: Union[str, OnlineProvider, BlobProvider] = "",
+            inference_store: Union[str, OnlineProvider, StoreProvider] = "",
             features: List[ColumnMapping] = None,
             labels: List[ColumnMapping] = None,
             timestamp_column: str = "",

--- a/client/src/featureform/register_test.py
+++ b/client/src/featureform/register_test.py
@@ -64,11 +64,11 @@ def test_register_postgres(registrar, args):
         "team": "featureform",
         "account_name": "<account_name>",
         "account_key": "<account_key>",
-        "container_name": "container"
-        "root_path": "example/path"
+        "container_name": "container",
+        "root_path": "example/path",
     }
 ])
-def test_register_blob_sture(registrar, args):
+def test_register_blob_store(registrar, args):
     registrar.register_blob_store(**args)
 
 @pytest.mark.parametrize("args", [

--- a/client/src/featureform/register_test.py
+++ b/client/src/featureform/register_test.py
@@ -33,7 +33,6 @@ def registrar():
 def test_register_snowflake(registrar, args):
     registrar.register_snowflake(**args)
 
-
 minimal_postgres_args = {
     "name": "postgres",
 }
@@ -55,6 +54,22 @@ minimal_postgres_args = {
 def test_register_postgres(registrar, args):
     registrar.register_postgres(**args)
 
+@pytest.mark.parametrize("args", [
+    {
+        "name": "azure_blob"
+    },
+    {
+        "name": "azure_blob",
+        "description": "test",
+        "team": "featureform",
+        "account_name": "<account_name>",
+        "account_key": "<account_key>",
+        "container_name": "container"
+        "root_path": "example/path"
+    }
+])
+def test_register_blob_sture(registrar, args):
+    registrar.register_blob_store(**args)
 
 @pytest.mark.parametrize("args", [
     {

--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -80,6 +80,43 @@ class RedisConfig:
         }
         return bytes(json.dumps(config), "utf-8")
 
+@typechecked
+@dataclass
+class AzureBlobStoreConfig:
+    account_name: str
+    account_key: str
+    container_name: str
+    root_path: str
+
+    def serialize(self) -> bytes:
+        config = {
+            "AccountName": self.account_name,
+            "AccountKey": self.account_key,
+            "ContainerName": self.container_name,
+            "Path": self.root_path,
+        }
+        return bytes(json.dumps(config), "utf-8")
+
+
+@typechecked
+@dataclass
+class OnlineBlobConfig:
+    store_type: str
+    store_config: bytes
+
+    def software(self) -> str:
+        return self.store_type
+
+    def type(self) -> str:
+        return "BLOB_ONLINE"
+
+    def serialize(self) -> bytes:
+        config = {
+            "Type": self.store_type,
+            "Config": self.store_config,
+        }
+        return bytes(json.dumps(config), "utf-8")
+
 
 @typechecked
 @dataclass
@@ -289,7 +326,7 @@ class SparkAWSConfig:
 
     def serialize(self) -> bytes:
         config = {
-            "ExecutorType": "EMR",
+            "ExecutorType": "EMR",  
             "StoreType": "S3",
             "ExecutorConfig": {
                 "AWSAccessKeyId": self.aws_access_key_id,

--- a/client/src/featureform/resources_test.py
+++ b/client/src/featureform/resources_test.py
@@ -4,7 +4,7 @@
 
 import pytest
 from .resources import ResourceRedefinedError, ResourceState, Provider, RedisConfig, CassandraConfig, FirestoreConfig, \
-SnowflakeConfig, PostgresConfig, RedshiftConfig, BigQueryConfig, User, Provider, Entity, Feature, Label, TrainingSet, PrimaryData, SQLTable, \
+SnowflakeConfig, PostgresConfig, RedshiftConfig, BigQueryConfig, OnlineBlobConfig, AzureBlobStoreConfig, User, Provider, Entity, Feature, Label, TrainingSet, PrimaryData, SQLTable, \
 Source, ResourceColumnMapping, DynamodbConfig, Schedule
 
 
@@ -39,6 +39,30 @@ def redis_config():
         password="abc",
         db=3,
     )
+
+@pytest.fixture
+def online_blob_config(
+    azure_blob_config = AzureBlobStoreConfig(
+        account_name="<account_name>",
+        account_key="<account_key>",
+        container_name="examplecontainer",
+        root_path="example/path",
+    )
+    return OnlineBlobConfig(
+        store_type="AZURE",
+        store_config=azure_blob.serialize(),
+    )
+)
+
+@pytest.fixture
+def azure_blob_store_config(
+    return AzureBlobStoreConfig(
+        account_name="<account_name>",
+        account_key="<account_key>",
+        container_name="examplecontainer",
+        root_path="example/path",
+    )
+)
 
 @pytest.fixture
 def cassandra_config():

--- a/client/src/featureform/resources_test.py
+++ b/client/src/featureform/resources_test.py
@@ -41,21 +41,7 @@ def redis_config():
     )
 
 @pytest.fixture
-def online_blob_config(
-    azure_blob_config = AzureBlobStoreConfig(
-        account_name="<account_name>",
-        account_key="<account_key>",
-        container_name="examplecontainer",
-        root_path="example/path",
-    )
-    return OnlineBlobConfig(
-        store_type="AZURE",
-        store_config=azure_blob.serialize(),
-    )
-)
-
-@pytest.fixture
-def azure_blob_store_config(
+def blob_store_config(
     return AzureBlobStoreConfig(
         account_name="<account_name>",
         account_key="<account_key>",
@@ -63,6 +49,16 @@ def azure_blob_store_config(
         root_path="example/path",
     )
 )
+
+
+@pytest.fixture
+def online_blob_config(blob_store_config):
+    return OnlineBlobConfig(
+        store_type="AZURE",
+        store_config=blob_store_config.serialize(),
+    )
+
+
 
 @pytest.fixture
 def cassandra_config():

--- a/provider/blob_online.go
+++ b/provider/blob_online.go
@@ -12,7 +12,7 @@ type OnlineBlobConfig struct {
 	Config BlobStoreConfig
 }
 
-func (online *OnlineBlobConfig) Serialized() SerializedConfig {
+func (online OnlineBlobConfig) Serialized() SerializedConfig {
 	config, err := json.Marshal(online)
 	if err != nil {
 		panic(err)
@@ -20,7 +20,7 @@ func (online *OnlineBlobConfig) Serialized() SerializedConfig {
 	return config
 }
 
-func (online *OnlineBlobConfig) Deserialize(config SerializedConfig) error {
+func (online OnlineBlobConfig) Deserialize(config SerializedConfig) error {
 	err := json.Unmarshal(config, online)
 	if err != nil {
 		return err

--- a/provider/blob_online.go
+++ b/provider/blob_online.go
@@ -170,8 +170,7 @@ func (table OnlineBlobStoreTable) Get(entity string) (interface{}, error) {
 	} else if err != nil {
 		return nil, err
 	}
-	valueBytes := []byte(fmt.Sprintf("%v", value))
-	return castBytesToValue(valueBytes, table.valueType)
+	return castBytesToValue(value.([]byte), table.valueType)
 }
 
 func castBytesToValue(value []byte, valueType ValueType) (interface{}, error) {

--- a/provider/blob_online.go
+++ b/provider/blob_online.go
@@ -20,7 +20,7 @@ func (online OnlineBlobConfig) Serialized() SerializedConfig {
 	return config
 }
 
-func (online OnlineBlobConfig) Deserialize(config SerializedConfig) error {
+func (online *OnlineBlobConfig) Deserialize(config SerializedConfig) error {
 	err := json.Unmarshal(config, online)
 	if err != nil {
 		return err

--- a/provider/blob_online.go
+++ b/provider/blob_online.go
@@ -141,7 +141,6 @@ func (store OnlineBlobStore) DeleteTable(feature, variant string) error {
 		return &TableNotFound{feature, variant}
 	}
 	return store.deleteTable(feature, variant)
-	//TODO should this also cycle through all values and delete them too?
 }
 
 func entityDirectory(feature, variant) string {

--- a/provider/blob_online.go
+++ b/provider/blob_online.go
@@ -183,13 +183,13 @@ func castBytesToValue(value []byte, valueType ValueType) (interface{}, error) {
 		return valueString, nil
 	case Int, Int32:
 		val, err = strconv.ParseInt(valueString, 10, 32)
-		return int(val.(int)), err
+		return int(val.(int64)), err
 	case Int64:
 		val, err = strconv.ParseInt(valueString, 10, 64)
 		return int64(val.(int64)), err
 	case Float32:
 		val, err = strconv.ParseFloat(valueString, 32)
-		return float32(val.(float32)), err
+		return float32(val.(float64)), err
 	case Float64:
 		val, err = strconv.ParseFloat(valueString, 64)
 		return float64(val.(float64)), err

--- a/provider/blob_online.go
+++ b/provider/blob_online.go
@@ -87,7 +87,7 @@ func (store OnlineBlobStore) writeTableValue(feature, variant string, valueType 
 func (store OnlineBlobStore) deleteTable(feature, variant string) error {
 	tableKey := blobTableKey(feature, variant)
 	entityDirectory := entityDirectory(feature, variant)
-	if err := store.Delete(tableKey); err != nil; {
+	if err := store.Delete(tableKey); err != nil {
 		return fmt.Errorf("could not delete table index key %s: %v", tableKey, err)
 	}
 	if err := store.DeleteAll(entityDirectory); err != nil {
@@ -143,7 +143,7 @@ func (store OnlineBlobStore) DeleteTable(feature, variant string) error {
 	return store.deleteTable(feature, variant)
 }
 
-func entityDirectory(feature, variant) string {
+func entityDirectory(feature, variant string) string {
 	return fmt.Sprintf("%s/values/%s/%s",STORE_PREFIX, feature, variant,)
 }
 

--- a/provider/blob_online.go
+++ b/provider/blob_online.go
@@ -1,0 +1,205 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+type OnlineBlobConfig struct {
+	Type   BlobStoreType
+	Config BlobStoreConfig
+}
+
+func (online *OnlineBlobConfig) Serialized() SerializedConfig {
+	config, err := json.Marshal(online)
+	if err != nil {
+		panic(err)
+	}
+	return config
+}
+
+func (online *OnlineBlobConfig) Deserialize(config SerializedConfig) error {
+	err := json.Unmarshal(config, online)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type OnlineBlobStore struct {
+	BlobStore
+	BaseProvider
+}
+
+func blobOnlineStoreFactory(serialized SerializedConfig) (Provider, error) {
+	onlineBlobConfig := &OnlineBlobConfig{}
+	if err := onlineBlobConfig.Deserialize(serialized); err != nil {
+		return nil, err
+	}
+	return NewOnlineBlobStore(onlineBlobConfig)
+}
+
+func NewOnlineBlobStore(config *OnlineBlobConfig) (*OnlineBlobStore, error) {
+	blobStore, err := CreateBlobStore(string(config.Type), Config(config.Config))
+	if err != nil {
+		return nil, fmt.Errorf("could not create blob store: %v", err)
+	}
+	return &OnlineBlobStore{
+		blobStore,
+		BaseProvider{
+			ProviderType:   BlobOnline,
+			ProviderConfig: config.Serialized(),
+		},
+	}, nil
+}
+
+func (store *OnlineBlobStore) AsOnlineStore() (OnlineStore, error) {
+	return store, nil
+}
+
+func blobTableKey(feature, variant string) string {
+	return fmt.Sprintf("tables/%s/%s", feature, variant)
+}
+
+func (store OnlineBlobStore) tableExists(feature, variant string) (bool, error) {
+	tableKey := blobTableKey(feature, variant)
+	return store.Exists(tableKey)
+}
+
+func (store OnlineBlobStore) readTableValue(feature, variant string) (ValueType, error) {
+	tableKey := blobTableKey(feature, variant)
+	value, err := store.Read(tableKey)
+	if err != nil {
+		return NilType, err
+	}
+	return ValueType(string(value)), nil
+}
+
+func (store OnlineBlobStore) writeTableValue(feature, variant string, valueType ValueType) error {
+	tableKey := blobTableKey(feature, variant)
+	return store.Write(tableKey, []byte(valueType))
+}
+
+func (store OnlineBlobStore) deleteTable(feature, variant string) error {
+	tableKey := blobTableKey(feature, variant)
+	return store.Delete(tableKey)
+}
+
+func (store OnlineBlobStore) GetTable(feature, variant string) (OnlineStoreTable, error) {
+	exists, err := store.tableExists(feature, variant)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, &TableNotFound{feature, variant}
+	}
+	tableType, err := store.readTableValue(feature, variant)
+	if err != nil {
+		return nil, err
+	}
+	return OnlineBlobStoreTable{store, feature, variant, tableType}, nil
+}
+
+func (store OnlineBlobStore) CreateTable(feature, variant string, valueType ValueType) (OnlineStoreTable, error) {
+	exists, err := store.tableExists(feature, variant)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return nil, &TableAlreadyExists{feature, variant}
+	}
+	if err := store.writeTableValue(feature, variant, valueType); err != nil {
+		return nil, err
+	}
+	return OnlineBlobStoreTable{store, feature, variant, valueType}, nil
+}
+
+type OnlineBlobStoreTable struct {
+	store     BlobStore
+	feature   string
+	variant   string
+	valueType ValueType
+}
+
+func (store OnlineBlobStore) DeleteTable(feature, variant string) error {
+	exists, err := store.tableExists(feature, variant)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return &TableNotFound{feature, variant}
+	}
+	return store.deleteTable(feature, variant)
+	//TODO should this also cycle through all values and delete them too?
+}
+
+func entityValueKey(feature, variant, entity string) string {
+	return fmt.Sprintf("values/%s/%s/%s", feature, variant, entity)
+}
+
+func (table OnlineBlobStoreTable) setEntityValue(feature, variant, entity string, value interface{}) error {
+	entityValueKey := entityValueKey(feature, variant, entity)
+	valueBytes := []byte(fmt.Sprintf("%v", value.(interface{})))
+	return table.store.Write(entityValueKey, valueBytes)
+}
+
+func (table OnlineBlobStoreTable) getEntityValue(feature, variant, entity string) (interface{}, error) {
+	entityValueKey := entityValueKey(feature, variant, entity)
+	exists, err := table.store.Exists(entityValueKey)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, &EntityNotFound{entity}
+	}
+
+	return table.store.Read(entityValueKey)
+}
+
+func (table OnlineBlobStoreTable) Set(entity string, value interface{}) error {
+	return table.setEntityValue(table.feature, table.variant, entity, value)
+}
+
+func (table OnlineBlobStoreTable) Get(entity string) (interface{}, error) {
+	value, err := table.getEntityValue(table.feature, table.variant, entity)
+	entityNotFoundError, ok := err.(*EntityNotFound)
+	if ok {
+		return nil, entityNotFoundError
+	} else if err != nil {
+		return nil, err
+	}
+	valueBytes := []byte(fmt.Sprintf("%v", value))
+	return castBytesToValue(valueBytes, table.valueType)
+}
+
+func castBytesToValue(value []byte, valueType ValueType) (interface{}, error) {
+	valueString := string(value)
+	var val interface{}
+	var err error
+	switch valueType {
+	case NilType, String:
+		return valueString, nil
+	case Int, Int32:
+		val, err = strconv.ParseInt(valueString, 10, 32)
+		return int(val.(int)), err
+	case Int64:
+		val, err = strconv.ParseInt(valueString, 10, 64)
+		return int64(val.(int64)), err
+	case Float32:
+		val, err = strconv.ParseFloat(valueString, 32)
+		return float32(val.(float32)), err
+	case Float64:
+		val, err = strconv.ParseFloat(valueString, 64)
+		return float64(val.(float64)), err
+	case Bool:
+		val, err = strconv.ParseBool(valueString)
+		return bool(val.(bool)), err
+	case Timestamp:
+		return time.Parse(time.ANSIC, valueString)
+	default:
+		return nil, fmt.Errorf("undefined value type: %v", valueType)
+	}
+
+}

--- a/provider/k8s.go
+++ b/provider/k8s.go
@@ -359,6 +359,7 @@ type BlobStore interface {
 	Serve(key string) (Iterator, error)
 	Exists(key string) (bool, error)
 	Delete(key string) error
+	DeleteAll(dir string) error
 	NewestBlob(prefix string) string
 	PathWithPrefix(path string) string
 	NumRows(key string) (int64, error)
@@ -423,6 +424,21 @@ func (store genericBlobStore) NewestBlob(prefix string) string {
 		}
 	}
 	return mostRecentKey
+}
+
+func (store genericBlobStore) DeleteAll(dir string) error {
+	opts := blob.ListOptions{
+		Prefix: dir,
+	}
+	listIterator := store.bucket.List(&opts)
+	for listObj, err := listIterator.Next(ctx); err == nil; listObj, err = listIterator.Next(ctx) {
+		if !listObj.IsDir {
+			if err := store.bucket.Delete(ctx, listObj.Key); err != nil {
+				return fmt.Errorf("failed to delete object %s in directory %s: %v", listObj.Key, dir, err)
+			}
+		}
+	}
+	return nil
 }
 
 func (store genericBlobStore) Write(key string, data []byte) error {

--- a/provider/online.go
+++ b/provider/online.go
@@ -17,6 +17,7 @@ const (
 	CassandraOnline      = "CASSANDRA_ONLINE"
 	FirestoreOnline      = "FIRESTORE_ONLINE"
 	DynamoDBOnline       = "DYNAMODB_ONLINE"
+	BlobOnline           = "BLOB_ONLINE"
 )
 
 var ctx = context.Background()

--- a/provider/online_test.go
+++ b/provider/online_test.go
@@ -130,6 +130,24 @@ func TestOnlineStores(t *testing.T) {
 		return *dynamoConfig
 	}
 
+	blobAzureInit := func() OnlineBlobConfig {
+		azureConfig := AzureBlobStoreConfig{
+			AccountName:   helpers.GetEnv("AZURE_ACCOUNT_NAME", ""),
+			AccountKey:    helpers.GetEnv("AZURE_ACCOUNT_KEY", ""),
+			ContainerName: helpers.GetEnv("AZURE_CONTAINER_NAME", ""),
+			Path:          "featureform/onlinetesting",
+		}
+		serializedAzureConfig, err := azureConfig.Serialize()
+		if err != nil {
+			panic(fmt.Errorf("cannot unmarshal azure credentials: %v", err))
+		}
+		blobConfig := &OnlineBlobConfig{
+			Type:   Azure,
+			Config: BlobStoreConfig(serializedAzureConfig),
+		}
+		return *blobConfig
+	}
+
 	type testMember struct {
 		t               Type
 		subType         string
@@ -161,6 +179,9 @@ func TestOnlineStores(t *testing.T) {
 	}
 	if *provider == "dynamo" || *provider == "" {
 		testList = append(testList, testMember{DynamoDBOnline, "", dynamoInit().Serialized(), true})
+	}
+	if *provider == "azure_blob" || *provider == "" {
+		testList = append(testList, testMember{BlobOnline, "_AZURE", blobAzureInit().Serialized(), true})
 	}
 
 	for _, testItem := range testList {

--- a/provider/online_test.go
+++ b/provider/online_test.go
@@ -15,6 +15,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/featureform/helpers"
+
 	"github.com/alicebob/miniredis"
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"

--- a/provider/online_test.go
+++ b/provider/online_test.go
@@ -136,7 +136,7 @@ func TestOnlineStores(t *testing.T) {
 		azureConfig := AzureBlobStoreConfig{
 			AccountName:   helpers.GetEnv("AZURE_ACCOUNT_NAME", ""),
 			AccountKey:    helpers.GetEnv("AZURE_ACCOUNT_KEY", ""),
-			ContainerName: helpers.GetEnv("AZURE_CONTAINER_NAME", ""),
+			ContainerName: helpers.GetEnv("AZURE_CONTAINER_NAME", "newcontainer"),
 			Path:          "featureform/onlinetesting",
 		}
 		serializedAzureConfig, err := azureConfig.Serialize()

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -23,6 +23,7 @@ func init() {
 		BigQueryOffline:  bigQueryOfflineStoreFactory,
 		SparkOffline:     sparkOfflineStoreFactory,
 		K8sOffline:       k8sAzureOfflineStoreFactory,
+		BlobOnline:       blobOnlineStoreFactory,
 	}
 	for name, factory := range unregisteredFactories {
 		if err := RegisterFactory(name, factory); err != nil {


### PR DESCRIPTION
# Description

Add functionality so an azure blob container can be registered as an online store. Also seed functionality for it to be used as a parameter for separated compute offline stores (via spark or k8s)

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
