### PR TITLE
Model Registration E2E Test Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,9 +219,10 @@ pytest:
 	pytest client/tests/test_spark_provider.py
 	pytest client/tests/test_localmode_include_label_ts.py
 	pytest client/tests/test_localmode_lag_features.py
-	pytest client/tests/test_serving_model.py
-	pytest client/tests/test_getting_model.py
+	pytest -m 'local' client/tests/test_serving_model.py
+	pytest -m 'local' client/tests/test_getting_model.py
 	-rm -r .featureform
+	-rm -f transactions.csv
 
 jupyter: update_python
 	pip3 install jupyter nbconvert matplotlib pandas scikit-learn requests

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2457,9 +2457,9 @@ class ResourceClient(Registrar):
             return
 
         if self.local:
-            self.state().create_all_local()
+            state().create_all_local()
         else:
-            self.state().create_all(self._stub)
+            state().create_all(self._stub)
 
     def get_user(self, name, local=False):
         """Get a user. Prints out name of user, and all resources associated with the user.

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -126,10 +126,10 @@ class HostedClientImpl:
         else:
             return secure_channel(host, cert_path)
 
-    def training_set(self, name, variation, include_label_timestamp):
+    def training_set(self, name, variation, include_label_timestamp, model: Union[str, Model] = None):
         return Dataset(self._stub).from_stub(name, variation)
 
-    def features(self, features, entities):
+    def features(self, features, entities, model: Union[str, Model] = None):
         req = serving_pb2.FeatureServeRequest()
         for name, value in entities.items():
             entity_proto = req.entities.add()

--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -149,20 +149,16 @@ def s3(aws_credentials):
 
 
 @pytest.fixture(scope="module")
-def local_client_provider_source():
-    def get_local(is_local):
-        resource_client = ResourceClient(local=is_local)
-        resource_client.register_user("test_user").make_default_owner()
-        provider = resource_client.register_local()
+def local_registrar_provider_source():
+        ff.register_user("test_user").make_default_owner()
+        provider = ff.register_local()
         source = provider.register_file(
             name="transactions",
             variant="quickstart",
             description="A dataset of fraudulent transactions.",
             path=f"{dir_path}/test_files/input_files/transactions.csv"
         )
-        return (resource_client, provider, source)
-
-    return get_local
+        return (ff, provider, source)
 
 
 @pytest.fixture(scope="module")
@@ -188,26 +184,23 @@ def del_rw(action, name, exc):
 
 @pytest.fixture(scope="module")
 def hosted_sql_provider_and_source():
-    def get_hosted(is_local):
-            ff.register_user("test_user").make_default_owner()
+    ff.register_user("test_user").make_default_owner()
 
-            provider = ff.register_postgres(
-                name = "postgres-quickstart",
-                host="0.0.0.0",
-                port="5432",
-                user="postgres",
-                password="password",
-                database="postgres",
-                description = "A Postgres deployment we created for the Featureform quickstart"
-            )
+    provider = ff.register_postgres(
+        name = "postgres-quickstart",
+        host="0.0.0.0",
+        port="5432",
+        user="postgres",
+        password="password",
+        database="postgres",
+        description = "A Postgres deployment we created for the Featureform quickstart"
+    )
 
-            source = provider.register_table(
-                name = "transactions",
-                variant = "kaggle",
-                description = "Fraud Dataset From Kaggle",
-                table = "Transactions", # This is the table's name in Postgres
-            )
+    source = provider.register_table(
+        name = "transactions",
+        variant = "kaggle",
+        description = "Fraud Dataset From Kaggle",
+        table = "Transactions", # This is the table's name in Postgres
+    )
 
-            return (ff.ResourceClient(), provider, source)
-
-    return get_hosted
+    return (ff, provider, source)

--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -13,7 +13,6 @@ from featureform.register import (
     OfflineSQLProvider,
     ResourceClient,
 )
-from featureform.serving import ServingClient
 from featureform.resources import (
     AWSCredentials,
     AzureFileStoreConfig,
@@ -149,22 +148,25 @@ def s3(aws_credentials):
 
 
 @pytest.fixture(scope="module")
-def local_registrar_provider_source():
-        ff.register_user("test_user").make_default_owner()
-        provider = ff.register_local()
-        source = provider.register_file(
-            name="transactions",
-            variant="quickstart",
-            description="A dataset of fraudulent transactions.",
-            path=f"{dir_path}/test_files/input_files/transactions.csv"
-        )
-        return (ff, provider, source)
+def local_provider_source():
+        def get_local():
+            ff.register_user("test_user").make_default_owner()
+            provider = ff.register_local()
+            source = provider.register_file(
+                name="transactions",
+                variant="quickstart",
+                description="A dataset of fraudulent transactions.",
+                path=f"{dir_path}/test_files/input_files/transactions.csv"
+            )
+            return (provider, source)
+        
+        return get_local
 
 
 @pytest.fixture(scope="module")
 def serving_client():
     def get_clients_for_context(is_local):
-            return ServingClient(local=is_local)
+            return ff.ServingClient(local=is_local)
     
     return get_clients_for_context
 
@@ -203,4 +205,4 @@ def hosted_sql_provider_and_source():
         table = "Transactions", # This is the table's name in Postgres
     )
 
-    return (ff, provider, source)
+    return (provider, source)

--- a/client/tests/register_test.py
+++ b/client/tests/register_test.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import stat
 import sys
+import featureform as ff
 
 sys.path.insert(0, 'client/src/')
 import pytest
@@ -90,15 +91,8 @@ def test_df_transformation_empty_description(registrar):
     # Checks that Transformation definition does not error when converting to source
     dec.to_source()
 
-@pytest.mark.parametrize(
-    "ff_provider_source_fxt,is_local",
-    [
-        ('local_registrar_provider_source', True),
-        ('hosted_sql_provider_and_source', False),
-    ]
-)
-def test_valid_model_registration(ff_provider_source_fxt, is_local, request):
-    ff = request.getfixturevalue(ff_provider_source_fxt)[0];
+
+def test_valid_model_registration():
     model_name = "model_a"
 
     model = ff.register_model(model_name)
@@ -106,15 +100,7 @@ def test_valid_model_registration(ff_provider_source_fxt, is_local, request):
     assert isinstance(model, Model) and model.name == model_name
 
 
-@pytest.mark.parametrize(
-    "ff_provider_source_fxt,is_local",
-    [
-        ('local_registrar_provider_source', True),
-        ('hosted_sql_provider_and_source', False),
-    ]
-)
-def test_invalid_model_registration(ff_provider_source_fxt, is_local, request):
-    ff = request.getfixturevalue(ff_provider_source_fxt)[0];
+def test_invalid_model_registration():
 
     with pytest.raises(TypeError, match="missing 1 required positional argument: 'name'"):
         model = ff.register_model()

--- a/client/tests/register_test.py
+++ b/client/tests/register_test.py
@@ -91,33 +91,33 @@ def test_df_transformation_empty_description(registrar):
     dec.to_source()
 
 @pytest.mark.parametrize(
-    "client_provider_source_fxt,is_local",
+    "ff_provider_source_fxt,is_local",
     [
-        ('local_client_provider_source', True),
+        ('local_registrar_provider_source', True),
         ('hosted_sql_provider_and_source', False),
     ]
 )
-def test_valid_model_registration(client_provider_source_fxt, is_local, request):
-    resource_client = request.getfixturevalue(client_provider_source_fxt)(is_local)[0];
+def test_valid_model_registration(ff_provider_source_fxt, is_local, request):
+    ff = request.getfixturevalue(ff_provider_source_fxt)[0];
     model_name = "model_a"
 
-    model = resource_client.register_model(model_name)
+    model = ff.register_model(model_name)
 
     assert isinstance(model, Model) and model.name == model_name
 
 
 @pytest.mark.parametrize(
-    "client_provider_source_fxt,is_local",
+    "ff_provider_source_fxt,is_local",
     [
-        ('local_client_provider_source', True),
+        ('local_registrar_provider_source', True),
         ('hosted_sql_provider_and_source', False),
     ]
 )
-def test_invalid_model_registration(client_provider_source_fxt, is_local, request):
-    resource_client = request.getfixturevalue(client_provider_source_fxt)(is_local)[0];
+def test_invalid_model_registration(ff_provider_source_fxt, is_local, request):
+    ff = request.getfixturevalue(ff_provider_source_fxt)[0];
 
     with pytest.raises(TypeError, match="missing 1 required positional argument: 'name'"):
-        model = resource_client.register_model()
+        model = ff.register_model()
 
 
 def del_rw(action, name, exc):

--- a/client/tests/test_executor_resources.py
+++ b/client/tests/test_executor_resources.py
@@ -10,12 +10,12 @@ from featureform.resources import DatabricksCredentials, EMRCredentials
         ("a", "b", "", "","c"),
         ("", "", "a", "b","c"),
         pytest.param("a", "b", "a","b","c", marks=pytest.mark.xfail),
-        pytest.param("", "", "", "","c", marks=pytest.mark.xfail)
+        pytest.param("", "", "", "","c", marks=pytest.mark.xfail),
         pytest.param("a", "b", "","","", marks=pytest.mark.xfail)
 
     ]
 )
-def test_databricks_credentials(username, password, host, token):
+def test_databricks_credentials(username, password, host, token, cluster_id):
     databricks = DatabricksCredentials(username=username, password=password, host=host, token=token, cluster_id=cluster_id)
 
     expected_config = {

--- a/client/tests/test_getting_model.py
+++ b/client/tests/test_getting_model.py
@@ -6,8 +6,8 @@ import featureform as ff
 @pytest.mark.parametrize(
     "is_local",
     [
-        (True),
-        (False),
+        pytest.param(True, marks=pytest.mark.local),
+        pytest.param(False, marks=pytest.mark.hosted),
     ]
 )
 def test_getting_model_successfully(is_local):
@@ -23,8 +23,8 @@ def test_getting_model_successfully(is_local):
 @pytest.mark.parametrize(
     "is_local",
     [
-        (True),
-        (False),
+        pytest.param(True, marks=pytest.mark.local),
+        pytest.param(False, marks=pytest.mark.hosted),
     ]
 )
 def test_getting_model_by_unregistered_name(is_local):
@@ -39,8 +39,8 @@ def test_getting_model_by_unregistered_name(is_local):
 @pytest.mark.parametrize(
     "is_local",
     [
-        (True),
-        (False),
+        pytest.param(True, marks=pytest.mark.local),
+        pytest.param(False, marks=pytest.mark.hosted),
     ]
 )
 def test_getting_model_no_name(is_local):

--- a/client/tests/test_getting_model.py
+++ b/client/tests/test_getting_model.py
@@ -1,19 +1,19 @@
 import pytest
 from featureform.register import ModelRegistrar
 from featureform.resources import Model
+import featureform as ff
 
 @pytest.mark.parametrize(
-    "ff_provider_source_fxt,is_local",
+    "is_local",
     [
-        ('local_registrar_provider_source', True),
-        ('hosted_sql_provider_and_source', False),
+        (True),
+        (False),
     ]
 )
-def test_getting_model_successfully(ff_provider_source_fxt, is_local, request):
-    ff = request.getfixturevalue(ff_provider_source_fxt)[0];
+def test_getting_model_successfully(is_local):
     model_name = "model_a"
 
-    resource_client = arrange_resources(ff, model_name, is_local)
+    resource_client = arrange_resources(model_name, is_local)
 
     model = resource_client.get_model(model_name, is_local)
 
@@ -21,34 +21,32 @@ def test_getting_model_successfully(ff_provider_source_fxt, is_local, request):
 
 
 @pytest.mark.parametrize(
-    "ff_provider_source_fxt,is_local",
+    "is_local",
     [
-        ('local_registrar_provider_source', True),
-        ('hosted_sql_provider_and_source', False),
+        (True),
+        (False),
     ]
 )
-def test_getting_model_by_unregistered_name(ff_provider_source_fxt, is_local, request):
-    ff = request.getfixturevalue(ff_provider_source_fxt)[0];
+def test_getting_model_by_unregistered_name(is_local):
     model_name = "model_a"
 
-    resource_client = arrange_resources(ff, model_name, is_local)
+    resource_client = arrange_resources(model_name, is_local)
 
     with pytest.raises(ValueError, match="not found"):
         resource_client.get_model("model_b", is_local)
 
 
 @pytest.mark.parametrize(
-    "ff_provider_source_fxt,is_local",
+    "is_local",
     [
-        ('local_registrar_provider_source', True),
-        ('hosted_sql_provider_and_source', False),
+        (True),
+        (False),
     ]
 )
-def test_getting_model_no_name(ff_provider_source_fxt, is_local, request):
-    ff = request.getfixturevalue(ff_provider_source_fxt)[0];
+def test_getting_model_no_name(is_local):
     model_name = "model_a"
 
-    resource_client = arrange_resources(ff, model_name, is_local)
+    resource_client = arrange_resources(model_name, is_local)
 
     with pytest.raises(TypeError, match="missing 1 required positional argument: 'name'"):
         resource_client.get_model(local=is_local)
@@ -60,7 +58,7 @@ def before_and_after_each(setup_teardown):
     yield
     setup_teardown()
 
-def arrange_resources(ff, model_name, is_local):
+def arrange_resources(model_name, is_local):
     ff.register_model(model_name)
     resource_client = ff.ResourceClient(local=is_local)
     resource_client.apply()

--- a/client/tests/test_getting_model.py
+++ b/client/tests/test_getting_model.py
@@ -3,17 +3,17 @@ from featureform.register import ModelRegistrar
 from featureform.resources import Model
 
 @pytest.mark.parametrize(
-    "client_provider_source_fxt,is_local",
+    "ff_provider_source_fxt,is_local",
     [
-        ('local_client_provider_source', True),
+        ('local_registrar_provider_source', True),
         ('hosted_sql_provider_and_source', False),
     ]
 )
-def test_getting_model_successfully(client_provider_source_fxt, is_local, request):
-    resource_client = request.getfixturevalue(client_provider_source_fxt)(is_local)[0];
+def test_getting_model_successfully(ff_provider_source_fxt, is_local, request):
+    ff = request.getfixturevalue(ff_provider_source_fxt)[0];
     model_name = "model_a"
 
-    arrange_resources(resource_client, model_name)
+    resource_client = arrange_resources(ff, model_name, is_local)
 
     model = resource_client.get_model(model_name, is_local)
 
@@ -21,34 +21,34 @@ def test_getting_model_successfully(client_provider_source_fxt, is_local, reques
 
 
 @pytest.mark.parametrize(
-    "client_provider_source_fxt,is_local",
+    "ff_provider_source_fxt,is_local",
     [
-        ('local_client_provider_source', True),
+        ('local_registrar_provider_source', True),
         ('hosted_sql_provider_and_source', False),
     ]
 )
-def test_getting_model_by_unregistered_name(client_provider_source_fxt, is_local, request):
-    resource_client = request.getfixturevalue(client_provider_source_fxt)(is_local)[0];
+def test_getting_model_by_unregistered_name(ff_provider_source_fxt, is_local, request):
+    ff = request.getfixturevalue(ff_provider_source_fxt)[0];
     model_name = "model_a"
 
-    arrange_resources(resource_client, model_name)
+    resource_client = arrange_resources(ff, model_name, is_local)
 
     with pytest.raises(ValueError, match="not found"):
         resource_client.get_model("model_b", is_local)
 
 
 @pytest.mark.parametrize(
-    "client_provider_source_fxt,is_local",
+    "ff_provider_source_fxt,is_local",
     [
-        ('local_client_provider_source', True),
+        ('local_registrar_provider_source', True),
         ('hosted_sql_provider_and_source', False),
     ]
 )
-def test_getting_model_no_name(client_provider_source_fxt, is_local, request):
-    resource_client = request.getfixturevalue(client_provider_source_fxt)(is_local)[0];
+def test_getting_model_no_name(ff_provider_source_fxt, is_local, request):
+    ff = request.getfixturevalue(ff_provider_source_fxt)[0];
     model_name = "model_a"
 
-    arrange_resources(resource_client, model_name)
+    resource_client = arrange_resources(ff, model_name, is_local)
 
     with pytest.raises(TypeError, match="missing 1 required positional argument: 'name'"):
         resource_client.get_model(local=is_local)
@@ -60,6 +60,9 @@ def before_and_after_each(setup_teardown):
     yield
     setup_teardown()
 
-def arrange_resources(resource_client, model_name):
-    resource_client.register_model(model_name)
+def arrange_resources(ff, model_name, is_local):
+    ff.register_model(model_name)
+    resource_client = ff.ResourceClient(local=is_local)
     resource_client.apply()
+
+    return resource_client

--- a/client/tests/test_serving_model.py
+++ b/client/tests/test_serving_model.py
@@ -8,18 +8,18 @@ dir_path = os.path.dirname(real_path)
 
 # TRAINING SET TESTS
 @pytest.mark.parametrize(
-    "client_provider_source_fxt,serving_client_fxt,is_local",
+    "ff_provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_client_provider_source', 'serving_client', True),
+        ('local_registrar_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_registering_model_while_serving_training_set(client_provider_source_fxt,serving_client_fxt, is_local, request):
-    resource_client, provider, source = request.getfixturevalue(client_provider_source_fxt)(is_local);
+def test_registering_model_while_serving_training_set(ff_provider_source_fxt,serving_client_fxt, is_local, request):
+    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    arrange_resources(resource_client, provider, source, is_local)
+    resource_client = arrange_resources(ff, provider, source, is_local)
 
     model_name = 'fraud_model_a'
 
@@ -31,18 +31,18 @@ def test_registering_model_while_serving_training_set(client_provider_source_fxt
 
 
 @pytest.mark.parametrize(
-    "client_provider_source_fxt,serving_client_fxt,is_local",
+    "ff_provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_client_provider_source', 'serving_client', True),
+        ('local_registrar_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_registering_two_models_while_serving_training_set(client_provider_source_fxt,serving_client_fxt, is_local, request):
-    resource_client, provider, source = request.getfixturevalue(client_provider_source_fxt)(is_local);
+def test_registering_two_models_while_serving_training_set(ff_provider_source_fxt,serving_client_fxt, is_local, request):
+    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    arrange_resources(resource_client, provider, source, is_local)
+    resource_client = arrange_resources(ff, provider, source, is_local)
 
     model_name_a = 'fraud_model_a';
     model_name_b = 'fraud_model_b';
@@ -56,18 +56,18 @@ def test_registering_two_models_while_serving_training_set(client_provider_sourc
 
 
 @pytest.mark.parametrize(
-    "client_provider_source_fxt,serving_client_fxt,is_local",
+    "ff_provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_client_provider_source', 'serving_client', True),
+        ('local_registrar_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_registering_same_model_twice_while_serving_training_set(client_provider_source_fxt,serving_client_fxt, is_local, request):
-    resource_client, provider, source = request.getfixturevalue(client_provider_source_fxt)(is_local);
+def test_registering_same_model_twice_while_serving_training_set(ff_provider_source_fxt,serving_client_fxt, is_local, request):
+    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    arrange_resources(resource_client, provider, source, is_local)
+    resource_client = arrange_resources(ff, provider, source, is_local)
 
     model_name = 'fraud_model';
 
@@ -81,18 +81,18 @@ def test_registering_same_model_twice_while_serving_training_set(client_provider
 
 # FEATURE TESTS
 @pytest.mark.parametrize(
-    "client_provider_source_fxt,serving_client_fxt,is_local",
+    "ff_provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_client_provider_source', 'serving_client', True),
+        ('local_registrar_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_registering_model_while_serving_features(client_provider_source_fxt,serving_client_fxt, is_local, request):
-    resource_client, provider, source = request.getfixturevalue(client_provider_source_fxt)(is_local);
+def test_registering_model_while_serving_features(ff_provider_source_fxt,serving_client_fxt, is_local, request):
+    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    arrange_resources(resource_client, provider, source, is_local)
+    resource_client = arrange_resources(ff, provider, source, is_local)
 
     model_name = 'fraud_model_a';
 
@@ -104,18 +104,18 @@ def test_registering_model_while_serving_features(client_provider_source_fxt,ser
 
 
 @pytest.mark.parametrize(
-    "client_provider_source_fxt,serving_client_fxt,is_local",
+    "ff_provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_client_provider_source', 'serving_client', True),
+        ('local_registrar_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_registering_two_models_while_serving_features(client_provider_source_fxt,serving_client_fxt, is_local, request):
-    resource_client, provider, source = request.getfixturevalue(client_provider_source_fxt)(is_local);
+def test_registering_two_models_while_serving_features(ff_provider_source_fxt,serving_client_fxt, is_local, request):
+    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    arrange_resources(resource_client, provider, source, is_local)
+    resource_client = arrange_resources(ff, provider, source, is_local)
 
     model_name_a = 'fraud_model_a';
     model_name_b = 'fraud_model_b';
@@ -129,18 +129,18 @@ def test_registering_two_models_while_serving_features(client_provider_source_fx
 
 
 @pytest.mark.parametrize(
-    "client_provider_source_fxt,serving_client_fxt,is_local",
+    "ff_provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_client_provider_source', 'serving_client', True),
+        ('local_registrar_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_registering_same_model_twice_while_serving_features(client_provider_source_fxt,serving_client_fxt, is_local, request):
-    resource_client, provider, source = request.getfixturevalue(client_provider_source_fxt)(is_local);
+def test_registering_same_model_twice_while_serving_features(ff_provider_source_fxt,serving_client_fxt, is_local, request):
+    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    arrange_resources(resource_client, provider, source, is_local)
+    resource_client = arrange_resources(ff, provider, source, is_local)
 
     model_name = 'fraud_model';
 
@@ -153,18 +153,18 @@ def test_registering_same_model_twice_while_serving_features(client_provider_sou
 
 
 @pytest.mark.parametrize(
-    "client_provider_source_fxt,serving_client_fxt,is_local",
+    "ff_provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_client_provider_source', 'serving_client', True),
+        ('local_registrar_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_no_models_registered_while_serving_training_set(client_provider_source_fxt,serving_client_fxt, is_local, request):
-    resource_client, provider, source = request.getfixturevalue(client_provider_source_fxt)(is_local);
+def test_no_models_registered_while_serving_training_set(ff_provider_source_fxt,serving_client_fxt, is_local, request):
+    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    arrange_resources(resource_client, provider, source, is_local)
+    resource_client = arrange_resources(ff, provider, source, is_local)
 
     serving_client.features([("avg_transactions", "quickstart")], {"user": "C1410926"})
     serving_client.features([("avg_transactions", "quickstart")], {"user": "C1410926"})
@@ -181,7 +181,7 @@ def before_and_after_each(setup_teardown):
     setup_teardown()
 
 
-def arrange_resources(resource_client, provider, source, is_local):
+def arrange_resources(ff, provider, source, is_local):
     if is_local:
         @provider.df_transformation(variant="quickstart", inputs=[("transactions", "quickstart")])
         def average_user_transaction(transactions):
@@ -191,7 +191,7 @@ def arrange_resources(resource_client, provider, source, is_local):
         def average_user_transaction():
             return "SELECT CustomerID as user_id, avg(TransactionAmount) as avg_transaction_amt from {{transactions.kaggle}} GROUP BY user_id"
 
-    user = resource_client.register_entity("user")
+    user = ff.register_entity("user")
     entity_column = "CustomerID" if is_local else "user_id"
 
     average_user_transaction.register_resources(
@@ -211,9 +211,13 @@ def arrange_resources(resource_client, provider, source, is_local):
         ],
     )
 
-    resource_client.register_training_set(
+    ff.register_training_set(
         "fraud_training", "quickstart",
         label=("fraudulent", "quickstart"),
         features=[("avg_transactions", "quickstart")],
     )
+
+    resource_client = ff.ResourceClient(local=is_local)
     resource_client.apply()
+
+    return resource_client

--- a/client/tests/test_serving_model.py
+++ b/client/tests/test_serving_model.py
@@ -11,8 +11,8 @@ dir_path = os.path.dirname(real_path)
 @pytest.mark.parametrize(
     "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_provider_source', 'serving_client', True),
-        ('hosted_sql_provider_and_source','serving_client', False),
+        pytest.param('local_provider_source', 'serving_client', True, marks=pytest.mark.local),
+        pytest.param('hosted_sql_provider_and_source','serving_client', False, marks=pytest.mark.hosted),
     ]
 )
 def test_registering_model_while_serving_training_set(provider_source_fxt,serving_client_fxt, is_local, request):
@@ -34,8 +34,8 @@ def test_registering_model_while_serving_training_set(provider_source_fxt,servin
 @pytest.mark.parametrize(
     "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_provider_source', 'serving_client', True),
-        ('hosted_sql_provider_and_source','serving_client', False),
+        pytest.param('local_provider_source', 'serving_client', True, marks=pytest.mark.local),
+        pytest.param('hosted_sql_provider_and_source','serving_client', False, marks=pytest.mark.hosted),
     ]
 )
 def test_registering_two_models_while_serving_training_set(provider_source_fxt,serving_client_fxt, is_local, request):
@@ -59,8 +59,8 @@ def test_registering_two_models_while_serving_training_set(provider_source_fxt,s
 @pytest.mark.parametrize(
     "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_provider_source', 'serving_client', True),
-        ('hosted_sql_provider_and_source','serving_client', False),
+        pytest.param('local_provider_source', 'serving_client', True, marks=pytest.mark.local),
+        pytest.param('hosted_sql_provider_and_source','serving_client', False, marks=pytest.mark.hosted),
     ]
 )
 def test_registering_same_model_twice_while_serving_training_set(provider_source_fxt,serving_client_fxt, is_local, request):
@@ -84,8 +84,8 @@ def test_registering_same_model_twice_while_serving_training_set(provider_source
 @pytest.mark.parametrize(
     "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_provider_source', 'serving_client', True),
-        ('hosted_sql_provider_and_source','serving_client', False),
+        pytest.param('local_provider_source', 'serving_client', True, marks=pytest.mark.local),
+        pytest.param('hosted_sql_provider_and_source','serving_client', False, marks=pytest.mark.hosted),
     ]
 )
 def test_registering_model_while_serving_features(provider_source_fxt,serving_client_fxt, is_local, request):
@@ -107,8 +107,8 @@ def test_registering_model_while_serving_features(provider_source_fxt,serving_cl
 @pytest.mark.parametrize(
     "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_provider_source', 'serving_client', True),
-        ('hosted_sql_provider_and_source','serving_client', False),
+        pytest.param('local_provider_source', 'serving_client', True, marks=pytest.mark.local),
+        pytest.param('hosted_sql_provider_and_source','serving_client', False, marks=pytest.mark.hosted),
     ]
 )
 def test_registering_two_models_while_serving_features(provider_source_fxt,serving_client_fxt, is_local, request):
@@ -132,8 +132,8 @@ def test_registering_two_models_while_serving_features(provider_source_fxt,servi
 @pytest.mark.parametrize(
     "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_provider_source', 'serving_client', True),
-        ('hosted_sql_provider_and_source','serving_client', False),
+        pytest.param('local_provider_source', 'serving_client', True, marks=pytest.mark.local),
+        pytest.param('hosted_sql_provider_and_source','serving_client', False, marks=pytest.mark.hosted),
     ]
 )
 def test_registering_same_model_twice_while_serving_features(provider_source_fxt,serving_client_fxt, is_local, request):
@@ -156,8 +156,8 @@ def test_registering_same_model_twice_while_serving_features(provider_source_fxt
 @pytest.mark.parametrize(
     "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_provider_source', 'serving_client', True),
-        ('hosted_sql_provider_and_source','serving_client', False),
+        pytest.param('local_provider_source', 'serving_client', True, marks=pytest.mark.local),
+        pytest.param('hosted_sql_provider_and_source','serving_client', False, marks=pytest.mark.hosted),
     ]
 )
 def test_no_models_registered_while_serving_training_set(provider_source_fxt,serving_client_fxt, is_local, request):

--- a/client/tests/test_serving_model.py
+++ b/client/tests/test_serving_model.py
@@ -1,3 +1,4 @@
+import featureform as ff
 from featureform.resources import Model
 import os
 import pytest
@@ -8,18 +9,18 @@ dir_path = os.path.dirname(real_path)
 
 # TRAINING SET TESTS
 @pytest.mark.parametrize(
-    "ff_provider_source_fxt,serving_client_fxt,is_local",
+    "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_registrar_provider_source', 'serving_client', True),
+        ('local_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_registering_model_while_serving_training_set(ff_provider_source_fxt,serving_client_fxt, is_local, request):
-    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
+def test_registering_model_while_serving_training_set(provider_source_fxt,serving_client_fxt, is_local, request):
+    provider, source = request.getfixturevalue(provider_source_fxt)();
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    resource_client = arrange_resources(ff, provider, source, is_local)
+    resource_client = arrange_resources(provider, source, is_local)
 
     model_name = 'fraud_model_a'
 
@@ -31,18 +32,18 @@ def test_registering_model_while_serving_training_set(ff_provider_source_fxt,ser
 
 
 @pytest.mark.parametrize(
-    "ff_provider_source_fxt,serving_client_fxt,is_local",
+    "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_registrar_provider_source', 'serving_client', True),
+        ('local_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_registering_two_models_while_serving_training_set(ff_provider_source_fxt,serving_client_fxt, is_local, request):
-    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
+def test_registering_two_models_while_serving_training_set(provider_source_fxt,serving_client_fxt, is_local, request):
+    provider, source = request.getfixturevalue(provider_source_fxt)();
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    resource_client = arrange_resources(ff, provider, source, is_local)
+    resource_client = arrange_resources(provider, source, is_local)
 
     model_name_a = 'fraud_model_a';
     model_name_b = 'fraud_model_b';
@@ -56,18 +57,18 @@ def test_registering_two_models_while_serving_training_set(ff_provider_source_fx
 
 
 @pytest.mark.parametrize(
-    "ff_provider_source_fxt,serving_client_fxt,is_local",
+    "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_registrar_provider_source', 'serving_client', True),
+        ('local_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_registering_same_model_twice_while_serving_training_set(ff_provider_source_fxt,serving_client_fxt, is_local, request):
-    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
+def test_registering_same_model_twice_while_serving_training_set(provider_source_fxt,serving_client_fxt, is_local, request):
+    provider, source = request.getfixturevalue(provider_source_fxt)();
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    resource_client = arrange_resources(ff, provider, source, is_local)
+    resource_client = arrange_resources(provider, source, is_local)
 
     model_name = 'fraud_model';
 
@@ -81,18 +82,18 @@ def test_registering_same_model_twice_while_serving_training_set(ff_provider_sou
 
 # FEATURE TESTS
 @pytest.mark.parametrize(
-    "ff_provider_source_fxt,serving_client_fxt,is_local",
+    "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_registrar_provider_source', 'serving_client', True),
+        ('local_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_registering_model_while_serving_features(ff_provider_source_fxt,serving_client_fxt, is_local, request):
-    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
+def test_registering_model_while_serving_features(provider_source_fxt,serving_client_fxt, is_local, request):
+    provider, source = request.getfixturevalue(provider_source_fxt)();
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    resource_client = arrange_resources(ff, provider, source, is_local)
+    resource_client = arrange_resources(provider, source, is_local)
 
     model_name = 'fraud_model_a';
 
@@ -104,18 +105,18 @@ def test_registering_model_while_serving_features(ff_provider_source_fxt,serving
 
 
 @pytest.mark.parametrize(
-    "ff_provider_source_fxt,serving_client_fxt,is_local",
+    "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_registrar_provider_source', 'serving_client', True),
+        ('local_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_registering_two_models_while_serving_features(ff_provider_source_fxt,serving_client_fxt, is_local, request):
-    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
+def test_registering_two_models_while_serving_features(provider_source_fxt,serving_client_fxt, is_local, request):
+    provider, source = request.getfixturevalue(provider_source_fxt)();
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    resource_client = arrange_resources(ff, provider, source, is_local)
+    resource_client = arrange_resources(provider, source, is_local)
 
     model_name_a = 'fraud_model_a';
     model_name_b = 'fraud_model_b';
@@ -129,18 +130,18 @@ def test_registering_two_models_while_serving_features(ff_provider_source_fxt,se
 
 
 @pytest.mark.parametrize(
-    "ff_provider_source_fxt,serving_client_fxt,is_local",
+    "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_registrar_provider_source', 'serving_client', True),
+        ('local_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_registering_same_model_twice_while_serving_features(ff_provider_source_fxt,serving_client_fxt, is_local, request):
-    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
+def test_registering_same_model_twice_while_serving_features(provider_source_fxt,serving_client_fxt, is_local, request):
+    provider, source = request.getfixturevalue(provider_source_fxt)();
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    resource_client = arrange_resources(ff, provider, source, is_local)
+    resource_client = arrange_resources(provider, source, is_local)
 
     model_name = 'fraud_model';
 
@@ -153,18 +154,18 @@ def test_registering_same_model_twice_while_serving_features(ff_provider_source_
 
 
 @pytest.mark.parametrize(
-    "ff_provider_source_fxt,serving_client_fxt,is_local",
+    "provider_source_fxt,serving_client_fxt,is_local",
     [
-        ('local_registrar_provider_source', 'serving_client', True),
+        ('local_provider_source', 'serving_client', True),
         ('hosted_sql_provider_and_source','serving_client', False),
     ]
 )
-def test_no_models_registered_while_serving_training_set(ff_provider_source_fxt,serving_client_fxt, is_local, request):
-    ff, provider, source = request.getfixturevalue(ff_provider_source_fxt);
+def test_no_models_registered_while_serving_training_set(provider_source_fxt,serving_client_fxt, is_local, request):
+    provider, source = request.getfixturevalue(provider_source_fxt)();
     serving_client = request.getfixturevalue(serving_client_fxt)(is_local);
 
     # Arranges the resources context following the Quickstart pattern
-    resource_client = arrange_resources(ff, provider, source, is_local)
+    resource_client = arrange_resources(provider, source, is_local)
 
     serving_client.features([("avg_transactions", "quickstart")], {"user": "C1410926"})
     serving_client.features([("avg_transactions", "quickstart")], {"user": "C1410926"})
@@ -181,7 +182,7 @@ def before_and_after_each(setup_teardown):
     setup_teardown()
 
 
-def arrange_resources(ff, provider, source, is_local):
+def arrange_resources(provider, source, is_local):
     if is_local:
         @provider.df_transformation(variant="quickstart", inputs=[("transactions", "quickstart")])
         def average_user_transaction(transactions):


### PR DESCRIPTION
# Description

I'd originally thought that the `apply` method for a resource client should call the `state` method on its own registrar; however, after discussing the implications for the current client API, it was clear this change, and the changes it would necessarily require, don't make sense at this time. This PR restores the original call to `apply` and refactors the tests to work with it. 

## Type of change

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
