### PR TITLE
Pinned sqlalchemy below 2.0.0

### DIFF
--- a/client/setup.cfg
+++ b/client/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     validators>=0.20.0
     dill==0.3.5.1
     pandasql==0.7.3
+    sqlalchemy<2.0.0
 
 [options.packages.find]
 where = src

--- a/provider/scripts/k8s/requirements.txt
+++ b/provider/scripts/k8s/requirements.txt
@@ -8,3 +8,4 @@ pytest-cov==3.0.0
 python-etcd==0.4.5
 python-dotenv==0.20.0
 azure-storage-blob==12.13.1
+sqlalchemy<2.0.0


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pandasql does not pin sqlalchemy, which introduced breaking changes to the client when sqlalchemy 2.0 was released. This PR sets a pin under v2.0.0 within our own package

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
