### PR TITLE
API Serving Host Env Var Misspelling

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -785,7 +785,7 @@ func main() {
 	apiPort := help.GetEnv("API_PORT", "7878")
 	metadataHost := help.GetEnv("METADATA_HOST", "localhost")
 	metadataPort := help.GetEnv("METADATA_PORT", "8080")
-	servingHost := help.GetEnv("SERVING_HOST", "locahost")
+	servingHost := help.GetEnv("SERVING_HOST", "localhost")
 	servingPort := help.GetEnv("SERVING_PORT", "8080")
 	apiConn := fmt.Sprintf("0.0.0.0:%s", apiPort)
 	metadataConn := fmt.Sprintf("%s:%s", metadataHost, metadataPort)


### PR DESCRIPTION
# Description

The fallback value for `SERVING_HOST` was spelled `"locahost"`, which would cause issues if the env var `SERVING_HOST` wasn't set.

## Type of change

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
