### PR TITLE
KCF Custom Image Tests

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2068,7 +2068,8 @@ class Registrar:
                      name: str,
                      store: FileStoreProvider,
                      description: str = "",
-                     team: str = ""):
+                     team: str = "",
+                     docker_image: str = ""):
         """
         Register an offline store provider to run on featureform's own k8s deployment
         

--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -456,29 +456,6 @@ class K8sConfig:
         }
         return bytes(json.dumps(config), "utf-8")
 
-
-@typechecked
-@dataclass
-class K8sConfig:
-    store_type: str
-    store_config: dict
-
-    def software(self) -> str:
-        return "k8s"
-
-    def type(self) -> str:
-        return "K8S_OFFLINE"
-
-    def serialize(self) -> bytes:
-        config = {
-            "ExecutorType": "K8S",
-            "ExecutorConfig": "",
-            "StoreType": self.store_type,
-            "StoreConfig": self.store_config,
-        }
-        return bytes(json.dumps(config), "utf-8")
-
-
 Config = Union[
     RedisConfig, SnowflakeConfig, PostgresConfig, RedshiftConfig, LocalConfig, BigQueryConfig,
     FirestoreConfig, SparkConfig, OnlineBlobConfig, AzureFileStoreConfig, S3StoreConfig, K8sConfig,

--- a/metadata/proto/metadata.proto
+++ b/metadata/proto/metadata.proto
@@ -308,3 +308,23 @@ message PrimaryData {
 message PrimarySQLTable {
     string name = 1;
 }
+
+message KCFConfig {
+    string executor_type = 1;
+    ExecutorConfig executor_config = 2;
+    string store_type = 3;
+    oneof store_config {
+        AzureBlobStoreConfig azure_blob_store_config = 4;
+    }
+}
+
+message ExecutorConfig {
+    string docker_image = 1;
+}
+
+message AzureBlobStoreConfig {
+    string account_name = 1;
+    string account_key = 2;
+    string container_name = 3;
+    string container_path = 4;
+}

--- a/provider/k8s_test.go
+++ b/provider/k8s_test.go
@@ -25,7 +25,7 @@ func uuidWithoutDashes() string {
 	return fmt.Sprintf("a%s", strings.ReplaceAll(uuid.New().String(), "-", ""))
 }
 
-func Test_Deserialize(t *testing.T) {
+func TestDeserialize(t *testing.T) {
 	storeType := "AZURE"
 	accountKey := "my key"
 	accountName := "my account name"
@@ -74,9 +74,9 @@ func Test_Deserialize(t *testing.T) {
 	}
 }
 
-func Test_K8sAzureOfflineStoreFactory(t *testing.T) {
+func TestK8sAzureOfflineStoreFactory(t *testing.T) {
 	dockerImage := "my-docker-image:latest"
-	KCFConfig := pb.KCFConfig{
+	kcfConfig := pb.KCFConfig{
 		StoreType: Memory,
 		StoreConfig: pb.AzureBlobStoreConfig{
 			AccountKey:    "",
@@ -90,7 +90,8 @@ func Test_K8sAzureOfflineStoreFactory(t *testing.T) {
 		},
 	}
 
-	store, err := k8sAzureOfflineStoreFactory()
+	serializedKCF := kcfConfig.String()
+	store, err := k8sAzureOfflineStoreFactory(serializedKCF)
 	if err != nil {
 		t.Fatalf("Could not register AzureOfflineStoreFactory: %s", err.Error())
 	}

--- a/provider/k8s_test.go
+++ b/provider/k8s_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/featureform/helpers"
 
+	pb "github.com/featureform/metadata/proto"
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"
 	"github.com/mitchellh/mapstructure"
@@ -22,6 +23,81 @@ import (
 
 func uuidWithoutDashes() string {
 	return fmt.Sprintf("a%s", strings.ReplaceAll(uuid.New().String(), "-", ""))
+}
+
+func Test_Deserialize(t *testing.T) {
+	storeType := "AZURE"
+	accountKey := "my key"
+	accountName := "my account name"
+	containerName := "my container name"
+	containerPath := "my container path"
+	executorType := "K8S"
+	dockerimage := "my-test-image:latest"
+
+	KCFConfig := pb.KCFConfig{
+		StoreType: storeType,
+		StoreConfig: pb.AzureBlobStoreConfig{
+			AccountKey:    accountKey,
+			AccountName:   accountName,
+			ContainerName: containerName,
+			ContainerPath: containerPath,
+		},
+		ExecutorType: executorType,
+		ExecutorConfig: pb.ExecutorConfig{
+			DockerImage: dockerimage,
+		},
+	}
+
+	expectedConfig := K8sConfig{
+		ExecutorType: executorType,
+		ExecutorConfig: ExecutorConfig{
+			DockerImage: dockerimage,
+		},
+		StoreType: storeType,
+		StoreConfig: AzureFileStoreConfig{
+			AccountName:   accountName,
+			AccountKey:    accountKey,
+			ContainerName: containerName,
+			Path:          containerPath,
+		},
+	}
+
+	serializedKCF := KCFConfig.String()
+	var config K8sConfig
+	err := config.Deserialize(serializedKCF)
+	if err != nil {
+		return t.Fatalf("Could not deserialize config: %s", err.Error())
+	}
+
+	if !reflect.DeepEqual(config, expectedConfig) {
+		t.Fatalf("Configs do not match: got %v, expected %v", config, expectedConfig)
+	}
+}
+
+func Test_K8sAzureOfflineStoreFactory(t *testing.T) {
+	dockerImage := "my-docker-image:latest"
+	KCFConfig := pb.KCFConfig{
+		StoreType: Memory,
+		StoreConfig: pb.AzureBlobStoreConfig{
+			AccountKey:    "",
+			AccountName:   "",
+			ContainerName: "",
+			ContainerPath: "",
+		},
+		ExecutorType: K8s,
+		ExecutorConfig: pb.ExecutorConfig{
+			DockerImage: dockerImage,
+		},
+	}
+
+	store, err := k8sAzureOfflineStoreFactory()
+	if err != nil {
+		t.Fatalf("Could not register AzureOfflineStoreFactory: %s", err.Error())
+	}
+	k8sStore := store.(*K8sOfflineStore)
+	if !k8sStore.executor.Dockerfile == dockerImage {
+		t.Fatalf("Executor docker image does not match: got %s, expected %s", k8sStore.executor.Dockerfile, dockerImage)
+	}
 }
 
 func TestBlobInterfaces(t *testing.T) {

--- a/provider/k8s_test.go
+++ b/provider/k8s_test.go
@@ -95,6 +95,7 @@ func Test_K8sAzureOfflineStoreFactory(t *testing.T) {
 		t.Fatalf("Could not register AzureOfflineStoreFactory: %s", err.Error())
 	}
 	k8sStore := store.(*K8sOfflineStore)
+	k8sExecutor := k8sStore.executor.(*KubernetesExecutor)
 	if !k8sStore.executor.Dockerfile == dockerImage {
 		t.Fatalf("Executor docker image does not match: got %s, expected %s", k8sStore.executor.Dockerfile, dockerImage)
 	}


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Added tests for KCF custom images:
- Test client config serialize ~~and de-serialize~~ (We never deserialize on the client side rn)
- Test k8s ~~serialize and~~ (We never serialize on the server side) deserialize
- Test k8sAzureOfflineStoreFactory with a config for ~~blob store~~ (Set to memory store to avoid attempts to connect to azure) with the DockerImage set, get the executor, cast it to KubernetesExecutor, verify that image is set correctly.


## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
