### PR TITLE
Fix outdated pydoc

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -1844,7 +1844,7 @@ class Registrar:
         snowflake = ff.register_snowflake(
             name="snowflake-quickstart",
             username="snowflake",
-            password="password",
+            password="password", #pragma: allowlist secret
             account="account",
             database="snowflake",
             schema="PUBLIC",
@@ -1898,7 +1898,7 @@ class Registrar:
             host="quickstart-postgres",  # The internal dns name for postgres
             port="5432",
             user="postgres",
-            password="password",
+            password="password", #pragma: allowlist secret
             database="postgres"
         )
         ```
@@ -1947,7 +1947,7 @@ class Registrar:
             host="quickstart-redshift",  # The internal dns name for postgres
             port="5432",
             user="redshift",
-            password="password",
+            password="password", #pragma: allowlist secret
             database="dev"
         )
         ```

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2064,17 +2064,15 @@ class Registrar:
                      name: str,
                      store: FileStoreProvider,
                      description: str = "",
-                     team: str = "", ):
+                     team: str = ""):
         """
         Register an offline store provider to run on featureform's own k8s deployment
         
         Args:
             name (str): Name of provider
             store (Union[str, FileStoreProvider]): name or reference to registered file store provider
-            location (Location): Location of primary data
-            provider (Union[str, OfflineProvider]): Provider
-            owner (Union[str, UserRegistrar]): Owner
             description (str): Description of primary data to be registered
+            team (str): A string parameter describing the team that owns the provider
         **Examples**:
         ```
         k8s = ff.register_k8s(
@@ -2082,6 +2080,7 @@ class Registrar:
             description="Native featureform kubernetes compute",
             store=azure_blob,
             team="featureform-team"
+        )
         ```
         """
         config = K8sConfig(

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2070,7 +2070,7 @@ class Registrar:
         
         Args:
             name (str): Name of provider
-            store (Union[str, FileStoreProvider]): name or reference to registered file store provider
+            store (FileStoreProvider): Reference to registered file store provider
             description (str): Description of primary data to be registered
             team (str): A string parameter describing the team that owns the provider
         **Examples**:


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
Pydoc is outdated for register_k8s

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue? No

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
