### PR TITLE
Model Metadata Upsert and Registration w/ Serving

### DIFF
--- a/metadata/client.go
+++ b/metadata/client.go
@@ -1051,7 +1051,6 @@ func (def ModelDef) ResourceType() ResourceType {
 func (client *Client) CreateModel(ctx context.Context, def ModelDef) error {
 	serialized := &pb.Model{
 		Name:         def.Name,
-		Status:       &pb.ResourceStatus{Status: pb.ResourceStatus_NO_STATUS},
 		Description:  def.Description,
 		Features:     def.Features.Serialize(),
 		Trainingsets: def.Trainingsets.Serialize(),
@@ -1467,16 +1466,10 @@ func (model *Model) Description() string {
 }
 
 func (model *Model) Status() ResourceStatus {
-	if model.serialized.GetStatus() != nil {
-		return ResourceStatus(model.serialized.GetStatus().Status)
-	}
 	return ResourceStatus(0)
 }
 
 func (model *Model) Error() string {
-	if model.serialized.GetStatus() != nil {
-		return model.serialized.GetStatus().ErrorMessage
-	}
 	return ""
 }
 

--- a/metadata/client.go
+++ b/metadata/client.go
@@ -1038,8 +1038,10 @@ func (client *Client) GetModels(ctx context.Context, models []string) ([]*Model,
 }
 
 type ModelDef struct {
-	Name        string
-	Description string
+	Name         string
+	Description  string
+	Features     NameVariants
+	Trainingsets NameVariants
 }
 
 func (def ModelDef) ResourceType() ResourceType {
@@ -1048,9 +1050,11 @@ func (def ModelDef) ResourceType() ResourceType {
 
 func (client *Client) CreateModel(ctx context.Context, def ModelDef) error {
 	serialized := &pb.Model{
-		Name:        def.Name,
-		Status:      &pb.ResourceStatus{Status: pb.ResourceStatus_NO_STATUS},
-		Description: def.Description,
+		Name:         def.Name,
+		Status:       &pb.ResourceStatus{Status: pb.ResourceStatus_NO_STATUS},
+		Description:  def.Description,
+		Features:     def.Features.Serialize(),
+		Trainingsets: def.Trainingsets.Serialize(),
 	}
 	_, err := client.grpcConn.CreateModel(ctx, serialized)
 	return err

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -317,6 +317,11 @@ func (lookup localResourceLookup) HasJob(id ResourceID) (bool, error) {
 	return false, nil
 }
 
+type NameVariantKey struct {
+	Name    string
+	Variant string
+}
+
 type sourceResource struct {
 	serialized *pb.Source
 }
@@ -888,14 +893,16 @@ func (resource *modelResource) Update(lookup ResourceLookup, updateRes Resource)
 }
 
 func unionNameVariants(source, destination []*pb.NameVariant) ([]*pb.NameVariant, error) {
-	set := make(map[string]bool)
+	set := make(map[NameVariantKey]bool)
 
 	for _, nameVariant := range destination {
-		set[fmt.Sprintf("%s|%s", nameVariant.Name, nameVariant.Variant)] = true
+		key := NameVariantKey{Name: nameVariant.Name, Variant: nameVariant.Variant}
+		set[key] = true
 	}
 
 	for _, nameVariant := range source {
-		if _, has := set[fmt.Sprintf("%s|%s", nameVariant.Name, nameVariant.Variant)]; !has {
+		key := NameVariantKey{Name: nameVariant.Name, Variant: nameVariant.Variant}
+		if _, has := set[key]; !has {
 			destination = append(destination, nameVariant)
 		}
 	}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -871,10 +871,8 @@ func (resource *modelResource) Update(lookup ResourceLookup, updateRes Resource)
 	if !ok {
 		return errors.New("failed to deserialize existing model record")
 	}
-	updated := unionNameVariants(resource.serialized.Features, updateModel.Features)
-	resource.serialized.Features = updated
-	updated = unionNameVariants(resource.serialized.Trainingsets, updateModel.Trainingsets)
-	resource.serialized.Trainingsets = updated
+	resource.serialized.Features = unionNameVariants(resource.serialized.Features, updateModel.Features)
+	resource.serialized.Trainingsets = unionNameVariants(resource.serialized.Trainingsets, updateModel.Trainingsets)
 	return nil
 }
 
@@ -887,12 +885,12 @@ func unionNameVariants(source, destination []*pb.NameVariant) []*pb.NameVariant 
 	set := make(map[nameVariantKey]bool)
 
 	for _, nameVariant := range destination {
-		key := nameVariantKey{Name: nameVariant.Name, Variant: nameVariant.Variant}
+		key := nameVariantKey{nameVariant.Name, nameVariant.Variant}
 		set[key] = true
 	}
 
 	for _, nameVariant := range source {
-		key := nameVariantKey{Name: nameVariant.Name, Variant: nameVariant.Variant}
+		key := nameVariantKey{nameVariant.Name, nameVariant.Variant}
 		if _, has := set[key]; !has {
 			destination = append(destination, nameVariant)
 		}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -7,11 +7,12 @@ package metadata
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	pb "github.com/featureform/metadata/proto"
 	"github.com/featureform/metadata/search"
@@ -192,6 +193,7 @@ type Resource interface {
 	Proto() proto.Message
 	UpdateStatus(pb.ResourceStatus) error
 	UpdateSchedule(string) error
+	Update(ResourceLookup) error
 }
 
 func isDirectDependency(lookup ResourceLookup, dependency, parent Resource) (bool, error) {
@@ -357,6 +359,10 @@ func (resource *sourceResource) UpdateSchedule(schedule string) error {
 	return fmt.Errorf("not implemented")
 }
 
+func (resource *sourceResource) Update(lookup ResourceLookup) error {
+	return &ResourceExists{resource.ID()}
+}
+
 type sourceVariantResource struct {
 	serialized *pb.SourceVariant
 }
@@ -427,6 +433,10 @@ func (resource *sourceVariantResource) UpdateSchedule(schedule string) error {
 	return nil
 }
 
+func (resource *sourceVariantResource) Update(lookup ResourceLookup) error {
+	return &ResourceExists{resource.ID()}
+}
+
 type featureResource struct {
 	serialized *pb.Feature
 }
@@ -467,6 +477,10 @@ func (resource *featureResource) UpdateStatus(status pb.ResourceStatus) error {
 
 func (resource *featureResource) UpdateSchedule(schedule string) error {
 	return fmt.Errorf("not implemented")
+}
+
+func (resource *featureResource) Update(lookup ResourceLookup) error {
+	return &ResourceExists{resource.ID()}
 }
 
 type featureVariantResource struct {
@@ -543,6 +557,10 @@ func (resource *featureVariantResource) UpdateSchedule(schedule string) error {
 	return nil
 }
 
+func (resource *featureVariantResource) Update(lookup ResourceLookup) error {
+	return &ResourceExists{resource.ID()}
+}
+
 type labelResource struct {
 	serialized *pb.Label
 }
@@ -583,6 +601,10 @@ func (resource *labelResource) UpdateStatus(status pb.ResourceStatus) error {
 
 func (resource *labelResource) UpdateSchedule(schedule string) error {
 	return fmt.Errorf("not implemented")
+}
+
+func (resource *labelResource) Update(lookup ResourceLookup) error {
+	return &ResourceExists{resource.ID()}
 }
 
 type labelVariantResource struct {
@@ -657,6 +679,10 @@ func (resource *labelVariantResource) UpdateSchedule(schedule string) error {
 	return fmt.Errorf("not implemented")
 }
 
+func (resource *labelVariantResource) Update(lookup ResourceLookup) error {
+	return &ResourceExists{resource.ID()}
+}
+
 type trainingSetResource struct {
 	serialized *pb.TrainingSet
 }
@@ -697,6 +723,10 @@ func (resource *trainingSetResource) UpdateStatus(status pb.ResourceStatus) erro
 
 func (resource *trainingSetResource) UpdateSchedule(schedule string) error {
 	return fmt.Errorf("not implemented")
+}
+
+func (resource *trainingSetResource) Update(lookup ResourceLookup) error {
+	return &ResourceExists{resource.ID()}
 }
 
 type trainingSetVariantResource struct {
@@ -769,6 +799,10 @@ func (resource *trainingSetVariantResource) UpdateSchedule(schedule string) erro
 	return nil
 }
 
+func (resource *trainingSetVariantResource) Update(lookup ResourceLookup) error {
+	return &ResourceExists{resource.ID()}
+}
+
 type modelResource struct {
 	serialized *pb.Model
 }
@@ -832,6 +866,45 @@ func (resource *modelResource) UpdateSchedule(schedule string) error {
 	return fmt.Errorf("not implemented")
 }
 
+func (resource *modelResource) Update(lookup ResourceLookup) error {
+	val, err := lookup.Lookup(resource.ID())
+	if err != nil {
+		return err
+	}
+	deserialized := val.Proto()
+	model, ok := deserialized.(*pb.Model)
+	if !ok {
+		return errors.New("failed to deserialize existing model record")
+	}
+	updated, err := unionNameVariants(resource.serialized.Features, model.Features)
+	if err != nil {
+		return err
+	}
+	resource.serialized.Features = updated
+	updated, err = unionNameVariants(resource.serialized.Trainingsets, model.Trainingsets)
+	if err != nil {
+		return err
+	}
+	resource.serialized.Trainingsets = updated
+	return nil
+}
+
+func unionNameVariants(source, destination []*pb.NameVariant) ([]*pb.NameVariant, error) {
+	set := make(map[string]bool)
+
+	for _, variant := range destination {
+		set[variant.String()] = true
+	}
+
+	for _, variant := range source {
+		if _, has := set[variant.String()]; !has {
+			destination = append(destination, variant)
+		}
+	}
+
+	return destination, nil
+}
+
 type userResource struct {
 	serialized *pb.User
 }
@@ -885,6 +958,10 @@ func (resource *userResource) UpdateStatus(status pb.ResourceStatus) error {
 
 func (resource *userResource) UpdateSchedule(schedule string) error {
 	return fmt.Errorf("not implemented")
+}
+
+func (resource *userResource) Update(lookup ResourceLookup) error {
+	return &ResourceExists{resource.ID()}
 }
 
 type providerResource struct {
@@ -942,6 +1019,10 @@ func (resource *providerResource) UpdateSchedule(schedule string) error {
 	return fmt.Errorf("not implemented")
 }
 
+func (resource *providerResource) Update(lookup ResourceLookup) error {
+	return &ResourceExists{resource.ID()}
+}
+
 type entityResource struct {
 	serialized *pb.Entity
 }
@@ -988,6 +1069,10 @@ func (resource *entityResource) UpdateStatus(status pb.ResourceStatus) error {
 
 func (resource *entityResource) UpdateSchedule(schedule string) error {
 	return fmt.Errorf("not implemented")
+}
+
+func (resource *entityResource) Update(lookup ResourceLookup) error {
+	return &ResourceExists{resource.ID()}
 }
 
 type MetadataServer struct {
@@ -1331,7 +1416,9 @@ func (serv *MetadataServer) genericCreate(ctx context.Context, res Resource, ini
 	if has, err := serv.lookup.Has(id); err != nil {
 		return nil, err
 	} else if has {
-		return nil, &ResourceExists{id}
+		if err := res.Update(serv.lookup); err != nil {
+			return nil, err
+		}
 	}
 	if err := serv.lookup.Set(id, res); err != nil {
 		return nil, err

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -1277,6 +1277,45 @@ func expectedModels() ResourceTests {
 	}
 }
 
+/*
+Currently, the testing pattern assumes immutability, which made writing
+test for model updates a bit awkward. As we roll out updates to other
+resource types, we should consider refactoring the top-level interfaces
+so we can more neatly encapsulate data/logic/etc. for updates.
+
+For now, the below two functions work in tandem:
+* `modelUpdates` holds 3 payloads that are applied in order
+* `expectedUpdatedModels` holds the expected state after each payload is persisted
+*/
+func modelUpdates() []ResourceDef {
+	return []ResourceDef{
+		ModelDef{
+			Name:        "fraud",
+			Description: "fraud model",
+			Features:    []NameVariant{},
+			Trainingsets: []NameVariant{
+				{Name: "training-set", Variant: "variant"},
+			},
+		},
+		ModelDef{
+			Name:        "fraud",
+			Description: "fraud model",
+			Features:    []NameVariant{},
+			Trainingsets: []NameVariant{
+				{Name: "training-set", Variant: "variant2"},
+			},
+		},
+		ModelDef{
+			Name:        "fraud",
+			Description: "fraud model",
+			Features:    []NameVariant{},
+			Trainingsets: []NameVariant{
+				{Name: "training-set", Variant: "variant2"},
+			},
+		},
+	}
+}
+
 func expectedUpdatedModels() ResourceTests {
 	return ResourceTests{
 		ModelTest{
@@ -1305,35 +1344,6 @@ func expectedUpdatedModels() ResourceTests {
 			Features:    []NameVariant{},
 			TrainingSets: []NameVariant{
 				{Name: "training-set", Variant: "variant"},
-				{Name: "training-set", Variant: "variant2"},
-			},
-		},
-	}
-}
-
-func modelUpdates() []ResourceDef {
-	return []ResourceDef{
-		ModelDef{
-			Name:        "fraud",
-			Description: "fraud model",
-			Features:    []NameVariant{},
-			Trainingsets: []NameVariant{
-				{Name: "training-set", Variant: "variant"},
-			},
-		},
-		ModelDef{
-			Name:        "fraud",
-			Description: "fraud model",
-			Features:    []NameVariant{},
-			Trainingsets: []NameVariant{
-				{Name: "training-set", Variant: "variant2"},
-			},
-		},
-		ModelDef{
-			Name:        "fraud",
-			Description: "fraud model",
-			Features:    []NameVariant{},
-			Trainingsets: []NameVariant{
 				{Name: "training-set", Variant: "variant2"},
 			},
 		},

--- a/metadata/proto/metadata.proto
+++ b/metadata/proto/metadata.proto
@@ -241,10 +241,9 @@ message Entity {
 message Model {
     string name = 1;
     string description = 2;
-    ResourceStatus status = 3;
-    repeated NameVariant features = 4;
-    repeated NameVariant labels = 5;
-    repeated NameVariant trainingsets = 6;
+    repeated NameVariant features = 3;
+    repeated NameVariant labels = 4;
+    repeated NameVariant trainingsets = 5;
 }
 
 message User {

--- a/serving/serving.go
+++ b/serving/serving.go
@@ -34,7 +34,7 @@ func NewFeatureServer(meta *metadata.Client, promMetrics metrics.MetricsHandler,
 	}, nil
 }
 
-func (serv *FeatureServer) TrainingData(ctx context.Context, req *pb.TrainingDataRequest, stream pb.Feature_TrainingDataServer) error {
+func (serv *FeatureServer) TrainingData(req *pb.TrainingDataRequest, stream pb.Feature_TrainingDataServer) error {
 	id := req.GetId()
 	name, variant := id.GetName(), id.GetVersion()
 	featureObserver := serv.Metrics.BeginObservingTrainingServe(name, variant)
@@ -43,7 +43,7 @@ func (serv *FeatureServer) TrainingData(ctx context.Context, req *pb.TrainingDat
 	logger.Info("Serving training data")
 	if model := req.GetModel(); model != nil {
 		trainingSets := []metadata.NameVariant{{Name: name, Variant: variant}}
-		err := serv.Metadata.CreateModel(ctx, metadata.ModelDef{Name: model.GetName(), Trainingsets: trainingSets})
+		err := serv.Metadata.CreateModel(stream.Context(), metadata.ModelDef{Name: model.GetName(), Trainingsets: trainingSets})
 		if err != nil {
 			return err
 		}

--- a/serving/serving_test.go
+++ b/serving/serving_test.go
@@ -910,7 +910,7 @@ func TestSimpleTrainingSetServe(t *testing.T) {
 	stream := newMockTrainingStream()
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
+		if err := serv.TrainingData(req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -964,7 +964,7 @@ func TestTrainingSetNotFound(t *testing.T) {
 	stream := newMockTrainingStream()
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
+		if err := serv.TrainingData(req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -990,7 +990,7 @@ func TestTrainingSetNoProviderFactory(t *testing.T) {
 	stream := newMockTrainingStream()
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
+		if err := serv.TrainingData(req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -1016,7 +1016,7 @@ func TestTrainingSetInOnlineStore(t *testing.T) {
 	stream := newMockTrainingStream()
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
+		if err := serv.TrainingData(req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -1043,7 +1043,7 @@ func TestTrainingSetStreamFailure(t *testing.T) {
 	stream.ShouldFail = true
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
+		if err := serv.TrainingData(req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -1070,7 +1070,7 @@ func TestTrainingSetInvalidLabel(t *testing.T) {
 	stream.ShouldFail = true
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
+		if err := serv.TrainingData(req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -1096,7 +1096,7 @@ func TestTrainingSetInvalidFeature(t *testing.T) {
 	stream := newMockTrainingStream()
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
+		if err := serv.TrainingData(req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -1127,7 +1127,7 @@ func TestSimpleModelRegistrationTrainingSetServe(t *testing.T) {
 	stream := newMockTrainingStream()
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
+		if err := serv.TrainingData(req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)

--- a/serving/serving_test.go
+++ b/serving/serving_test.go
@@ -801,6 +801,57 @@ func TestAllFeatureTypes(t *testing.T) {
 	}
 }
 
+func TestSimpleModelRegistrationFeatureServe(t *testing.T) {
+	ctx := onlineTestContext{
+		ResourceDefsFn: simpleResourceDefsFn,
+		FactoryFn:      createMockOnlineStoreFactory(simpleFeatureRecords()),
+	}
+	serv := ctx.Create(t)
+	defer ctx.Destroy()
+	modelName := "model"
+	feature := &pb.FeatureID{
+		Name:    "feature",
+		Version: "variant",
+	}
+	req := &pb.FeatureServeRequest{
+		Features: []*pb.FeatureID{
+			feature,
+		},
+		Entities: []*pb.Entity{
+			{
+				Name:  "mockEntity",
+				Value: "a",
+			},
+		},
+		Model: &pb.Model{
+			Name: modelName,
+		},
+	}
+	resp, err := serv.FeatureServe(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Failed to serve feature: %s", err)
+	}
+	vals := resp.Values
+	if len(vals) != len(req.Features) {
+		t.Fatalf("Wrong number of values: %d\nExpected: %d", len(vals), len(req.Features))
+	}
+	dblVal := unwrapVal(vals[0])
+	if dblVal != 12.5 {
+		t.Fatalf("Wrong feature value: %v\nExpected: %v", dblVal, 12.5)
+	}
+	modelResp, err := serv.Metadata.GetModel(context.Background(), modelName)
+	if err != nil {
+		t.Fatalf("Failed to get model: %s", err)
+	}
+	if len(modelResp.Features()) != 1 {
+		t.Fatalf("Failed to associate model with feature")
+	}
+	modelFeature := modelResp.Features()[0]
+	if !(modelFeature.Name == feature.Name && modelFeature.Variant == feature.Version) {
+		t.Fatalf("Wrong feature associated with registered model: %v\nExpected %v", modelFeature, feature)
+	}
+}
+
 type mockTrainingStream struct {
 	RowChan    chan *pb.TrainingDataRow
 	ShouldFail bool
@@ -859,7 +910,7 @@ func TestSimpleTrainingSetServe(t *testing.T) {
 	stream := newMockTrainingStream()
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(req, stream); err != nil {
+		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -913,7 +964,7 @@ func TestTrainingSetNotFound(t *testing.T) {
 	stream := newMockTrainingStream()
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(req, stream); err != nil {
+		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -939,7 +990,7 @@ func TestTrainingSetNoProviderFactory(t *testing.T) {
 	stream := newMockTrainingStream()
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(req, stream); err != nil {
+		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -965,7 +1016,7 @@ func TestTrainingSetInOnlineStore(t *testing.T) {
 	stream := newMockTrainingStream()
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(req, stream); err != nil {
+		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -992,7 +1043,7 @@ func TestTrainingSetStreamFailure(t *testing.T) {
 	stream.ShouldFail = true
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(req, stream); err != nil {
+		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -1019,7 +1070,7 @@ func TestTrainingSetInvalidLabel(t *testing.T) {
 	stream.ShouldFail = true
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(req, stream); err != nil {
+		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
@@ -1045,12 +1096,82 @@ func TestTrainingSetInvalidFeature(t *testing.T) {
 	stream := newMockTrainingStream()
 	errChan := make(chan error)
 	go func() {
-		if err := serv.TrainingData(req, stream); err != nil {
+		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
 			errChan <- err
 		}
 		close(errChan)
 	}()
 	if err := <-errChan; err == nil {
 		t.Fatalf("Succeeded in serving invalid feature: %s", err)
+	}
+}
+
+func TestSimpleModelRegistrationTrainingSetServe(t *testing.T) {
+	ctx := onlineTestContext{
+		ResourceDefsFn: simpleResourceDefsFn,
+		FactoryFn:      createMockOfflineStoreFactory(simpleFeatureRecords(), simpleTrainingSetDefs()),
+	}
+	serv := ctx.Create(t)
+	defer ctx.Destroy()
+	modelName := "model"
+	trainingData := &pb.TrainingDataID{
+		Name:    "training-set",
+		Version: "variant",
+	}
+	req := &pb.TrainingDataRequest{
+		Id: trainingData,
+		Model: &pb.Model{
+			Name: modelName,
+		},
+	}
+	stream := newMockTrainingStream()
+	errChan := make(chan error)
+	go func() {
+		if err := serv.TrainingData(context.Background(), req, stream); err != nil {
+			errChan <- err
+		}
+		close(errChan)
+	}()
+	type Row struct {
+		Feature interface{}
+		Label   interface{}
+	}
+	// We use a map since the order is not guaranteed.
+	expectedRows := map[Row]bool{
+		{12.5, true}:   true,
+		{"def", false}: true,
+	}
+	actualRows := make(map[Row]bool)
+	moreVals := true
+	for moreVals {
+		select {
+		case row := <-stream.RowChan:
+			if len(row.Features) != 1 {
+				t.Fatalf("Row has too many features: %v", row)
+			}
+			actualRows[Row{
+				Feature: unwrapVal(row.Features[0]),
+				Label:   unwrapVal(row.Label),
+			}] = true
+		case err := <-errChan:
+			if err != nil {
+				t.Fatalf("Failed to get training data: %s", err)
+			}
+			moreVals = false
+		}
+	}
+	if !reflect.DeepEqual(expectedRows, actualRows) {
+		t.Fatalf("Rows aren't equal: %v\n%v", expectedRows, actualRows)
+	}
+	modelResp, err := serv.Metadata.GetModel(context.Background(), modelName)
+	if err != nil {
+		t.Fatalf("Failed to get model: %s", err)
+	}
+	if len(modelResp.TrainingSets()) != 1 {
+		t.Fatalf("Failed to associate model with feature")
+	}
+	modelTrainingSet := modelResp.TrainingSets()[0]
+	if !(modelTrainingSet.Name == trainingData.Name && modelTrainingSet.Variant == trainingData.Version) {
+		t.Fatalf("Wrong training set associated with registered model: %v\nExpected %v", modelTrainingSet, trainingData)
 	}
 }


### PR DESCRIPTION
# Description

This PR introduces the upsert pattern for resources, with the model resource as an initial example, as well as the implementation for model registration while serving features or training sets.

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
