### PR TITLE
Fix for Provider Image in Local Mode

### DIFF
--- a/dashboard/src/api/resources/Resources.js
+++ b/dashboard/src/api/resources/Resources.js
@@ -118,6 +118,7 @@ export const providerLogos = Object.freeze({
   "APACHE SPARK": "static/Apache_Spark_logo.svg",
   POSTGRES: "static/Postgresql_elephant.svg",
   SNOWFLAKE: "static/Snowflake_Logo.svg",
+  LOCALMODE: "static/Featureform_logo_pink.svg",
 });
 
 var hostname = "localhost";


### PR DESCRIPTION
# Description

An image to represent the provider in local mode (i.e. SQLite given all local mode operations are persisted in a SQLite instance) was missing from the list of provider logos. This resulted in a broken image element under the "Software" column at Home > Providers.

**Before:**
<img width="1505" alt="Screen Shot 2023-01-24 at 8 03 58 AM" src="https://user-images.githubusercontent.com/10430775/214346140-1cc6ec40-f9b6-4a7c-b85c-89e4dbc52217.png">
**After:**
![Screen Shot 2023-01-31 at 9 15 23 AM](https://user-images.githubusercontent.com/10430775/215834823-bea34b14-d91c-4a53-96ca-236b4531c485.png)

## Type of change

### Does this correspond to an open issue?

This PR addresses [Issue 597](https://github.com/featureform/featureform/issues/597).

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
