### PR TITLE
Expose Featureform Version Interally

### DIFF
--- a/charts/featureform/charts/coodinator/templates/deployment.yaml
+++ b/charts/featureform/charts/coodinator/templates/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               value: "{{ .Values.global.repo | default .Values.image.repository }}/worker:{{ .Values.global.version | default .Chart.AppVersion }}"
             - name: PANDAS_RUNNER_IMAGE
               value: "{{ .Values.global.repo | default .Values.image.repository }}/k8s_runner:{{ .Values.global.version | default .Chart.AppVersion }}"
+            - name: FEATUREFORM_VERSION
+              value: {{ .Values.global.version | default .Chart.AppVersion }}
 
           ports:
             - name: http

--- a/config/config.go
+++ b/config/config.go
@@ -7,3 +7,7 @@ const PandasBaseImage = "featureformcom/k8s_runner"
 func GetPandasRunnerImage() string {
 	return helpers.GetEnv("PANDAS_RUNNER_IMAGE", PandasBaseImage)
 }
+
+func GetFeatureformVersion() string {
+	return helpers.GetEnv("FEATUREFORM_VERSION", "0.0.0")
+}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/featureform/config"
 	"io"
 	"io/ioutil"
 	"math"
@@ -103,6 +104,10 @@ func generateKubernetesEnvVars(envVars map[string]string) []v1.EnvVar {
 		kubeEnvVars[i] = v1.EnvVar{Name: key, Value: element}
 		i++
 	}
+	kubeEnvVars = append(kubeEnvVars, v1.EnvVar{
+		Name:  "FEATUREFORM_VERSION",
+		Value: config.GetFeatureformVersion(),
+	})
 	return kubeEnvVars
 }
 


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows the current version of Featureform to be view internally using environment variable `FEATUREFORM_VERSION` or config.GetFeatureformVersion()
## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
