### PR TITLE
adding support for default for register_parquet_file

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -113,8 +113,8 @@ class OfflineSparkProvider(OfflineProvider):
 
     def register_parquet_file(self,
                               name: str,
-                              variant: str,
                               file_path: str,
+                              variant: str = "default",
                               owner: Union[str, UserRegistrar] = "",
                               description: str = ""):
         """Register a Spark data source as a primary data source.

--- a/client/tests/test_spark_provider.py
+++ b/client/tests/test_spark_provider.py
@@ -17,23 +17,33 @@ def test_create_provider():
     assert offline_spark_provider.name() == provider_name
 
 @pytest.mark.parametrize(
-    "test_name,file_path",
+    "test_name,file_path,default_variant",
     [
-        ("file", "test_files/input/transaction")
+        ("file", "test_files/input/transaction", False),
+        ("file", "test_files/input/transaction", True),
     ]
 )
-def test_register_parquet_file(test_name, file_path, spark_provider):
-    s = spark_provider.register_parquet_file(
-        name=test_name,
-        variant="test_variant",
-        file_path=file_path,
-    )
+def test_register_parquet_file(test_name, file_path, default_variant, spark_provider):
+    if default_variant:
+        variant = "default"
+        s = spark_provider.register_parquet_file(
+            name=test_name,
+            file_path=file_path,
+        )
+    else:
+        variant = "test_variant"
+        s = spark_provider.register_parquet_file(
+            name=test_name,
+            variant=variant,
+            file_path=file_path,
+        )
 
     assert type(s) == ColumnSourceRegistrar
 
     src = s._SourceRegistrar__source
     assert src.owner == spark_provider._OfflineSparkProvider__registrar.default_owner()
     assert src.provider == spark_provider.name()
+    assert src.variant == variant 
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description
Fixing the issue with not having `"default"` variant for the `register_parquet_file`.

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
