### PR TITLE
[Bugfix] Check if description is None in SQL Transformation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ pytest:
 	curl -C - https://featureform-demo-files.s3.amazonaws.com/transactions_short.csv -o transactions.csv
 	pytest client/tests/test_cli.py
 	pytest client/tests/resources_test.py
+	pytest client/tests/register_test.py
 	pytest client/tests/provider_config_test.py
 	pytest client/tests/serving_test.py
 	pytest client/src/featureform/local_dash_test.py

--- a/client/setup.cfg
+++ b/client/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     click>=7.1.2
     protobuf>=3.20.0
     typeguard>=2.7.1
-    grpcio==1.46.1
+    grpcio>=1.47.0
     numpy==1.21.6
     pandas==1.3.5
     pandasql>=0.7.3

--- a/client/tests/register_test.py
+++ b/client/tests/register_test.py
@@ -5,7 +5,8 @@ import sys
 
 sys.path.insert(0, 'client/src/')
 import pytest
-from featureform.register import LocalProvider, Provider, Registrar, LocalConfig
+from featureform.register import LocalProvider, Provider, Registrar, LocalConfig, SQLTransformationDecorator, \
+    DFTransformationDecorator
 from featureform.resources import SQLTransformation, Source, DFTransformation
 
 @pytest.fixture
@@ -40,6 +41,25 @@ def test_sql_transformation_decorator_invalid_fn(local, fn):
     )
     with pytest.raises((TypeError, ValueError)):
         decorator(fn)
+
+
+
+def test_sql_transformation_empty_description(registrar):
+    def my_function():
+        return "SELECT * FROM X"
+
+    dec = SQLTransformationDecorator(registrar=registrar, owner="", provider="", variant="sql")
+    dec.__call__(my_function)
+    dec.to_source()
+
+def test_df_transformation_empty_description(registrar):
+    def my_function(df):
+        return df
+
+    dec = DFTransformationDecorator(registrar=registrar, owner="", provider="", variant="df")
+    dec.__call__(my_function)
+    dec.to_source()
+
 
 def del_rw(action, name, exc):
     os.chmod(name, stat.S_IWRITE)

--- a/client/tests/register_test.py
+++ b/client/tests/register_test.py
@@ -9,29 +9,35 @@ from featureform.register import LocalProvider, Provider, Registrar, LocalConfig
     DFTransformationDecorator
 from featureform.resources import SQLTransformation, Source, DFTransformation
 
+
 @pytest.fixture
 def local():
     config = LocalConfig()
     provider = Provider(name="local-mode",
-                    function="LOCAL_ONLINE",
-                    description="This is local mode",
-                    team="team",
-                    config=config)
+                        function="LOCAL_ONLINE",
+                        description="This is local mode",
+                        team="team",
+                        config=config)
     return LocalProvider(Registrar(), provider)
+
 
 @pytest.fixture
 def registrar():
     return Registrar()
 
+
 def name():
     """doc string"""
     return "query"
 
+
 def empty_string():
     return ""
 
+
 def return_5():
     return 5
+
 
 @pytest.mark.parametrize("fn", [empty_string, return_5])
 def test_sql_transformation_decorator_invalid_fn(local, fn):
@@ -43,14 +49,16 @@ def test_sql_transformation_decorator_invalid_fn(local, fn):
         decorator(fn)
 
 
-
 def test_sql_transformation_empty_description(registrar):
     def my_function():
         return "SELECT * FROM X"
 
     dec = SQLTransformationDecorator(registrar=registrar, owner="", provider="", variant="sql")
     dec.__call__(my_function)
+
+    # Checks that Transformation definition does not error when converting to source
     dec.to_source()
+
 
 def test_df_transformation_empty_description(registrar):
     def my_function(df):
@@ -58,13 +66,16 @@ def test_df_transformation_empty_description(registrar):
 
     dec = DFTransformationDecorator(registrar=registrar, owner="", provider="", variant="df")
     dec.__call__(my_function)
+
+    # Checks that Transformation definition does not error when converting to source
     dec.to_source()
 
 
 def del_rw(action, name, exc):
     os.chmod(name, stat.S_IWRITE)
     os.remove(name)
-    
+
+
 @pytest.fixture(autouse=True)
 def run_before_and_after_tests(tmpdir):
     """Fixture to execute asserts before and after a test is run"""


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Checks to see if the description of an SQL transformation is None before trying to apply
- Makes apply errors more clear

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
