### PR TITLE
Fixed cert name in minikube quickstart

### DIFF
--- a/docs/deployment/minikube.md
+++ b/docs/deployment/minikube.md
@@ -94,5 +94,5 @@ Since we're using a self-signed certificate, we can run the CLI using the certif
 
 ```
 export FEATUREFORM_HOST="localhost:443"
-featureform apply <file> --cert tls.cert
+featureform apply <file> --cert tls.crt
 ```


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Quickstart creates the certificate `tls.crt`, but asks the user to use `tls.cert`. Changed to be consistent

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
