### PR TITLE
Added different parsing for legacy configs

### DIFF
--- a/provider/k8s.go
+++ b/provider/k8s.go
@@ -303,10 +303,6 @@ func (config *K8sConfig) Deserialize(data []byte) error {
 	if err != nil {
 		return fmt.Errorf("deserialize k8s config: %w", err)
 	}
-	conf, ok := config.ExecutorConfig.(ExecutorConfig)
-	if ok {
-		config.ExecutorConfig = conf
-	}
 	if config.ExecutorConfig == "" {
 		config.ExecutorConfig = ExecutorConfig{}
 	} else {

--- a/provider/k8s.go
+++ b/provider/k8s.go
@@ -199,10 +199,15 @@ func k8sOfflineStoreFactory(config SerializedConfig) (Provider, error) {
 		return nil, fmt.Errorf("invalid k8s config: %w", err)
 	}
 	logger.Info("Creating executor with type:", k8.ExecutorType)
-	serializedExecutor, err := k8.ExecutorConfig.Serialize()
+	executor := k8.ExecutorConfig.(ExecutorConfig)
+	serializedExecutor, err := executor.Serialize()
+	if err != nil {
+		logger.Errorw("Failure serializing executor", "executor_type", k8.ExecutorType, "error", err)
+		return nil, err
+	}
 	exec, err := CreateExecutor(string(k8.ExecutorType), serializedExecutor, logger)
 	if err != nil {
-		logger.Errorw("Failure initializing executor with type", "executor_type", k8.ExecutorType, "error", err)
+		logger.Errorw("Failure initializing executor", "executor_type", k8.ExecutorType, "error", err)
 		return nil, err
 	}
 
@@ -280,7 +285,7 @@ const (
 
 type K8sConfig struct {
 	ExecutorType   ExecutorType
-	ExecutorConfig ExecutorConfig
+	ExecutorConfig interface{}
 	StoreType      FileStoreType
 	StoreConfig    AzureFileStoreConfig
 }
@@ -298,6 +303,33 @@ func (config *K8sConfig) Deserialize(data []byte) error {
 	if err != nil {
 		return fmt.Errorf("deserialize k8s config: %w", err)
 	}
+	conf, ok := config.ExecutorConfig.(ExecutorConfig)
+	if ok {
+		config.ExecutorConfig = conf
+	}
+	if config.ExecutorConfig == "" {
+		config.ExecutorConfig = ExecutorConfig{}
+	} else {
+		return config.executorConfigFromMap()
+	}
+	return nil
+}
+
+func (config *K8sConfig) executorConfigFromMap() error {
+	cfgMap, ok := config.ExecutorConfig.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("could not get ExecutorConfig values")
+	}
+	serializedExecutor, err := json.Marshal(cfgMap)
+	if err != nil {
+		return fmt.Errorf("could not marshal executor config: %w", err)
+	}
+	excConfig := ExecutorConfig{}
+	err = excConfig.Deserialize(serializedExecutor)
+	if err != nil {
+		return fmt.Errorf("could not deserialize config into ExecutorConfig: %w", err)
+	}
+	config.ExecutorConfig = excConfig
 	return nil
 }
 

--- a/provider/k8s_test.go
+++ b/provider/k8s_test.go
@@ -96,7 +96,7 @@ func TestDeserializeExecutorConfig(t *testing.T) {
 			receivedConfig := K8sConfig{}
 			receivedConfig.Deserialize(serializedConfig)
 			if !reflect.DeepEqual(expectedConfig, receivedConfig) {
-				t.Errorf("Expected %#v, Got %#v\n", expectedConfig, receivedConfig)
+				t.Errorf("\nExpected %#v\nGot %#v\n", expectedConfig, receivedConfig)
 			}
 		})
 	}

--- a/tests/end_to_end/serving.py
+++ b/tests/end_to_end/serving.py
@@ -51,6 +51,7 @@ def serve_data():
                 
         except Exception as e:
             print(f"\twaiting for {SLEEP_DURATION} seconds")
+            print(e)
             time.sleep(SLEEP_DURATION)
     
     raise Exception(f"Serving for {TRAININGSET_NAME}:{TRAININGSET_VARIANT} could not be completed.")
@@ -65,6 +66,7 @@ def serve_feature():
             print(f"\twaiting for {SLEEP_DURATION} seconds")
             print(e)
             time.sleep(SLEEP_DURATION)
+    raise Exception(f"Serving for {FEATURE_NAME}:{FEATURE_VARIANT}-{FEATURE_ENTITY}:{FEATURE_VALUE} could not be completed.")
 
 print(f"Serving the training set ({TRAININGSET_NAME}:{TRAININGSET_VARIANT})")
 serve_data()


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Checks if ExecutorConfig is an empty string from legacy config and converts to ExecutorConfig if so. 
- This is a hold over while we change configs to protos

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
