### PR TITLE
Tags & Properties: Local Implementation + E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,7 @@ pytest:
 	pytest -m 'local' client/tests/test_serving_model.py
 	pytest -m 'local' client/tests/test_getting_model.py
 	pytest -m 'local' client/tests/test_search.py
+	pytest -m 'local' client/tests/test_tags_and_properties.py
 	-rm -r .featureform
 	-rm -f transactions.csv
 

--- a/client/README.md
+++ b/client/README.md
@@ -22,7 +22,7 @@ See grpc.io for instructions on installing the [protocol buffer compiler](https:
 You may create a Python virtual environment however you prefer, but the directory name `.venv` is ignored by Git for convenience, so you may choose to create your virtual environment in the root of the project.
 
 ```shell
-> python -m venv .venv && . ~/.venv/bin/activate
+> python -m venv .venv && . .venv/bin/activate
 (.venv) >
 ```
 

--- a/client/src/featureform/dashboard_metadata.py
+++ b/client/src/featureform/dashboard_metadata.py
@@ -80,7 +80,9 @@ def feature_variant(variantData):
                 "value": variantRow['source_value'], 
                 "timestamp": variantRow['source_timestamp']},
                 {"Name":variantRow['source_name'],
-                "Variant":variantRow['source_variant']} 
+                "Variant":variantRow['source_variant']},
+                json.loads(variantRow['tags']) if variantRow['tags'] is not None else [],
+                json.loads(variantRow['properties']) if variantRow['properties'] is not None else {}
             ).toDictionary()
 
         allVariantList.append(variantRow['variant'])
@@ -89,7 +91,7 @@ def feature_variant(variantData):
     return variantsDict, allVariantList, variants
 
 def features(featureRow):
-    variantData = feature_variant(sqlObject.query_resource("feature_variant", "name",featureRow['name']))
+    variantData = feature_variant(sqlObject.query_resource_variant("feature_variant", "name", featureRow['name']))
     
     return FeatureResource(
                 featureRow['name'], 
@@ -119,6 +121,8 @@ def training_set_variant(variantData):
                 "Variant":variantRow['label_variant']}, 
                 variantRow['status'], 
                 variant_organiser(feature_variant(getTrainingSetFeatures(feature_list))[2]),
+                json.loads(variantRow['tags']) if variantRow['tags'] is not None else [],
+                json.loads(variantRow['properties']) if variantRow['properties'] is not None else {}
             ).toDictionary()
         allVariantList.append(variantRow['variant'])
         variantDict[variantRow['variant']] = trainingSetVariant
@@ -133,7 +137,7 @@ def getTrainingSetFeatures(feature_list):
     return feature_variant_tuple
 
 def training_sets(rowData):
-    variantData = training_set_variant(sqlObject.query_resource("training_set_variant", "name", rowData['name']))
+    variantData = training_set_variant(sqlObject.query_resource_variant("training_set_variant", "name", rowData['name']))
     return TrainingSetResource( 
                 "TrainingSet", 
                 rowData['default_variant'], 
@@ -185,8 +189,10 @@ def source_variant(variantData):
                 variantRow['status'], 
                 definition, 
                 variant_organiser(label_variant(label_list)[2]), 
-                variant_organiser(feature_variant(feature_list)[2]), 
-                variant_organiser(training_set_variant(training_set_list)[2]) 
+                variant_organiser(feature_variant(feature_list)[2]),
+                variant_organiser(training_set_variant(training_set_list)[2]),
+                json.loads(variantRow['tags']) if variantRow['tags'] is not None else [],
+                json.loads(variantRow['properties']) if variantRow['properties'] is not None else {}
             ).toDictionary()
         allVariantList.append(variantRow['name'])
         variantDict[variantRow['variant']] = sourceVariant
@@ -195,7 +201,7 @@ def source_variant(variantData):
     return variantDict, allVariantList, variants
 
 def sources(rowData):
-    variantData = source_variant(sqlObject.query_resource("source_variant", "name", rowData['name']))
+    variantData = source_variant(sqlObject.query_resource_variant("source_variant", "name", rowData['name']))
     return SourceResource( 
                 "Source", 
                 rowData['default_variant'], 
@@ -226,7 +232,9 @@ def label_variant(variantData):
                 variantRow['status'], 
                 {"Name":variantRow['source_name'],
                 "Variant":variantRow['source_variant']}, 
-                variant_organiser(training_set_variant(sqlObject.get_training_set_variant_from_label(variantRow['name'], variantRow['variant']))[2]) 
+                variant_organiser(training_set_variant(sqlObject.get_training_set_variant_from_label(variantRow['name'], variantRow['variant']))[2]),
+                json.loads(variantRow['tags']) if variantRow['tags'] is not None else [],
+                json.loads(variantRow['properties']) if variantRow['properties'] is not None else {}
             ).toDictionary()
         
         allVariantList.append(variantRow['variant'])
@@ -235,7 +243,7 @@ def label_variant(variantData):
     return variantDict, allVariantList, variants
 
 def labels(rowData):
-    variantData = label_variant(sqlObject.query_resource("label_variant", "name", rowData['name']))
+    variantData = label_variant(sqlObject.query_resource_variant("label_variant", "name", rowData['name']))
     return LabelResource(
                 "Label", 
                 rowData['default_variant'], 
@@ -245,7 +253,7 @@ def labels(rowData):
             ).toDictionary()
 
 def entities(rowData):
-    label_list = sqlObject.query_resource( "label_variant", "entity", rowData['name'])
+    label_list = sqlObject.query_resource_variant( "label_variant", "entity", rowData['name'])
     training_set_list = set()
     for label in label_list:
         for training_set in sqlObject.get_training_set_variant_from_label(label["name"], label["variant"]):
@@ -255,9 +263,11 @@ def entities(rowData):
                 rowData['type'], 
                 rowData['description'], 
                 rowData['status'], 
-                variant_organiser(feature_variant(sqlObject.query_resource( "feature_variant", "entity", rowData['name']))[2]), 
+                variant_organiser(feature_variant(sqlObject.query_resource_variant( "feature_variant", "entity", rowData['name']))[2]),
                 variant_organiser(label_variant(label_list)[2]), 
-                variant_organiser(training_set_variant(training_set_list)[2]) 
+                variant_organiser(training_set_variant(training_set_list)[2]),
+                json.loads(rowData['tags']) if rowData['tags'] is not None else [],
+                json.loads(rowData['properties']) if rowData['properties'] is not None else {}
             ).toDictionary()
 
 def models(rowData):
@@ -266,9 +276,11 @@ def models(rowData):
                 "Model", 
                 rowData['description'], 
                 rowData['status'], 
-                variant_organiser(feature_variant(sqlObject.query_resource( "feature_variant", "name", rowData['name']))[2]), 
-                variant_organiser(label_variant(sqlObject.query_resource( "label_variant", "variant", rowData['name']))[2]), 
-                variant_organiser(training_set_variant(sqlObject.query_resource( "training_set_variant", "name", rowData['name']))[2]) 
+                variant_organiser(feature_variant(sqlObject.query_resource_variant( "feature_variant", "name", rowData['name']))[2]),
+                variant_organiser(label_variant(sqlObject.query_resource_variant( "label_variant", "variant", rowData['name']))[2]),
+                variant_organiser(training_set_variant(sqlObject.query_resource_variant( "training_set_variant", "name", rowData['name']))[2]),
+                json.loads(rowData['tags']) if rowData['tags'] is not None else [],
+                json.loads(rowData['properties']) if rowData['properties'] is not None else {}
             ).toDictionary()
 
 def users(rowData):
@@ -276,23 +288,25 @@ def users(rowData):
                 rowData['name'], 
                 rowData['type'], 
                 rowData['status'],  
-                variant_organiser(feature_variant(sqlObject.query_resource( "feature_variant", "owner", rowData['name']))[2]), 
-                variant_organiser(label_variant(sqlObject.query_resource( "label_variant", "owner", rowData['name']))[2]), 
-                variant_organiser(training_set_variant(sqlObject.query_resource( "training_set_variant", "owner", rowData['name']))[2]), 
-                variant_organiser(source_variant(sqlObject.query_resource( "source_variant", "owner", rowData['name']))[2]), 
+                variant_organiser(feature_variant(sqlObject.query_resource_variant( "feature_variant", "owner", rowData['name']))[2]),
+                variant_organiser(label_variant(sqlObject.query_resource_variant( "label_variant", "owner", rowData['name']))[2]),
+                variant_organiser(training_set_variant(sqlObject.query_resource_variant( "training_set_variant", "owner", rowData['name']))[2]),
+                variant_organiser(source_variant(sqlObject.query_resource_variant( "source_variant", "owner", rowData['name']))[2]),
+                json.loads(rowData['tags']) if rowData['tags'] is not None else [],
+                json.loads(rowData['properties']) if rowData['properties'] is not None else {}
             ).toDictionary()
 
 def providers(rowData):
     try:
-        source_list = sqlObject.query_resource( "source_variant", "provider", rowData['name'])
+        source_list = sqlObject.query_resource_variant( "source_variant", "provider", rowData['name'])
     except ValueError:
         source_list = []
     try:
-        feature_list = sqlObject.query_resource( "feature_variant", "provider", rowData['name'])
+        feature_list = sqlObject.query_resource_variant( "feature_variant", "provider", rowData['name'])
     except ValueError:
         feature_list = []
     try:
-        label_list = sqlObject.query_resource( "label_variant", "provider", rowData['name'])
+        label_list = sqlObject.query_resource_variant( "label_variant", "provider", rowData['name'])
     except ValueError:
         label_list = []
     return ProviderResource(
@@ -305,8 +319,10 @@ def providers(rowData):
                 variant_organiser(source_variant(source_list)[2]), 
                 rowData['status'], 
                 rowData['serialized_config'],
-                variant_organiser(feature_variant(feature_list)[2]), 
-                variant_organiser(label_variant(label_list)[2])
+                variant_organiser(feature_variant(feature_list)[2]),
+                variant_organiser(label_variant(label_list)[2]),
+                json.loads(rowData['tags']) if rowData['tags'] is not None else [],
+                json.loads(rowData['properties']) if rowData['properties'] is not None else {}
             ).toDictionary()
 
 @dashboard_app.route("/data/<type>", methods = ['POST', 'GET'])
@@ -360,7 +376,8 @@ def GetMetadata(type, resource):
             mimetype='application/json'
             )
             return response
-        row = sqlObject.query_resource(type, "name", "".join(resource))[0]
+        should_fetch_tags_and_properties = type in ["entities", "models", "users", "providers"]
+        row = sqlObject.query_resource(type, "name", "".join(resource), should_fetch_tags_and_properties)[0]
 
         if type == "features":
             dataAsList =  features(row)

--- a/client/src/featureform/get_local.py
+++ b/client/src/featureform/get_local.py
@@ -1,18 +1,22 @@
+import json
 from .format import *
 from .sqlite_metadata import *
 from .resources import Model
 
 def get_user_info_local(name):
-    user = get_resource("user", name)
+    user = get_resource("user", name, True)
 
     format_rows("USER NAME: ", user["name"])
     format_rows("TYPE: ", user["type"])
     format_rows("STATUS: ", user["status"])
-    return user
+    tags = json.loads(user["tags"]) if user["tags"] is not None else []
+    properties = json.loads(user["properties"]) if user["properties"] is not None else {}
+    format_tags_and_properties(tags, properties)
+    return {**user, "tags": tags, "properties": properties}
 
 def get_entity_info_local(name):
     db = SQLiteMetadata()
-    entity = get_resource("entity", name)
+    entity = get_resource("entity", name, True)
     
     returned_features_query_list = get_related_resources("feature_variant", "entity", name)
     returned_features_list = format_resource_list(returned_features_query_list)
@@ -36,11 +40,14 @@ def get_entity_info_local(name):
         "status": entity["status"],
         "features": returned_features_list,
         "labels": returned_labels_list,
-        "trainingsets": returned_training_sets_list
+        "trainingsets": returned_training_sets_list,
+        "tags": json.loads(entity["tags"]) if entity["tags"] is not None else [],
+        "properties": json.loads(entity["properties"]) if entity["properties"] is not None else {},
     }
 
     format_rows([("ENTITY NAME: ", returned_entity["name"]),
     ("STATUS: ", returned_entity["status"])])
+    format_tags_and_properties(returned_entity["tags"], returned_entity["properties"])
     format_pg()
     format_rows('NAME', 'VARIANT', 'TYPE')
     for f in returned_entity["features"]:
@@ -63,17 +70,20 @@ def get_resource_info_local(resource_type, name):
     returned_resource_list = {
         "name": resource["name"],
         "default_variant": resource["default_variant"],
-        "variants": [v["variant"] for v in variants_list]
+        "variants": [(v["variant"], v["tags"], v["properties"]) for v in variants_list],
     }
-   
+
     format_rows("NAME: ", returned_resource_list["name"])
     if "status" in resource:
         format_rows("STATUS: ", resource["status"])
     format_pg("VARIANTS:")
-    format_rows(returned_resource_list["default_variant"], 'default')
-    for v in returned_resource_list["variants"]:
-        if v != returned_resource_list["default_variant"]:
-            format_rows(v, '')
+    formatted_variants = [("NAME", "DEFAULT", "TAGS", "PROPERTIES")]
+    for v, t, p in returned_resource_list["variants"]:
+        t = json.loads(t) if t is not None else []
+        p = json.loads(p) if p is not None else {}
+        default = "" if v != returned_resource_list["default_variant"] else "default"
+        formatted_variants.append((v, default, ", ".join(t), ", ".join([f"{k}:{v}" for (k,v) in p.items()])))
+    format_rows(formatted_variants)
     format_pg()
     return returned_resource_list
 
@@ -100,7 +110,10 @@ def get_feature_variant_info_local(name, variant):
             "name": feature["source_name"],
             "variant": feature["source_variant"]
         },
-        "trainingsets": returned_training_sets_list
+        "trainingsets": returned_training_sets_list,
+        "tags": json.loads(feature["tags"]) if feature["tags"] is not None else [],
+        "properties": json.loads(feature["properties"]) if feature["properties"] is not None else {},
+
     }
     format_rows([("NAME: ", returned_feature["name"]), 
     ("VARIANT: ", returned_feature["variant"]), 
@@ -111,6 +124,7 @@ def get_feature_variant_info_local(name, variant):
     ("PROVIDER:", returned_feature["provider"]),
     ("STATUS: ", returned_feature["status"])
     ])
+    format_tags_and_properties(returned_feature["tags"], returned_feature["properties"])
     format_pg("SOURCE: ")
     format_rows([("NAME", "VARIANT"), (returned_feature["source"]["name"], returned_feature["source"]["variant"])])
     format_pg("TRAINING SETS:")
@@ -144,7 +158,9 @@ def get_label_variant_info_local(name, variant):
             "name": label["source_name"],
             "variant": label["source_variant"]
         },
-        "trainingsets": returned_training_sets_list
+        "trainingsets": returned_training_sets_list,
+        "tags": json.loads(label["tags"]) if label["tags"] is not None else [],
+        "properties": json.loads(label["properties"]) if label["properties"] is not None else {},
     }
     format_rows([("NAME: ", returned_label["name"]), 
     ("VARIANT: ", returned_label["variant"]), 
@@ -155,6 +171,7 @@ def get_label_variant_info_local(name, variant):
     ("PROVIDER:", returned_label["provider"]),
     ("STATUS: ", returned_label["status"])
     ])
+    format_tags_and_properties(returned_label["tags"], returned_label["properties"])
     format_pg("SOURCE: ")
     format_rows([("NAME", "VARIANT"), (returned_label["source"]["name"], returned_label["source"]["variant"])])
     format_pg("TRAINING SETS:")
@@ -210,7 +227,9 @@ def get_source_variant_info_local(name, variant):
         "definition": source["definition"],
         "features": returned_features_list,
         "labels": returned_labels_list,
-        "trainingsets": returned_training_sets_list
+        "trainingsets": returned_training_sets_list,
+        "tags": json.loads(source["tags"]) if source["tags"] is not None else [],
+        "properties": json.loads(source["properties"]) if source["properties"] is not None else {},
     }
 
     format_rows([("NAME: ", returned_source["name"]),
@@ -219,6 +238,7 @@ def get_source_variant_info_local(name, variant):
     ("DESCRIPTION:", returned_source["description"]),
     ("PROVIDER:", returned_source["provider"]),
     ("STATUS: ", returned_source["status"])])
+    format_tags_and_properties(returned_source["tags"], returned_source["properties"])
     format_pg("DEFINITION:")
     print(returned_source["definition"])
     print("FEATURES:")
@@ -256,7 +276,9 @@ def get_training_set_variant_info_local(name, variant):
             "name": training_set["label_name"],
             "variant": training_set["label_variant"]
         },
-        "features": returned_features_list
+        "features": returned_features_list,
+        "tags": json.loads(training_set["tags"]) if training_set["tags"] is not None else [],
+        "properties": json.loads(training_set["properties"]) if training_set["properties"] is not None else {},
     }
 
     format_rows([("NAME: ", returned_training_set["name"]),
@@ -264,6 +286,7 @@ def get_training_set_variant_info_local(name, variant):
     ("OWNER:", returned_training_set["owner"]),
     ("DESCRIPTION:", returned_training_set["description"]),
     ("STATUS: ", returned_training_set["status"])])
+    format_tags_and_properties(returned_training_set["tags"], returned_training_set["properties"])
     format_pg("LABEL: ")
     format_rows([("NAME", "VARIANT"), (returned_training_set["label"]["name"], returned_training_set["label"]["variant"])])
     format_pg("FEATURES:")
@@ -275,7 +298,7 @@ def get_training_set_variant_info_local(name, variant):
 
 def get_provider_info_local(name):
     db = SQLiteMetadata()
-    provider = get_resource("provider", name)
+    provider = get_resource("provider", name, True)
 
     try:
         returned_features_query_list = db.get_feature_variants_from_provider(name)
@@ -300,7 +323,9 @@ def get_provider_info_local(name):
         "serializedConfig": provider["serialized_config"],
         "sources": provider["sources"],
         "features": returned_features_list,
-        "labels": returned_labels_list
+        "labels": returned_labels_list,
+        "tags": json.loads(provider["tags"]) if provider["tags"] is not None else [],
+        "properties": json.loads(provider["properties"]) if provider["properties"] is not None else {},
     }
 
     format_rows([("NAME: ", returned_provider["name"]),
@@ -309,6 +334,7 @@ def get_provider_info_local(name):
     ("SOFTWARE: ", returned_provider["software"]),
     ("TEAM: ", returned_provider["team"]),
     ("STATUS: ", returned_provider["status"])])
+    format_tags_and_properties(returned_provider["tags"], returned_provider["properties"])
     format_rows("SOURCE:", returned_provider["sources"])
     format_pg("FEATURES:")
     format_rows("NAME", "VARIANT")
@@ -329,7 +355,7 @@ def get_related_resources(table, column, name):
         res_list = []
     return res_list
 
-def get_resource(resource_type, name):
+def get_resource(resource_type, name, should_fetch_tags_properties=False):
     db = SQLiteMetadata()
     resource_sql_functions = {
         "user": db.get_user,
@@ -341,7 +367,7 @@ def get_resource(resource_type, name):
         "model": db.get_model,
         "provider": db.get_provider
     }
-    res_list = resource_sql_functions[resource_type](name)
+    res_list = resource_sql_functions[resource_type](name, should_fetch_tags_properties)
     return res_list
 
 def get_variant_list(resource_type, name):
@@ -379,4 +405,11 @@ def get_model_info_local(name) -> Model:
     format_rows("MODEL NAME: ", model["name"])
     format_rows("TYPE: ", model["type"])
 
-    return Model(model["name"])
+    return Model(model["name"], tags=[], properties={})
+
+def format_tags_and_properties(tags, properties):
+    if len(tags):
+        format_rows("TAGS:", ", ".join(tags))
+    if len(properties):
+        format_rows("PROPERTIES:", ", ".join([f"{k}:{v}" for (k,v) in properties.items()]))
+

--- a/client/src/featureform/local_dash_test.py
+++ b/client/src/featureform/local_dash_test.py
@@ -5,99 +5,2041 @@ import json
 import shutil
 import stat
 
-features = [{'all-variants': ['quickstart'], 'type': 'Feature', 'default-variant': 'quickstart', 'name': 'avg_transactions', 'variants': {'quickstart': {'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}}}]
-labels = [{'all-variants': ['quickstart'], 'type': 'Label', 'default-variant': 'quickstart', 'name': 'fraudulent', 'variants': {'quickstart': {'description': '', 'entity': 'user', 'data-type': 'bool', 'name': 'fraudulent', 'owner': 'default_user', 'provider': '', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'IsFraud', 'timestamp': ''}, 'source': {'Name': 'transactions', 'Variant': 'quickstart'}, 'trainingSets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}}}]
-sources = [{'all-variants': ['transactions'], 'type': 'Source', 'default-variant': 'quickstart', 'name': 'transactions', 'variants': {'quickstart': {'description': 'A dataset of fraudulent transactions', 'name': 'transactions', 'source-type': 'Source', 'owner': 'default_user', 'provider': 'local-mode', 'variant': 'quickstart', 'status': 'ready', 'labels': {'fraudulent': [{'description': '', 'entity': 'user', 'data-type': 'bool', 'name': 'fraudulent', 'owner': 'default_user', 'provider': '', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'IsFraud', 'timestamp': ''}, 'source': {'Name': 'transactions', 'Variant': 'quickstart'}, 'trainingSets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}]}, 'features': {}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}}}, {'all-variants': ['average_user_transaction'], 'type': 'Source', 'default-variant': 'quickstart', 'name': 'average_user_transaction', 'variants': {'quickstart': {'description': 'the average transaction amount for a user ', 'name': 'average_user_transaction', 'source-type': 'Source', 'owner': 'default_user', 'provider': 'local-mode', 'variant': 'quickstart', 'status': 'ready', 'labels': {}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}}}]
-training_sets = [{'all-variants': ['quickstart'], 'type': 'TrainingSet', 'default-variant': 'quickstart', 'name': 'fraud_training', 'variants': {'quickstart': {'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}}}]
-entities = [{'description': '', 'type': 'Entity', 'name': 'user', 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}, 'labels': {'fraudulent': [{'description': '', 'entity': 'user', 'data-type': 'bool', 'name': 'fraudulent', 'owner': 'default_user', 'provider': '', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'IsFraud', 'timestamp': ''}, 'source': {'Name': 'transactions', 'Variant': 'quickstart'}, 'trainingSets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}]}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}, 'status': 'ready'}]
+features = [
+    {
+        "all-variants": ["quickstart"],
+        "type": "Feature",
+        "default-variant": "quickstart",
+        "name": "avg_transactions",
+        "variants": {
+            "quickstart": {
+                "description": "",
+                "entity": "user",
+                "name": "avg_transactions",
+                "owner": "default_user",
+                "provider": "local-mode",
+                "data-type": "float32",
+                "variant": "quickstart",
+                "status": "ready",
+                "location": {
+                    "entity": "CustomerID",
+                    "value": "TransactionAmount",
+                    "timestamp": "",
+                },
+                "source": {"Name": "average_user_transaction", "Variant": "quickstart"},
+                "tags": [],
+                "properties": {},
+            }
+        },
+    }
+]
+labels = [
+    {
+        "all-variants": ["quickstart"],
+        "type": "Label",
+        "default-variant": "quickstart",
+        "name": "fraudulent",
+        "variants": {
+            "quickstart": {
+                "description": "",
+                "entity": "user",
+                "data-type": "bool",
+                "name": "fraudulent",
+                "owner": "default_user",
+                "provider": "",
+                "variant": "quickstart",
+                "status": "ready",
+                "location": {
+                    "entity": "CustomerID",
+                    "value": "IsFraud",
+                    "timestamp": "",
+                },
+                "source": {"Name": "transactions", "Variant": "quickstart"},
+                "trainingSets": {
+                    "fraud_training": [
+                        {
+                            "description": "",
+                            "name": "fraud_training",
+                            "owner": "default_user",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                            "features": {
+                                "avg_transactions": [
+                                    {
+                                        "description": "",
+                                        "entity": "user",
+                                        "name": "avg_transactions",
+                                        "owner": "default_user",
+                                        "provider": "local-mode",
+                                        "data-type": "float32",
+                                        "variant": "quickstart",
+                                        "status": "ready",
+                                        "location": {
+                                            "entity": "CustomerID",
+                                            "value": "TransactionAmount",
+                                            "timestamp": "",
+                                        },
+                                        "source": {
+                                            "Name": "average_user_transaction",
+                                            "Variant": "quickstart",
+                                        },
+                                        "tags": [],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "tags": [],
+                "properties": {},
+            }
+        },
+    }
+]
+sources = [
+    {
+        "all-variants": ["transactions"],
+        "type": "Source",
+        "default-variant": "quickstart",
+        "name": "transactions",
+        "variants": {
+            "quickstart": {
+                "description": "A dataset of fraudulent transactions",
+                "name": "transactions",
+                "source-type": "Source",
+                "owner": "default_user",
+                "provider": "local-mode",
+                "variant": "quickstart",
+                "status": "ready",
+                "labels": {
+                    "fraudulent": [
+                        {
+                            "description": "",
+                            "entity": "user",
+                            "data-type": "bool",
+                            "name": "fraudulent",
+                            "owner": "default_user",
+                            "provider": "",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "location": {
+                                "entity": "CustomerID",
+                                "value": "IsFraud",
+                                "timestamp": "",
+                            },
+                            "source": {"Name": "transactions", "Variant": "quickstart"},
+                            "trainingSets": {
+                                "fraud_training": [
+                                    {
+                                        "description": "",
+                                        "name": "fraud_training",
+                                        "owner": "default_user",
+                                        "variant": "quickstart",
+                                        "status": "ready",
+                                        "label": {
+                                            "Name": "fraudulent",
+                                            "Variant": "quickstart",
+                                        },
+                                        "features": {
+                                            "avg_transactions": [
+                                                {
+                                                    "description": "",
+                                                    "entity": "user",
+                                                    "name": "avg_transactions",
+                                                    "owner": "default_user",
+                                                    "provider": "local-mode",
+                                                    "data-type": "float32",
+                                                    "variant": "quickstart",
+                                                    "status": "ready",
+                                                    "location": {
+                                                        "entity": "CustomerID",
+                                                        "value": "TransactionAmount",
+                                                        "timestamp": "",
+                                                    },
+                                                    "source": {
+                                                        "Name": "average_user_transaction",
+                                                        "Variant": "quickstart",
+                                                    },
+                                                    "tags": [],
+                                                    "properties": {},
+                                                }
+                                            ]
+                                        },
+                                        "tags": [],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "features": {},
+                "training-sets": {
+                    "fraud_training": [
+                        {
+                            "description": "",
+                            "name": "fraud_training",
+                            "owner": "default_user",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                            "features": {
+                                "avg_transactions": [
+                                    {
+                                        "description": "",
+                                        "entity": "user",
+                                        "name": "avg_transactions",
+                                        "owner": "default_user",
+                                        "provider": "local-mode",
+                                        "data-type": "float32",
+                                        "variant": "quickstart",
+                                        "status": "ready",
+                                        "location": {
+                                            "entity": "CustomerID",
+                                            "value": "TransactionAmount",
+                                            "timestamp": "",
+                                        },
+                                        "source": {
+                                            "Name": "average_user_transaction",
+                                            "Variant": "quickstart",
+                                        },
+                                        "tags": [],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "tags": [],
+                "properties": {},
+            }
+        },
+    },
+    {
+        "all-variants": ["average_user_transaction"],
+        "type": "Source",
+        "default-variant": "quickstart",
+        "name": "average_user_transaction",
+        "variants": {
+            "quickstart": {
+                "description": "the average transaction amount for a user ",
+                "name": "average_user_transaction",
+                "source-type": "Source",
+                "owner": "default_user",
+                "provider": "local-mode",
+                "variant": "quickstart",
+                "status": "ready",
+                "labels": {},
+                "features": {
+                    "avg_transactions": [
+                        {
+                            "description": "",
+                            "entity": "user",
+                            "name": "avg_transactions",
+                            "owner": "default_user",
+                            "provider": "local-mode",
+                            "data-type": "float32",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "location": {
+                                "entity": "CustomerID",
+                                "value": "TransactionAmount",
+                                "timestamp": "",
+                            },
+                            "source": {
+                                "Name": "average_user_transaction",
+                                "Variant": "quickstart",
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "training-sets": {
+                    "fraud_training": [
+                        {
+                            "description": "",
+                            "name": "fraud_training",
+                            "owner": "default_user",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                            "features": {
+                                "avg_transactions": [
+                                    {
+                                        "description": "",
+                                        "entity": "user",
+                                        "name": "avg_transactions",
+                                        "owner": "default_user",
+                                        "provider": "local-mode",
+                                        "data-type": "float32",
+                                        "variant": "quickstart",
+                                        "status": "ready",
+                                        "location": {
+                                            "entity": "CustomerID",
+                                            "value": "TransactionAmount",
+                                            "timestamp": "",
+                                        },
+                                        "source": {
+                                            "Name": "average_user_transaction",
+                                            "Variant": "quickstart",
+                                        },
+                                        "tags": [],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "tags": [],
+                "properties": {},
+            }
+        },
+    },
+]
+training_sets = [
+    {
+        "all-variants": ["quickstart"],
+        "type": "TrainingSet",
+        "default-variant": "quickstart",
+        "name": "fraud_training",
+        "variants": {
+            "quickstart": {
+                "description": "",
+                "name": "fraud_training",
+                "owner": "default_user",
+                "variant": "quickstart",
+                "status": "ready",
+                "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                "features": {
+                    "avg_transactions": [
+                        {
+                            "description": "",
+                            "entity": "user",
+                            "name": "avg_transactions",
+                            "owner": "default_user",
+                            "provider": "local-mode",
+                            "data-type": "float32",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "location": {
+                                "entity": "CustomerID",
+                                "value": "TransactionAmount",
+                                "timestamp": "",
+                            },
+                            "source": {
+                                "Name": "average_user_transaction",
+                                "Variant": "quickstart",
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "tags": [],
+                "properties": {},
+            }
+        },
+    }
+]
+entities = [
+    {
+        "description": "",
+        "type": "Entity",
+        "name": "user",
+        "features": {
+            "avg_transactions": [
+                {
+                    "description": "",
+                    "entity": "user",
+                    "name": "avg_transactions",
+                    "owner": "default_user",
+                    "provider": "local-mode",
+                    "data-type": "float32",
+                    "variant": "quickstart",
+                    "status": "ready",
+                    "location": {
+                        "entity": "CustomerID",
+                        "value": "TransactionAmount",
+                        "timestamp": "",
+                    },
+                    "source": {
+                        "Name": "average_user_transaction",
+                        "Variant": "quickstart",
+                    },
+                    "tags": [],
+                    "properties": {},
+                }
+            ]
+        },
+        "labels": {
+            "fraudulent": [
+                {
+                    "description": "",
+                    "entity": "user",
+                    "data-type": "bool",
+                    "name": "fraudulent",
+                    "owner": "default_user",
+                    "provider": "",
+                    "variant": "quickstart",
+                    "status": "ready",
+                    "location": {
+                        "entity": "CustomerID",
+                        "value": "IsFraud",
+                        "timestamp": "",
+                    },
+                    "source": {"Name": "transactions", "Variant": "quickstart"},
+                    "trainingSets": {
+                        "fraud_training": [
+                            {
+                                "description": "",
+                                "name": "fraud_training",
+                                "owner": "default_user",
+                                "variant": "quickstart",
+                                "status": "ready",
+                                "label": {
+                                    "Name": "fraudulent",
+                                    "Variant": "quickstart",
+                                },
+                                "features": {
+                                    "avg_transactions": [
+                                        {
+                                            "description": "",
+                                            "entity": "user",
+                                            "name": "avg_transactions",
+                                            "owner": "default_user",
+                                            "provider": "local-mode",
+                                            "data-type": "float32",
+                                            "variant": "quickstart",
+                                            "status": "ready",
+                                            "location": {
+                                                "entity": "CustomerID",
+                                                "value": "TransactionAmount",
+                                                "timestamp": "",
+                                            },
+                                            "source": {
+                                                "Name": "average_user_transaction",
+                                                "Variant": "quickstart",
+                                            },
+                                            "tags": [],
+                                            "properties": {},
+                                        }
+                                    ]
+                                },
+                                "tags": [],
+                                "properties": {},
+                            }
+                        ]
+                    },
+                    "tags": [],
+                    "properties": {},
+                }
+            ]
+        },
+        "training-sets": {
+            "fraud_training": [
+                {
+                    "description": "",
+                    "name": "fraud_training",
+                    "owner": "default_user",
+                    "variant": "quickstart",
+                    "status": "ready",
+                    "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                    "features": {
+                        "avg_transactions": [
+                            {
+                                "description": "",
+                                "entity": "user",
+                                "name": "avg_transactions",
+                                "owner": "default_user",
+                                "provider": "local-mode",
+                                "data-type": "float32",
+                                "variant": "quickstart",
+                                "status": "ready",
+                                "location": {
+                                    "entity": "CustomerID",
+                                    "value": "TransactionAmount",
+                                    "timestamp": "",
+                                },
+                                "source": {
+                                    "Name": "average_user_transaction",
+                                    "Variant": "quickstart",
+                                },
+                                "tags": [],
+                                "properties": {},
+                            }
+                        ]
+                    },
+                    "tags": [],
+                    "properties": {},
+                }
+            ]
+        },
+        "status": "ready",
+        "tags": [],
+        "properties": {},
+    }
+]
 models = []
-users = [{'name': 'default_user', 'type': 'User', 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}, 'labels': {'fraudulent': [{'description': '', 'entity': 'user', 'data-type': 'bool', 'name': 'fraudulent', 'owner': 'default_user', 'provider': '', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'IsFraud', 'timestamp': ''}, 'source': {'Name': 'transactions', 'Variant': 'quickstart'}, 'trainingSets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}]}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}, 'sources': {'transactions': [{'description': 'A dataset of fraudulent transactions', 'name': 'transactions', 'source-type': 'Source', 'owner': 'default_user', 'provider': 'local-mode', 'variant': 'quickstart', 'status': 'ready', 'labels': {'fraudulent': [{'description': '', 'entity': 'user', 'data-type': 'bool', 'name': 'fraudulent', 'owner': 'default_user', 'provider': '', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'IsFraud', 'timestamp': ''}, 'source': {'Name': 'transactions', 'Variant': 'quickstart'}, 'trainingSets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}]}, 'features': {}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}], 'average_user_transaction': [{'description': 'the average transaction amount for a user ', 'name': 'average_user_transaction', 'source-type': 'Source', 'owner': 'default_user', 'provider': 'local-mode', 'variant': 'quickstart', 'status': 'ready', 'labels': {}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}]}, 'status': 'ready'}]
-providers = [{"name": "local-mode", "type": "Provider", "description": "This is local mode", "provider-type": "LOCAL_ONLINE", "software": "localmode", "team": "team", "sources": {"transactions": [{"description": "A dataset of fraudulent transactions", "name": "transactions", "source-type": "Source", "owner": "default_user", "provider": "local-mode", "variant": "quickstart", "status": "ready", "labels": {"fraudulent": [{"description": "", "entity": "user", "data-type": "bool", "name": "fraudulent", "owner": "default_user", "provider": "", "variant": "quickstart", "status": "ready", "location": {"entity": "CustomerID", "value": "IsFraud", "timestamp": ""}, "source": {"Name": "transactions", "Variant": "quickstart"}, "trainingSets": {"fraud_training": [{"description": "", "name": "fraud_training", "owner": "default_user", "variant": "quickstart", "status": "ready", "label": {"Name": "fraudulent", "Variant": "quickstart"}, "features": {"avg_transactions": [{"description": "", "entity": "user", "name": "avg_transactions", "owner": "default_user", "provider": "local-mode", "data-type": "float32", "variant": "quickstart", "status": "ready", "location": {"entity": "CustomerID", "value": "TransactionAmount", "timestamp": ""}, "source": {"Name": "average_user_transaction", "Variant": "quickstart"}}]}}]}}]}, "features": {}, "training-sets": {"fraud_training": [{"description": "", "name": "fraud_training", "owner": "default_user", "variant": "quickstart", "status": "ready", "label": {"Name": "fraudulent", "Variant": "quickstart"}, "features": {"avg_transactions": [{"description": "", "entity": "user", "name": "avg_transactions", "owner": "default_user", "provider": "local-mode", "data-type": "float32", "variant": "quickstart", "status": "ready", "location": {"entity": "CustomerID", "value": "TransactionAmount", "timestamp": ""}, "source": {"Name": "average_user_transaction", "Variant": "quickstart"}}]}}]}}], "average_user_transaction": [{"description": "the average transaction amount for a user ", "name": "average_user_transaction", "source-type": "Source", "owner": "default_user", "provider": "local-mode", "variant": "quickstart", "status": "ready", "labels": {}, "features": {"avg_transactions": [{"description": "", "entity": "user", "name": "avg_transactions", "owner": "default_user", "provider": "local-mode", "data-type": "float32", "variant": "quickstart", "status": "ready", "location": {"entity": "CustomerID", "value": "TransactionAmount", "timestamp": ""}, "source": {"Name": "average_user_transaction", "Variant": "quickstart"}}]}, "training-sets": {"fraud_training": [{"description": "", "name": "fraud_training", "owner": "default_user", "variant": "quickstart", "status": "ready", "label": {"Name": "fraudulent", "Variant": "quickstart"}, "features": {"avg_transactions": [{"description": "", "entity": "user", "name": "avg_transactions", "owner": "default_user", "provider": "local-mode", "data-type": "float32", "variant": "quickstart", "status": "ready", "location": {"entity": "CustomerID", "value": "TransactionAmount", "timestamp": ""}, "source": {"Name": "average_user_transaction", "Variant": "quickstart"}}]}}]}}]}, "features": {"avg_transactions": [{"description": "", "entity": "user", "name": "avg_transactions", "owner": "default_user", "provider": "local-mode", "data-type": "float32", "variant": "quickstart", "status": "ready", "location": {"entity": "CustomerID", "value": "TransactionAmount", "timestamp": ""}, "source": {"Name": "average_user_transaction", "Variant": "quickstart"}}]}, "labels": {}, "status": "status", "serializedConfig": "{}"}]
+users = [
+    {
+        "name": "default_user",
+        "type": "User",
+        "features": {
+            "avg_transactions": [
+                {
+                    "description": "",
+                    "entity": "user",
+                    "name": "avg_transactions",
+                    "owner": "default_user",
+                    "provider": "local-mode",
+                    "data-type": "float32",
+                    "variant": "quickstart",
+                    "status": "ready",
+                    "location": {
+                        "entity": "CustomerID",
+                        "value": "TransactionAmount",
+                        "timestamp": "",
+                    },
+                    "source": {
+                        "Name": "average_user_transaction",
+                        "Variant": "quickstart",
+                    },
+                    "tags": [],
+                    "properties": {},
+                }
+            ]
+        },
+        "labels": {
+            "fraudulent": [
+                {
+                    "description": "",
+                    "entity": "user",
+                    "data-type": "bool",
+                    "name": "fraudulent",
+                    "owner": "default_user",
+                    "provider": "",
+                    "variant": "quickstart",
+                    "status": "ready",
+                    "location": {
+                        "entity": "CustomerID",
+                        "value": "IsFraud",
+                        "timestamp": "",
+                    },
+                    "source": {"Name": "transactions", "Variant": "quickstart"},
+                    "trainingSets": {
+                        "fraud_training": [
+                            {
+                                "description": "",
+                                "name": "fraud_training",
+                                "owner": "default_user",
+                                "variant": "quickstart",
+                                "status": "ready",
+                                "label": {
+                                    "Name": "fraudulent",
+                                    "Variant": "quickstart",
+                                },
+                                "features": {
+                                    "avg_transactions": [
+                                        {
+                                            "description": "",
+                                            "entity": "user",
+                                            "name": "avg_transactions",
+                                            "owner": "default_user",
+                                            "provider": "local-mode",
+                                            "data-type": "float32",
+                                            "variant": "quickstart",
+                                            "status": "ready",
+                                            "location": {
+                                                "entity": "CustomerID",
+                                                "value": "TransactionAmount",
+                                                "timestamp": "",
+                                            },
+                                            "source": {
+                                                "Name": "average_user_transaction",
+                                                "Variant": "quickstart",
+                                            },
+                                            "tags": [],
+                                            "properties": {},
+                                        }
+                                    ]
+                                },
+                                "tags": [],
+                                "properties": {},
+                            }
+                        ]
+                    },
+                    "tags": [],
+                    "properties": {},
+                }
+            ]
+        },
+        "training-sets": {
+            "fraud_training": [
+                {
+                    "description": "",
+                    "name": "fraud_training",
+                    "owner": "default_user",
+                    "variant": "quickstart",
+                    "status": "ready",
+                    "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                    "features": {
+                        "avg_transactions": [
+                            {
+                                "description": "",
+                                "entity": "user",
+                                "name": "avg_transactions",
+                                "owner": "default_user",
+                                "provider": "local-mode",
+                                "data-type": "float32",
+                                "variant": "quickstart",
+                                "status": "ready",
+                                "location": {
+                                    "entity": "CustomerID",
+                                    "value": "TransactionAmount",
+                                    "timestamp": "",
+                                },
+                                "source": {
+                                    "Name": "average_user_transaction",
+                                    "Variant": "quickstart",
+                                },
+                                "tags": [],
+                                "properties": {},
+                            }
+                        ]
+                    },
+                    "tags": [],
+                    "properties": {},
+                }
+            ]
+        },
+        "sources": {
+            "transactions": [
+                {
+                    "description": "A dataset of fraudulent transactions",
+                    "name": "transactions",
+                    "source-type": "Source",
+                    "owner": "default_user",
+                    "provider": "local-mode",
+                    "variant": "quickstart",
+                    "status": "ready",
+                    "labels": {
+                        "fraudulent": [
+                            {
+                                "description": "",
+                                "entity": "user",
+                                "data-type": "bool",
+                                "name": "fraudulent",
+                                "owner": "default_user",
+                                "provider": "",
+                                "variant": "quickstart",
+                                "status": "ready",
+                                "location": {
+                                    "entity": "CustomerID",
+                                    "value": "IsFraud",
+                                    "timestamp": "",
+                                },
+                                "source": {
+                                    "Name": "transactions",
+                                    "Variant": "quickstart",
+                                },
+                                "trainingSets": {
+                                    "fraud_training": [
+                                        {
+                                            "description": "",
+                                            "name": "fraud_training",
+                                            "owner": "default_user",
+                                            "variant": "quickstart",
+                                            "status": "ready",
+                                            "label": {
+                                                "Name": "fraudulent",
+                                                "Variant": "quickstart",
+                                            },
+                                            "features": {
+                                                "avg_transactions": [
+                                                    {
+                                                        "description": "",
+                                                        "entity": "user",
+                                                        "name": "avg_transactions",
+                                                        "owner": "default_user",
+                                                        "provider": "local-mode",
+                                                        "data-type": "float32",
+                                                        "variant": "quickstart",
+                                                        "status": "ready",
+                                                        "location": {
+                                                            "entity": "CustomerID",
+                                                            "value": "TransactionAmount",
+                                                            "timestamp": "",
+                                                        },
+                                                        "source": {
+                                                            "Name": "average_user_transaction",
+                                                            "Variant": "quickstart",
+                                                        },
+                                                    }
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    },
+                    "features": {},
+                    "training-sets": {
+                        "fraud_training": [
+                            {
+                                "description": "",
+                                "name": "fraud_training",
+                                "owner": "default_user",
+                                "variant": "quickstart",
+                                "status": "ready",
+                                "label": {
+                                    "Name": "fraudulent",
+                                    "Variant": "quickstart",
+                                },
+                                "features": {
+                                    "avg_transactions": [
+                                        {
+                                            "description": "",
+                                            "entity": "user",
+                                            "name": "avg_transactions",
+                                            "owner": "default_user",
+                                            "provider": "local-mode",
+                                            "data-type": "float32",
+                                            "variant": "quickstart",
+                                            "status": "ready",
+                                            "location": {
+                                                "entity": "CustomerID",
+                                                "value": "TransactionAmount",
+                                                "timestamp": "",
+                                            },
+                                            "source": {
+                                                "Name": "average_user_transaction",
+                                                "Variant": "quickstart",
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    },
+                }
+            ],
+            "average_user_transaction": [
+                {
+                    "description": "the average transaction amount for a user ",
+                    "name": "average_user_transaction",
+                    "source-type": "Source",
+                    "owner": "default_user",
+                    "provider": "local-mode",
+                    "variant": "quickstart",
+                    "status": "ready",
+                    "labels": {},
+                    "features": {
+                        "avg_transactions": [
+                            {
+                                "description": "",
+                                "entity": "user",
+                                "name": "avg_transactions",
+                                "owner": "default_user",
+                                "provider": "local-mode",
+                                "data-type": "float32",
+                                "variant": "quickstart",
+                                "status": "ready",
+                                "location": {
+                                    "entity": "CustomerID",
+                                    "value": "TransactionAmount",
+                                    "timestamp": "",
+                                },
+                                "source": {
+                                    "Name": "average_user_transaction",
+                                    "Variant": "quickstart",
+                                },
+                            }
+                        ]
+                    },
+                    "training-sets": {
+                        "fraud_training": [
+                            {
+                                "description": "",
+                                "name": "fraud_training",
+                                "owner": "default_user",
+                                "variant": "quickstart",
+                                "status": "ready",
+                                "label": {
+                                    "Name": "fraudulent",
+                                    "Variant": "quickstart",
+                                },
+                                "features": {
+                                    "avg_transactions": [
+                                        {
+                                            "description": "",
+                                            "entity": "user",
+                                            "name": "avg_transactions",
+                                            "owner": "default_user",
+                                            "provider": "local-mode",
+                                            "data-type": "float32",
+                                            "variant": "quickstart",
+                                            "status": "ready",
+                                            "location": {
+                                                "entity": "CustomerID",
+                                                "value": "TransactionAmount",
+                                                "timestamp": "",
+                                            },
+                                            "source": {
+                                                "Name": "average_user_transaction",
+                                                "Variant": "quickstart",
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    },
+                }
+            ],
+        },
+        "status": "ready",
+        "tags": [],
+        "properties": {},
+    }
+]
+providers = [
+    {
+        "name": "local-mode",
+        "type": "Provider",
+        "description": "This is local mode",
+        "provider-type": "LOCAL_ONLINE",
+        "software": "localmode",
+        "team": "team",
+        "sources": {
+            "transactions": [
+                {
+                    "description": "A dataset of fraudulent transactions",
+                    "name": "transactions",
+                    "source-type": "Source",
+                    "owner": "default_user",
+                    "provider": "local-mode",
+                    "variant": "quickstart",
+                    "status": "ready",
+                    "labels": {
+                        "fraudulent": [
+                            {
+                                "description": "",
+                                "entity": "user",
+                                "data-type": "bool",
+                                "name": "fraudulent",
+                                "owner": "default_user",
+                                "provider": "",
+                                "variant": "quickstart",
+                                "status": "ready",
+                                "location": {
+                                    "entity": "CustomerID",
+                                    "value": "IsFraud",
+                                    "timestamp": "",
+                                },
+                                "source": {
+                                    "Name": "transactions",
+                                    "Variant": "quickstart",
+                                },
+                                "trainingSets": {
+                                    "fraud_training": [
+                                        {
+                                            "description": "",
+                                            "name": "fraud_training",
+                                            "owner": "default_user",
+                                            "variant": "quickstart",
+                                            "status": "ready",
+                                            "label": {
+                                                "Name": "fraudulent",
+                                                "Variant": "quickstart",
+                                            },
+                                            "features": {
+                                                "avg_transactions": [
+                                                    {
+                                                        "description": "",
+                                                        "entity": "user",
+                                                        "name": "avg_transactions",
+                                                        "owner": "default_user",
+                                                        "provider": "local-mode",
+                                                        "data-type": "float32",
+                                                        "variant": "quickstart",
+                                                        "status": "ready",
+                                                        "location": {
+                                                            "entity": "CustomerID",
+                                                            "value": "TransactionAmount",
+                                                            "timestamp": "",
+                                                        },
+                                                        "source": {
+                                                            "Name": "average_user_transaction",
+                                                            "Variant": "quickstart",
+                                                        },
+                                                        "tags": [],
+                                                        "properties": {},
+                                                    }
+                                                ]
+                                            },
+                                            "tags": [],
+                                            "properties": {},
+                                        }
+                                    ]
+                                },
+                                "tags": [],
+                                "properties": {},
+                            }
+                        ]
+                    },
+                    "features": {},
+                    "training-sets": {
+                        "fraud_training": [
+                            {
+                                "description": "",
+                                "name": "fraud_training",
+                                "owner": "default_user",
+                                "variant": "quickstart",
+                                "status": "ready",
+                                "label": {
+                                    "Name": "fraudulent",
+                                    "Variant": "quickstart",
+                                },
+                                "features": {
+                                    "avg_transactions": [
+                                        {
+                                            "description": "",
+                                            "entity": "user",
+                                            "name": "avg_transactions",
+                                            "owner": "default_user",
+                                            "provider": "local-mode",
+                                            "data-type": "float32",
+                                            "variant": "quickstart",
+                                            "status": "ready",
+                                            "location": {
+                                                "entity": "CustomerID",
+                                                "value": "TransactionAmount",
+                                                "timestamp": "",
+                                            },
+                                            "source": {
+                                                "Name": "average_user_transaction",
+                                                "Variant": "quickstart",
+                                            },
+                                            "tags": [],
+                                            "properties": {},
+                                        }
+                                    ]
+                                },
+                                "tags": [],
+                                "properties": {},
+                            }
+                        ]
+                    },
+                    "tags": [],
+                    "properties": {},
+                }
+            ],
+            "average_user_transaction": [
+                {
+                    "description": "the average transaction amount for a user ",
+                    "name": "average_user_transaction",
+                    "source-type": "Source",
+                    "owner": "default_user",
+                    "provider": "local-mode",
+                    "variant": "quickstart",
+                    "status": "ready",
+                    "labels": {},
+                    "features": {
+                        "avg_transactions": [
+                            {
+                                "description": "",
+                                "entity": "user",
+                                "name": "avg_transactions",
+                                "owner": "default_user",
+                                "provider": "local-mode",
+                                "data-type": "float32",
+                                "variant": "quickstart",
+                                "status": "ready",
+                                "location": {
+                                    "entity": "CustomerID",
+                                    "value": "TransactionAmount",
+                                    "timestamp": "",
+                                },
+                                "source": {
+                                    "Name": "average_user_transaction",
+                                    "Variant": "quickstart",
+                                },
+                                "tags": [],
+                                "properties": {},
+                            }
+                        ]
+                    },
+                    "training-sets": {
+                        "fraud_training": [
+                            {
+                                "description": "",
+                                "name": "fraud_training",
+                                "owner": "default_user",
+                                "variant": "quickstart",
+                                "status": "ready",
+                                "label": {
+                                    "Name": "fraudulent",
+                                    "Variant": "quickstart",
+                                },
+                                "features": {
+                                    "avg_transactions": [
+                                        {
+                                            "description": "",
+                                            "entity": "user",
+                                            "name": "avg_transactions",
+                                            "owner": "default_user",
+                                            "provider": "local-mode",
+                                            "data-type": "float32",
+                                            "variant": "quickstart",
+                                            "status": "ready",
+                                            "location": {
+                                                "entity": "CustomerID",
+                                                "value": "TransactionAmount",
+                                                "timestamp": "",
+                                            },
+                                            "source": {
+                                                "Name": "average_user_transaction",
+                                                "Variant": "quickstart",
+                                            },
+                                            "tags": [],
+                                            "properties": {},
+                                        }
+                                    ]
+                                },
+                                "tags": [],
+                                "properties": {},
+                            }
+                        ]
+                    },
+                    "tags": [],
+                    "properties": {},
+                }
+            ],
+        },
+        "features": {
+            "avg_transactions": [
+                {
+                    "description": "",
+                    "entity": "user",
+                    "name": "avg_transactions",
+                    "owner": "default_user",
+                    "provider": "local-mode",
+                    "data-type": "float32",
+                    "variant": "quickstart",
+                    "status": "ready",
+                    "location": {
+                        "entity": "CustomerID",
+                        "value": "TransactionAmount",
+                        "timestamp": "",
+                    },
+                    "source": {
+                        "Name": "average_user_transaction",
+                        "Variant": "quickstart",
+                    },
+                    "tags": [],
+                    "properties": {},
+                }
+            ]
+        },
+        "labels": {},
+        "status": "status",
+        "serializedConfig": "{}",
+        "tags": ["local-mode"],
+        "properties": {"resource_type": "Provider"},
+    }
+]
 
-default_user = {'name': 'default_user', 'type': 'User', 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}, 'labels': {'fraudulent': [{'description': '', 'entity': 'user', 'data-type': 'bool', 'name': 'fraudulent', 'owner': 'default_user', 'provider': '', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'IsFraud', 'timestamp': ''}, 'source': {'Name': 'transactions', 'Variant': 'quickstart'}, 'trainingSets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}]}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}, 'sources': {'transactions': [{'description': 'A dataset of fraudulent transactions', 'name': 'transactions', 'source-type': 'Source', 'owner': 'default_user', 'provider': 'local-mode', 'variant': 'quickstart', 'status': 'ready', 'labels': {'fraudulent': [{'description': '', 'entity': 'user', 'data-type': 'bool', 'name': 'fraudulent', 'owner': 'default_user', 'provider': '', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'IsFraud', 'timestamp': ''}, 'source': {'Name': 'transactions', 'Variant': 'quickstart'}, 'trainingSets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}]}, 'features': {}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}], 'average_user_transaction': [{'description': 'the average transaction amount for a user ', 'name': 'average_user_transaction', 'source-type': 'Source', 'owner': 'default_user', 'provider': 'local-mode', 'variant': 'quickstart', 'status': 'ready', 'labels': {}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}]}, 'status': 'ready'}
-localmode = {'name': 'local-mode', 'type': 'Provider', 'description': 'This is local mode', 'provider-type': 'LOCAL_ONLINE', 'software': 'localmode', 'team': 'team', 'sources': {'transactions': [{'description': 'A dataset of fraudulent transactions', 'name': 'transactions', 'source-type': 'Source', 'owner': 'default_user', 'provider': 'local-mode', 'variant': 'quickstart', 'status': 'ready', 'labels': {'fraudulent': [{'description': '', 'entity': 'user', 'data-type': 'bool', 'name': 'fraudulent', 'owner': 'default_user', 'provider': '', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'IsFraud', 'timestamp': ''}, 'source': {'Name': 'transactions', 'Variant': 'quickstart'}, 'trainingSets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}]}, 'features': {}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}], 'average_user_transaction': [{'description': 'the average transaction amount for a user ', 'name': 'average_user_transaction', 'source-type': 'Source', 'owner': 'default_user', 'provider': 'local-mode', 'variant': 'quickstart', 'status': 'ready', 'labels': {}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}]}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}, 'labels': {}, 'status': 'status', 'serializedConfig': '{}'}
-average_user_transaction = {'all-variants': ['average_user_transaction'], 'type': 'Source', 'default-variant': 'quickstart', 'name': 'average_user_transaction', 'variants': {'quickstart': {'description': 'the average transaction amount for a user ', 'name': 'average_user_transaction', 'source-type': 'Source', 'owner': 'default_user', 'provider': 'local-mode', 'variant': 'quickstart', 'status': 'ready', 'labels': {}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}}}
-user = {'description': '', 'type': 'Entity', 'name': 'user', 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}, 'labels': {'fraudulent': [{'description': '', 'entity': 'user', 'data-type': 'bool', 'name': 'fraudulent', 'owner': 'default_user', 'provider': '', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'IsFraud', 'timestamp': ''}, 'source': {'Name': 'transactions', 'Variant': 'quickstart'}, 'trainingSets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}]}, 'training-sets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}, 'status': 'ready'}
-fraudulent = {'all-variants': ['quickstart'], 'type': 'Label', 'default-variant': 'quickstart', 'name': 'fraudulent', 'variants': {'quickstart': {'description': '', 'entity': 'user', 'data-type': 'bool', 'name': 'fraudulent', 'owner': 'default_user', 'provider': '', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'IsFraud', 'timestamp': ''}, 'source': {'Name': 'transactions', 'Variant': 'quickstart'}, 'trainingSets': {'fraud_training': [{'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}]}}}}
-fraud_training = {'all-variants': ['quickstart'], 'type': 'TrainingSet', 'default-variant': 'quickstart', 'name': 'fraud_training', 'variants': {'quickstart': {'description': '', 'name': 'fraud_training', 'owner': 'default_user', 'variant': 'quickstart', 'status': 'ready', 'label': {'Name': 'fraudulent', 'Variant': 'quickstart'}, 'features': {'avg_transactions': [{'description': '', 'entity': 'user', 'name': 'avg_transactions', 'owner': 'default_user', 'provider': 'local-mode', 'data-type': 'float32', 'variant': 'quickstart', 'status': 'ready', 'location': {'entity': 'CustomerID', 'value': 'TransactionAmount', 'timestamp': ''}, 'source': {'Name': 'average_user_transaction', 'Variant': 'quickstart'}}]}}}}
+default_user = {
+    "name": "default_user",
+    "type": "User",
+    "features": {
+        "avg_transactions": [
+            {
+                "description": "",
+                "entity": "user",
+                "name": "avg_transactions",
+                "owner": "default_user",
+                "provider": "local-mode",
+                "data-type": "float32",
+                "variant": "quickstart",
+                "status": "ready",
+                "location": {
+                    "entity": "CustomerID",
+                    "value": "TransactionAmount",
+                    "timestamp": "",
+                },
+                "source": {"Name": "average_user_transaction", "Variant": "quickstart"},
+                "tags": [],
+                "properties": {},
+            }
+        ]
+    },
+    "labels": {
+        "fraudulent": [
+            {
+                "description": "",
+                "entity": "user",
+                "data-type": "bool",
+                "name": "fraudulent",
+                "owner": "default_user",
+                "provider": "",
+                "variant": "quickstart",
+                "status": "ready",
+                "location": {
+                    "entity": "CustomerID",
+                    "value": "IsFraud",
+                    "timestamp": "",
+                },
+                "source": {"Name": "transactions", "Variant": "quickstart"},
+                "trainingSets": {
+                    "fraud_training": [
+                        {
+                            "description": "",
+                            "name": "fraud_training",
+                            "owner": "default_user",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                            "features": {
+                                "avg_transactions": [
+                                    {
+                                        "description": "",
+                                        "entity": "user",
+                                        "name": "avg_transactions",
+                                        "owner": "default_user",
+                                        "provider": "local-mode",
+                                        "data-type": "float32",
+                                        "variant": "quickstart",
+                                        "status": "ready",
+                                        "location": {
+                                            "entity": "CustomerID",
+                                            "value": "TransactionAmount",
+                                            "timestamp": "",
+                                        },
+                                        "source": {
+                                            "Name": "average_user_transaction",
+                                            "Variant": "quickstart",
+                                        },
+                                        "tags": [],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "tags": [],
+                "properties": {},
+            }
+        ]
+    },
+    "training-sets": {
+        "fraud_training": [
+            {
+                "description": "",
+                "name": "fraud_training",
+                "owner": "default_user",
+                "variant": "quickstart",
+                "status": "ready",
+                "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                "features": {
+                    "avg_transactions": [
+                        {
+                            "description": "",
+                            "entity": "user",
+                            "name": "avg_transactions",
+                            "owner": "default_user",
+                            "provider": "local-mode",
+                            "data-type": "float32",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "location": {
+                                "entity": "CustomerID",
+                                "value": "TransactionAmount",
+                                "timestamp": "",
+                            },
+                            "source": {
+                                "Name": "average_user_transaction",
+                                "Variant": "quickstart",
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "tags": [],
+                "properties": {},
+            }
+        ]
+    },
+    "sources": {
+        "transactions": [
+            {
+                "description": "A dataset of fraudulent transactions",
+                "name": "transactions",
+                "source-type": "Source",
+                "owner": "default_user",
+                "provider": "local-mode",
+                "variant": "quickstart",
+                "status": "ready",
+                "labels": {
+                    "fraudulent": [
+                        {
+                            "description": "",
+                            "entity": "user",
+                            "data-type": "bool",
+                            "name": "fraudulent",
+                            "owner": "default_user",
+                            "provider": "",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "location": {
+                                "entity": "CustomerID",
+                                "value": "IsFraud",
+                                "timestamp": "",
+                            },
+                            "source": {"Name": "transactions", "Variant": "quickstart"},
+                            "trainingSets": {
+                                "fraud_training": [
+                                    {
+                                        "description": "",
+                                        "name": "fraud_training",
+                                        "owner": "default_user",
+                                        "variant": "quickstart",
+                                        "status": "ready",
+                                        "label": {
+                                            "Name": "fraudulent",
+                                            "Variant": "quickstart",
+                                        },
+                                        "features": {
+                                            "avg_transactions": [
+                                                {
+                                                    "description": "",
+                                                    "entity": "user",
+                                                    "name": "avg_transactions",
+                                                    "owner": "default_user",
+                                                    "provider": "local-mode",
+                                                    "data-type": "float32",
+                                                    "variant": "quickstart",
+                                                    "status": "ready",
+                                                    "location": {
+                                                        "entity": "CustomerID",
+                                                        "value": "TransactionAmount",
+                                                        "timestamp": "",
+                                                    },
+                                                    "source": {
+                                                        "Name": "average_user_transaction",
+                                                        "Variant": "quickstart",
+                                                    },
+                                                    "tags": [],
+                                                    "properties": {},
+                                                }
+                                            ]
+                                        },
+                                        "tags": [],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "features": {},
+                "training-sets": {
+                    "fraud_training": [
+                        {
+                            "description": "",
+                            "name": "fraud_training",
+                            "owner": "default_user",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                            "features": {
+                                "avg_transactions": [
+                                    {
+                                        "description": "",
+                                        "entity": "user",
+                                        "name": "avg_transactions",
+                                        "owner": "default_user",
+                                        "provider": "local-mode",
+                                        "data-type": "float32",
+                                        "variant": "quickstart",
+                                        "status": "ready",
+                                        "location": {
+                                            "entity": "CustomerID",
+                                            "value": "TransactionAmount",
+                                            "timestamp": "",
+                                        },
+                                        "source": {
+                                            "Name": "average_user_transaction",
+                                            "Variant": "quickstart",
+                                        },
+                                        "tags": [],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "tags": [],
+                "properties": {},
+            }
+        ],
+        "average_user_transaction": [
+            {
+                "description": "the average transaction amount for a user ",
+                "name": "average_user_transaction",
+                "source-type": "Source",
+                "owner": "default_user",
+                "provider": "local-mode",
+                "variant": "quickstart",
+                "status": "ready",
+                "labels": {},
+                "features": {
+                    "avg_transactions": [
+                        {
+                            "description": "",
+                            "entity": "user",
+                            "name": "avg_transactions",
+                            "owner": "default_user",
+                            "provider": "local-mode",
+                            "data-type": "float32",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "location": {
+                                "entity": "CustomerID",
+                                "value": "TransactionAmount",
+                                "timestamp": "",
+                            },
+                            "source": {
+                                "Name": "average_user_transaction",
+                                "Variant": "quickstart",
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "training-sets": {
+                    "fraud_training": [
+                        {
+                            "description": "",
+                            "name": "fraud_training",
+                            "owner": "default_user",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                            "features": {
+                                "avg_transactions": [
+                                    {
+                                        "description": "",
+                                        "entity": "user",
+                                        "name": "avg_transactions",
+                                        "owner": "default_user",
+                                        "provider": "local-mode",
+                                        "data-type": "float32",
+                                        "variant": "quickstart",
+                                        "status": "ready",
+                                        "location": {
+                                            "entity": "CustomerID",
+                                            "value": "TransactionAmount",
+                                            "timestamp": "",
+                                        },
+                                        "source": {
+                                            "Name": "average_user_transaction",
+                                            "Variant": "quickstart",
+                                        },
+                                        "tags": [],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "tags": [],
+                "properties": {},
+            }
+        ],
+    },
+    "status": "ready",
+    "tags": [],
+    "properties": {},
+}
+localmode = {
+    "name": "local-mode",
+    "type": "Provider",
+    "description": "This is local mode",
+    "provider-type": "LOCAL_ONLINE",
+    "software": "localmode",
+    "team": "team",
+    "sources": {
+        "transactions": [
+            {
+                "description": "A dataset of fraudulent transactions",
+                "name": "transactions",
+                "source-type": "Source",
+                "owner": "default_user",
+                "provider": "local-mode",
+                "variant": "quickstart",
+                "status": "ready",
+                "labels": {
+                    "fraudulent": [
+                        {
+                            "description": "",
+                            "entity": "user",
+                            "data-type": "bool",
+                            "name": "fraudulent",
+                            "owner": "default_user",
+                            "provider": "",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "location": {
+                                "entity": "CustomerID",
+                                "value": "IsFraud",
+                                "timestamp": "",
+                            },
+                            "source": {"Name": "transactions", "Variant": "quickstart"},
+                            "trainingSets": {
+                                "fraud_training": [
+                                    {
+                                        "description": "",
+                                        "name": "fraud_training",
+                                        "owner": "default_user",
+                                        "variant": "quickstart",
+                                        "status": "ready",
+                                        "label": {
+                                            "Name": "fraudulent",
+                                            "Variant": "quickstart",
+                                        },
+                                        "features": {
+                                            "avg_transactions": [
+                                                {
+                                                    "description": "",
+                                                    "entity": "user",
+                                                    "name": "avg_transactions",
+                                                    "owner": "default_user",
+                                                    "provider": "local-mode",
+                                                    "data-type": "float32",
+                                                    "variant": "quickstart",
+                                                    "status": "ready",
+                                                    "location": {
+                                                        "entity": "CustomerID",
+                                                        "value": "TransactionAmount",
+                                                        "timestamp": "",
+                                                    },
+                                                    "source": {
+                                                        "Name": "average_user_transaction",
+                                                        "Variant": "quickstart",
+                                                    },
+                                                    "tags": [],
+                                                    "properties": {},
+                                                }
+                                            ]
+                                        },
+                                        "tags": [],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "features": {},
+                "training-sets": {
+                    "fraud_training": [
+                        {
+                            "description": "",
+                            "name": "fraud_training",
+                            "owner": "default_user",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                            "features": {
+                                "avg_transactions": [
+                                    {
+                                        "description": "",
+                                        "entity": "user",
+                                        "name": "avg_transactions",
+                                        "owner": "default_user",
+                                        "provider": "local-mode",
+                                        "data-type": "float32",
+                                        "variant": "quickstart",
+                                        "status": "ready",
+                                        "location": {
+                                            "entity": "CustomerID",
+                                            "value": "TransactionAmount",
+                                            "timestamp": "",
+                                        },
+                                        "source": {
+                                            "Name": "average_user_transaction",
+                                            "Variant": "quickstart",
+                                        },
+                                        "tags": [],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "tags": [],
+                "properties": {},
+            }
+        ],
+        "average_user_transaction": [
+            {
+                "description": "the average transaction amount for a user ",
+                "name": "average_user_transaction",
+                "source-type": "Source",
+                "owner": "default_user",
+                "provider": "local-mode",
+                "variant": "quickstart",
+                "status": "ready",
+                "labels": {},
+                "features": {
+                    "avg_transactions": [
+                        {
+                            "description": "",
+                            "entity": "user",
+                            "name": "avg_transactions",
+                            "owner": "default_user",
+                            "provider": "local-mode",
+                            "data-type": "float32",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "location": {
+                                "entity": "CustomerID",
+                                "value": "TransactionAmount",
+                                "timestamp": "",
+                            },
+                            "source": {
+                                "Name": "average_user_transaction",
+                                "Variant": "quickstart",
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "training-sets": {
+                    "fraud_training": [
+                        {
+                            "description": "",
+                            "name": "fraud_training",
+                            "owner": "default_user",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                            "features": {
+                                "avg_transactions": [
+                                    {
+                                        "description": "",
+                                        "entity": "user",
+                                        "name": "avg_transactions",
+                                        "owner": "default_user",
+                                        "provider": "local-mode",
+                                        "data-type": "float32",
+                                        "variant": "quickstart",
+                                        "status": "ready",
+                                        "location": {
+                                            "entity": "CustomerID",
+                                            "value": "TransactionAmount",
+                                            "timestamp": "",
+                                        },
+                                        "source": {
+                                            "Name": "average_user_transaction",
+                                            "Variant": "quickstart",
+                                        },
+                                        "tags": [],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "tags": [],
+                "properties": {},
+            }
+        ],
+    },
+    "features": {
+        "avg_transactions": [
+            {
+                "description": "",
+                "entity": "user",
+                "name": "avg_transactions",
+                "owner": "default_user",
+                "provider": "local-mode",
+                "data-type": "float32",
+                "variant": "quickstart",
+                "status": "ready",
+                "location": {
+                    "entity": "CustomerID",
+                    "value": "TransactionAmount",
+                    "timestamp": "",
+                },
+                "source": {"Name": "average_user_transaction", "Variant": "quickstart"},
+                "tags": [],
+                "properties": {},
+            }
+        ]
+    },
+    "labels": {},
+    "status": "status",
+    "serializedConfig": "{}",
+    "tags": ["local-mode"],
+    "properties": {"resource_type": "Provider"},
+}
+average_user_transaction = {
+    "all-variants": ["average_user_transaction"],
+    "type": "Source",
+    "default-variant": "quickstart",
+    "name": "average_user_transaction",
+    "variants": {
+        "quickstart": {
+            "description": "the average transaction amount for a user ",
+            "name": "average_user_transaction",
+            "source-type": "Source",
+            "owner": "default_user",
+            "provider": "local-mode",
+            "variant": "quickstart",
+            "status": "ready",
+            "labels": {},
+            "features": {
+                "avg_transactions": [
+                    {
+                        "description": "",
+                        "entity": "user",
+                        "name": "avg_transactions",
+                        "owner": "default_user",
+                        "provider": "local-mode",
+                        "data-type": "float32",
+                        "variant": "quickstart",
+                        "status": "ready",
+                        "location": {
+                            "entity": "CustomerID",
+                            "value": "TransactionAmount",
+                            "timestamp": "",
+                        },
+                        "source": {
+                            "Name": "average_user_transaction",
+                            "Variant": "quickstart",
+                        },
+                        "tags": [],
+                        "properties": {},
+                    }
+                ]
+            },
+            "training-sets": {
+                "fraud_training": [
+                    {
+                        "description": "",
+                        "name": "fraud_training",
+                        "owner": "default_user",
+                        "variant": "quickstart",
+                        "status": "ready",
+                        "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                        "features": {
+                            "avg_transactions": [
+                                {
+                                    "description": "",
+                                    "entity": "user",
+                                    "name": "avg_transactions",
+                                    "owner": "default_user",
+                                    "provider": "local-mode",
+                                    "data-type": "float32",
+                                    "variant": "quickstart",
+                                    "status": "ready",
+                                    "location": {
+                                        "entity": "CustomerID",
+                                        "value": "TransactionAmount",
+                                        "timestamp": "",
+                                    },
+                                    "source": {
+                                        "Name": "average_user_transaction",
+                                        "Variant": "quickstart",
+                                    },
+                                    "tags": [],
+                                    "properties": {},
+                                }
+                            ]
+                        },
+                        "tags": [],
+                        "properties": {},
+                    }
+                ]
+            },
+            "tags": [],
+            "properties": {},
+        }
+    },
+}
+user = {
+    "description": "",
+    "type": "Entity",
+    "name": "user",
+    "features": {
+        "avg_transactions": [
+            {
+                "description": "",
+                "entity": "user",
+                "name": "avg_transactions",
+                "owner": "default_user",
+                "provider": "local-mode",
+                "data-type": "float32",
+                "variant": "quickstart",
+                "status": "ready",
+                "location": {
+                    "entity": "CustomerID",
+                    "value": "TransactionAmount",
+                    "timestamp": "",
+                },
+                "source": {"Name": "average_user_transaction", "Variant": "quickstart"},
+                "tags": [],
+                "properties": {},
+            }
+        ]
+    },
+    "labels": {
+        "fraudulent": [
+            {
+                "description": "",
+                "entity": "user",
+                "data-type": "bool",
+                "name": "fraudulent",
+                "owner": "default_user",
+                "provider": "",
+                "variant": "quickstart",
+                "status": "ready",
+                "location": {
+                    "entity": "CustomerID",
+                    "value": "IsFraud",
+                    "timestamp": "",
+                },
+                "source": {"Name": "transactions", "Variant": "quickstart"},
+                "trainingSets": {
+                    "fraud_training": [
+                        {
+                            "description": "",
+                            "name": "fraud_training",
+                            "owner": "default_user",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                            "features": {
+                                "avg_transactions": [
+                                    {
+                                        "description": "",
+                                        "entity": "user",
+                                        "name": "avg_transactions",
+                                        "owner": "default_user",
+                                        "provider": "local-mode",
+                                        "data-type": "float32",
+                                        "variant": "quickstart",
+                                        "status": "ready",
+                                        "location": {
+                                            "entity": "CustomerID",
+                                            "value": "TransactionAmount",
+                                            "timestamp": "",
+                                        },
+                                        "source": {
+                                            "Name": "average_user_transaction",
+                                            "Variant": "quickstart",
+                                        },
+                                        "tags": [],
+                                        "properties": {},
+                                    }
+                                ]
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "tags": [],
+                "properties": {},
+            }
+        ]
+    },
+    "training-sets": {
+        "fraud_training": [
+            {
+                "description": "",
+                "name": "fraud_training",
+                "owner": "default_user",
+                "variant": "quickstart",
+                "status": "ready",
+                "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                "features": {
+                    "avg_transactions": [
+                        {
+                            "description": "",
+                            "entity": "user",
+                            "name": "avg_transactions",
+                            "owner": "default_user",
+                            "provider": "local-mode",
+                            "data-type": "float32",
+                            "variant": "quickstart",
+                            "status": "ready",
+                            "location": {
+                                "entity": "CustomerID",
+                                "value": "TransactionAmount",
+                                "timestamp": "",
+                            },
+                            "source": {
+                                "Name": "average_user_transaction",
+                                "Variant": "quickstart",
+                            },
+                            "tags": [],
+                            "properties": {},
+                        }
+                    ]
+                },
+                "tags": [],
+                "properties": {},
+            }
+        ]
+    },
+    "status": "ready",
+    "tags": [],
+    "properties": {},
+}
+fraudulent = {
+    "all-variants": ["quickstart"],
+    "type": "Label",
+    "default-variant": "quickstart",
+    "name": "fraudulent",
+    "variants": {
+        "quickstart": {
+            "description": "",
+            "entity": "user",
+            "data-type": "bool",
+            "name": "fraudulent",
+            "owner": "default_user",
+            "provider": "",
+            "variant": "quickstart",
+            "status": "ready",
+            "location": {"entity": "CustomerID", "value": "IsFraud", "timestamp": ""},
+            "source": {"Name": "transactions", "Variant": "quickstart"},
+            "trainingSets": {
+                "fraud_training": [
+                    {
+                        "description": "",
+                        "name": "fraud_training",
+                        "owner": "default_user",
+                        "variant": "quickstart",
+                        "status": "ready",
+                        "label": {"Name": "fraudulent", "Variant": "quickstart"},
+                        "features": {
+                            "avg_transactions": [
+                                {
+                                    "description": "",
+                                    "entity": "user",
+                                    "name": "avg_transactions",
+                                    "owner": "default_user",
+                                    "provider": "local-mode",
+                                    "data-type": "float32",
+                                    "variant": "quickstart",
+                                    "status": "ready",
+                                    "location": {
+                                        "entity": "CustomerID",
+                                        "value": "TransactionAmount",
+                                        "timestamp": "",
+                                    },
+                                    "source": {
+                                        "Name": "average_user_transaction",
+                                        "Variant": "quickstart",
+                                    },
+                                    "tags": [],
+                                    "properties": {},
+                                }
+                            ]
+                        },
+                        "tags": [],
+                        "properties": {},
+                    }
+                ]
+            },
+            "tags": [],
+            "properties": {},
+        }
+    },
+}
+fraud_training = {
+    "all-variants": ["quickstart"],
+    "type": "TrainingSet",
+    "default-variant": "quickstart",
+    "name": "fraud_training",
+    "variants": {
+        "quickstart": {
+            "description": "",
+            "name": "fraud_training",
+            "owner": "default_user",
+            "variant": "quickstart",
+            "status": "ready",
+            "label": {"Name": "fraudulent", "Variant": "quickstart"},
+            "features": {
+                "avg_transactions": [
+                    {
+                        "description": "",
+                        "entity": "user",
+                        "name": "avg_transactions",
+                        "owner": "default_user",
+                        "provider": "local-mode",
+                        "data-type": "float32",
+                        "variant": "quickstart",
+                        "status": "ready",
+                        "location": {
+                            "entity": "CustomerID",
+                            "value": "TransactionAmount",
+                            "timestamp": "",
+                        },
+                        "source": {
+                            "Name": "average_user_transaction",
+                            "Variant": "quickstart",
+                        },
+                        "tags": [],
+                        "properties": {},
+                    }
+                ]
+            },
+            "tags": [],
+            "properties": {},
+        }
+    },
+}
+
 
 def remove_keys(obj, rubbish):
     if isinstance(obj, dict):
         obj = {
-            key: remove_keys(value, rubbish) 
+            key: remove_keys(value, rubbish)
             for key, value in obj.items()
-            if key not in rubbish}
+            if key not in rubbish
+        }
     elif isinstance(obj, list):
-        obj = [remove_keys(item, rubbish)
-                  for item in obj
-                  if item not in rubbish]
+        obj = [remove_keys(item, rubbish) for item in obj if item not in rubbish]
     return obj
+
 
 def test_setup():
     import subprocess
-    apply = subprocess.run(['featureform', 'apply', 'client/examples/local_quickstart.py', '--local'])
+
+    apply = subprocess.run(
+        ["featureform", "apply", "client/examples/local_quickstart.py", "--local"]
+    )
     print("The exit code was: %d" % apply.returncode)
     assert apply.returncode == 0, f"OUT: {apply.stdout}, ERR: {apply.stderr}"
 
+
 @pytest.fixture
 def client():
-    app.config['TESTING'] = True
+    app.config["TESTING"] = True
     with app.test_client() as client:
         with app.app_context():
             yield client
 
+
 def check_objs(path, test_obj, client):
     response = client.get(path)
-    assert response.status == '200 OK'
+    assert response.status == "200 OK"
     json_resource = json.loads(response.data.decode())
-    removed_created_json = remove_keys(json_resource, ['created', 'definition'])
+    removed_created_json = remove_keys(json_resource, ["created", "definition"])
+    print("++++++++++ ACTUAL", removed_created_json)
     assert removed_created_json == test_obj
+
 
 def test_features(client):
     check_objs("/data/features", features, client)
 
+
 def test_labels(client):
     check_objs("/data/labels", labels, client)
+
 
 def test_sources(client):
     check_objs("/data/sources", sources, client)
 
+
 def test_training_sets(client):
     check_objs("/data/training_sets", training_sets, client)
+
 
 def test_entities(client):
     check_objs("/data/entities", entities, client)
 
+
 def test_models(client):
     check_objs("/data/models", models, client)
+
 
 def test_providers(client):
     check_objs("/data/providers", providers, client)
 
+
 def test_default_user(client):
     check_objs("/data/users/default_user", default_user, client)
+
 
 def test_localmode(client):
     check_objs("/data/providers/local-mode", localmode, client)
 
+
 def test_average_user_transaction(client):
-    check_objs("/data/sources/average_user_transaction", average_user_transaction, client)
+    check_objs(
+        "/data/sources/average_user_transaction", average_user_transaction, client
+    )
+
 
 def test_fraudulent(client):
     check_objs("/data/labels/fraudulent", fraudulent, client)
 
+
 def test_fraud_training(client):
     check_objs("/data/training_sets/fraud_training", fraud_training, client)
 
+
 def test_user(client):
     check_objs("/data/entities/user", user, client)
+
 
 def test_cleanup():
     def del_rw(action, name, exc):
         os.chmod(name, stat.S_IWRITE)
         os.remove(name)
+
     try:
-        shutil.rmtree('.featureform', onerror=del_rw)
+        shutil.rmtree(".featureform", onerror=del_rw)
     except:
         print("File Already Removed")
-

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -79,7 +79,9 @@ class OfflineSQLProvider(OfflineProvider):
                        table: str,
                        variant: str = "default",
                        owner: Union[str, UserRegistrar] = "",
-                       description: str = ""):
+                       description: str = "",
+                       tags: List[str] = [],
+                       properties: dict = {}):
         """Register a SQL table as a primary data source.
 
         Args:
@@ -97,20 +99,26 @@ class OfflineSQLProvider(OfflineProvider):
                                                       location=SQLTable(table),
                                                       owner=owner,
                                                       provider=self.name(),
-                                                      description=description)
+                                                      description=description,
+                                                      tags=tags,
+                                                      properties=properties)
 
     def sql_transformation(self,
                            owner: Union[str, UserRegistrar] = "",
                            variant: str = "default",
                            name: str = "",
                            schedule: str = "",
-                           description: str = ""):
+                           description: str = "",
+                           tags: List[str] = [],
+                           properties: dict = {}):
         return self.__registrar.sql_transformation(name=name,
                                                    variant=variant,
                                                    owner=owner,
                                                    schedule=schedule,
                                                    provider=self.name(),
-                                                   description=description)
+                                                   description=description,
+                                                   tags=tags,
+                                                   properties=properties)
 
 
 class OfflineSparkProvider(OfflineProvider):
@@ -124,7 +132,9 @@ class OfflineSparkProvider(OfflineProvider):
                         file_path: str,
                         variant: str = "default",
                         owner: Union[str, UserRegistrar] = "",
-                        description: str = ""):
+                        description: str = "",
+                        tags: List[str] = [],
+                        properties: dict = {}):
         """Register a Spark data source as a primary data source.
 
         Args:
@@ -142,7 +152,9 @@ class OfflineSparkProvider(OfflineProvider):
                                                       location=SQLTable(file_path),
                                                       owner=owner,
                                                       provider=self.name(),
-                                                      description=description)
+                                                      description=description,
+                                                      tags=tags,
+                                                      properties=properties)
     
     def register_parquet_file(self,
                               name: str,
@@ -160,7 +172,9 @@ class OfflineSparkProvider(OfflineProvider):
                            owner: Union[str, UserRegistrar] = "",
                            name: str = "",
                            schedule: str = "",
-                           description: str = ""):
+                           description: str = "",
+                           tags: List[str] = [],
+                           properties: dict = {}):
         """
         Register a SQL transformation source. The spark.sql_transformation decorator takes the returned string in the
         following function and executes it as a SQL Query.
@@ -193,14 +207,18 @@ class OfflineSparkProvider(OfflineProvider):
                                                    owner=owner,
                                                    schedule=schedule,
                                                    provider=self.name(),
-                                                   description=description)
+                                                   description=description,
+                                                   tags=tags,
+                                                   properties=properties)
 
     def df_transformation(self,
                           variant: str = "default",
                           owner: Union[str, UserRegistrar] = "",
                           name: str = "",
                           description: str = "",
-                          inputs: list = []):
+                          inputs: list = [],
+                          tags: List[str] = [],
+                          properties: dict = {}):
         """
         Register a Dataframe transformation source. The k8s_azure.df_transformation decorator takes the contents
         of the following function and executes the code it contains at serving time.
@@ -231,7 +249,9 @@ class OfflineSparkProvider(OfflineProvider):
                                                   owner=owner,
                                                   provider=self.name(),
                                                   description=description,
-                                                  inputs=inputs)
+                                                  inputs=inputs,
+                                                  tags=tags,
+                                                  properties=properties)
 
 
 class OfflineK8sProvider(OfflineProvider):
@@ -245,7 +265,9 @@ class OfflineK8sProvider(OfflineProvider):
                       path: str,
                       variant: str = "default",
                       owner: Union[str, UserRegistrar] = "",
-                      description: str = ""):
+                      description: str = "",
+                      tags: List[str] = [],
+                      properties: dict = {}):
         """Register a blob data source path as a primary data source.
 
         Args:
@@ -263,7 +285,9 @@ class OfflineK8sProvider(OfflineProvider):
                                                       location=SQLTable(path),
                                                       owner=owner,
                                                       provider=self.name(),
-                                                      description=description)
+                                                      description=description,
+                                                      tags=tags,
+                                                      properties=properties)
 
     def sql_transformation(self,
                            variant: str = "",
@@ -272,8 +296,9 @@ class OfflineK8sProvider(OfflineProvider):
                            schedule: str = "",
                            description: str = "",
                            docker_image: str = "",
-                           resource_specs: Union[K8sResourceSpecs, None] = None
-                           ):
+                           resource_specs: Union[K8sResourceSpecs, None] = None,
+                           tags: List[str] = [],
+                           properties: dict = {}):
         """
         Register a SQL transformation source. The k8s.sql_transformation decorator takes the returned string in the
         following function and executes it as a SQL Query.
@@ -309,8 +334,9 @@ class OfflineK8sProvider(OfflineProvider):
                                                    schedule=schedule,
                                                    provider=self.name(),
                                                    description=description,
-                                                   args=K8sArgs(docker_image=docker_image, specs=resource_specs)
-                                                   )
+                                                   args=K8sArgs(docker_image=docker_image, specs=resource_specs),
+                                                   tags=tags,
+                                                   properties=properties)
 
     def df_transformation(self,
                           variant: str = "default",
@@ -319,8 +345,9 @@ class OfflineK8sProvider(OfflineProvider):
                           description: str = "",
                           inputs: list = [],
                           docker_image: str = "",
-                          resource_specs: Union[K8sResourceSpecs, None] = None
-                          ):
+                          resource_specs: Union[K8sResourceSpecs, None] = None,
+                          tags: List[str] = [],
+                          properties: dict = {}):
         """
         Register a Dataframe transformation source. The k8s_azure.df_transformation decorator takes the contents
         of the following function and executes the code it contains at serving time.
@@ -354,8 +381,9 @@ class OfflineK8sProvider(OfflineProvider):
                                                   provider=self.name(),
                                                   description=description,
                                                   inputs=inputs,
-                                                  args=K8sArgs(docker_image=docker_image, specs=resource_specs)
-                                                  )
+                                                  args=K8sArgs(docker_image=docker_image, specs=resource_specs),
+                                                  tags=tags,
+                                                  properties=properties)
 
 
 class OnlineProvider:
@@ -408,7 +436,7 @@ class LocalProvider:
     def name(self) -> str:
         return self.__provider.name
 
-    def register_file(self, name, description, path, variant="default", owner=""):
+    def register_file(self, name, description, path, variant="default", owner="", tags: List[str] = [], properties: dict = {}):
         """Register a local file.
 
         **Examples**:
@@ -433,7 +461,14 @@ class LocalProvider:
         if owner == "":
             owner = self.__registrar.must_get_default_owner()
         # Store the file as a source
-        self.__registrar.register_primary_data(name, variant, SQLTable(path), self.__provider.name, owner, description)
+        self.__registrar.register_primary_data(name=name,
+                                               variant=variant,
+                                               location=SQLTable(path),
+                                               provider=self.__provider.name,
+                                               owner=owner,
+                                               description=description,
+                                               tags=tags,
+                                               properties=properties)
         return LocalSource(self.__registrar, name, owner, variant, self.name(), path, description)
 
     def insert_provider(self):
@@ -457,7 +492,9 @@ class LocalProvider:
                           owner: Union[str, UserRegistrar] = "",
                           name: str = "",
                           description: str = "",
-                          inputs: list = []):
+                          inputs: list = [],
+                          tags: List[str] = [],
+                          properties: dict = {}):
         """
         Register a Dataframe transformation source. The local.df_transformation decorator takes the contents
         of the following function and executes the code it contains at serving time.
@@ -488,13 +525,17 @@ class LocalProvider:
                                                   owner=owner,
                                                   provider=self.name(),
                                                   description=description,
-                                                  inputs=inputs)
+                                                  inputs=inputs,
+                                                  tags=tags,
+                                                  properties=properties)
 
     def sql_transformation(self,
                            variant: str = "default",
                            owner: Union[str, UserRegistrar] = "",
                            name: str = "",
-                           description: str = ""):
+                           description: str = "",
+                           tags: List[str] = [],
+                           properties: dict = {}):
         """
         Register a SQL transformation source. The local.sql_transformation decorator takes the returned string in the
         following function and executes it as a SQL Query.
@@ -526,7 +567,9 @@ class LocalProvider:
                                                    variant=variant,
                                                    owner=owner,
                                                    provider=self.name(),
-                                                   description=description)
+                                                   description=description,
+                                                   tags=tags,
+                                                   properties=properties)
 
 
 class SourceRegistrar:
@@ -547,6 +590,8 @@ class ColumnMapping(dict):
     variant: str
     column: str
     resource_type: str
+    tags: List[str]
+    properties: dict
 
 
 class LocalSource:
@@ -599,7 +644,7 @@ class LocalSource:
             inference_store: Union[str, OnlineProvider, FileStoreProvider] = "",
             features: List[ColumnMapping] = None,
             labels: List[ColumnMapping] = None,
-            timestamp_column: str = ""
+            timestamp_column: str = "",
     ):
         """
         Registers a features and/or labels that can be used in training sets or served.
@@ -647,12 +692,14 @@ class SQLTransformationDecorator:
                  registrar,
                  owner: str,
                  provider: str,
+                 tags: List[str],
+                 properties: dict,
                  variant: str = "default",
                  name: str = "",
                  schedule: str = "",
                  description: str = "",
                  args: K8sArgs = None):
-        self.registrar = registrar,
+        self.registrar = registrar
         self.name = name
         self.variant = variant
         self.owner = owner
@@ -660,6 +707,8 @@ class SQLTransformationDecorator:
         self.provider = provider
         self.description = description
         self.args = args
+        self.tags = tags
+        self.properties = properties
 
     def __call__(self, fn: Callable[[], str]):
         if self.description == "" and fn.__doc__ is not None:
@@ -686,6 +735,8 @@ class SQLTransformationDecorator:
             schedule=self.schedule,
             provider=self.provider,
             description=self.description,
+            tags=self.tags,
+            properties=self.properties
         )
 
     def name_variant(self):
@@ -703,7 +754,7 @@ class SQLTransformationDecorator:
             description: str = "",
             schedule: str = "",
     ):
-        return self.registrar[0].register_column_resources(
+        return self.registrar.register_column_resources(
             source=(self.name, self.variant),
             entity=entity,
             entity_column=entity_column,
@@ -723,12 +774,14 @@ class DFTransformationDecorator:
                  registrar,
                  owner: str,
                  provider: str,
+                 tags: List[str],
+                 properties: dict,
                  variant: str = "default",
                  name: str = "",
                  description: str = "",
                  inputs: list = [],
                  args: K8sArgs = None):
-        self.registrar = registrar,
+        self.registrar = registrar
         self.name = name
         self.variant = variant
         self.owner = owner
@@ -736,6 +789,8 @@ class DFTransformationDecorator:
         self.description = description
         self.inputs = inputs
         self.args = args
+        self.tags = tags
+        self.properties = properties
 
     def __call__(self, fn):
         if self.description == "" and fn.__doc__ is not None:
@@ -759,6 +814,8 @@ class DFTransformationDecorator:
             owner=self.owner,
             provider=self.provider,
             description=self.description,
+            tags=self.tags,
+            properties=self.properties
         )
 
     def name_variant(self):
@@ -773,9 +830,9 @@ class DFTransformationDecorator:
             features: List[ColumnMapping] = None,
             labels: List[ColumnMapping] = None,
             timestamp_column: str = "",
-            description: str = "",
+            description: str = ""
     ):
-        return self.registrar[0].register_column_resources(
+        return self.registrar.register_column_resources(
             source=(self.name, self.variant),
             entity=entity,
             entity_column=entity_column,
@@ -945,7 +1002,7 @@ class Registrar:
     def get_resources(self):
         return self.__resources
 
-    def register_user(self, name: str) -> UserRegistrar:
+    def register_user(self, name: str, tags: List[str] = [], properties: dict = {}) -> UserRegistrar:
         """Register a user.
 
         Args:
@@ -954,7 +1011,7 @@ class Registrar:
         Returns:
             UserRegistrar: User
         """
-        user = User(name)
+        user = User(name, tags, properties)
         self.__resources.append(user)
         return UserRegistrar(self, user)
 
@@ -1341,7 +1398,9 @@ class Registrar:
                        host: str = "0.0.0.0",
                        port: int = 6379,
                        password: str = "",
-                       db: int = 0):
+                       db: int = 0,
+                       tags: List[str] = [],
+                       properties: dict = {}):
         """Register a Redis provider.
 
         **Examples**:
@@ -1361,6 +1420,8 @@ class Registrar:
             port (int): Redis port
             password (str): Redis password
             db (str): Redis database
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             redis (OnlineProvider): Provider
@@ -1370,7 +1431,9 @@ class Registrar:
                             function="ONLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return OnlineProvider(self, provider)
 
@@ -1381,7 +1444,9 @@ class Registrar:
                             container_name: str,
                             root_path: str,
                             description: str = "",
-                            team: str = "", ):
+                            team: str = "",
+                            tags: List[str] = [],
+                            properties: dict = {}):
 
         """Register an azure blob store provider.
 
@@ -1408,6 +1473,8 @@ class Registrar:
             account_name (str): Azure account name
             account_key (str): Secret azure account key
             config (AzureConfig): an azure config object (can be used in place of container name and account name)
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
         Returns:
             blob (StorageProvider): Provider
                 has all the functionality of OnlineProvider
@@ -1421,7 +1488,9 @@ class Registrar:
                             function="ONLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return FileStoreProvider(self, provider, azure_config, "AZURE")
 
@@ -1431,7 +1500,9 @@ class Registrar:
                     bucket_path: str,
                     bucket_region: str,
                     description: str = "",
-                    team: str = "", ):
+                    team: str = "",
+                    tags: List[str] = [],
+                    properties: dict = {}):
         """Register a S3 store provider.
 
         This has the functionality of an offline store and can be used as a parameter
@@ -1454,6 +1525,8 @@ class Registrar:
             bucket_region (str): aws region the bucket is located in
             description (str): Description of S3 provider to be registered
             team (str): the name of the team registering the filestore
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
         Returns:
             s3 (FileStoreProvider): Provider
                 has all the functionality of OfflineProvider
@@ -1465,7 +1538,9 @@ class Registrar:
                             function="OFFLINE",
                             description=description,
                             team=team,
-                            config=s3_config)
+                            config=s3_config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return FileStoreProvider(self, provider, s3_config, s3_config.type())
 
@@ -1476,7 +1551,9 @@ class Registrar:
                     bucket_name: str,
                     bucket_path: str = "",
                     description: str = "",
-                    team: str = "", ):
+                    team: str = "",
+                    tags: List[str] = [],
+                    properties: dict = {}):
         """Register a GCS store provider.
                 **Examples**:
         ```
@@ -1495,6 +1572,8 @@ class Registrar:
             bucket_path (str): Custom path to be used by featureform
             description (str): Description of GCS provider to be registered
             team (str): The name of the team registering the filestore
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
         Returns:
             gcs (FileStoreProvider): Provider
                 has all the functionality of OfflineProvider
@@ -1505,7 +1584,9 @@ class Registrar:
                             function="OFFLINE",
                             description=description,
                             team=team,
-                            config=gcs_config)
+                            config=gcs_config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return FileStoreProvider(self, provider, gcs_config, gcs_config.type())
 
@@ -1562,7 +1643,8 @@ class Registrar:
                            credentials_path: str,
                            description: str = "",
                            team: str = "",
-                           ):
+                           tags: List[str] = [],
+                           properties: dict = {}):
         """Register a Firestore provider.
 
         **Examples**:
@@ -1581,7 +1663,8 @@ class Registrar:
             project_id (str): The Project name in GCP
             collection (str): The Collection name in Firestore under the given project ID
             credentials_path (str): A path to a Google Credentials file with access permissions for Firestore
-
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
         Returns:
             firestore (OfflineSQLProvider): Provider
         """
@@ -1590,7 +1673,9 @@ class Registrar:
                             function="ONLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return OnlineProvider(self, provider)
 
@@ -1604,14 +1689,50 @@ class Registrar:
                            password: str = "cassandra",
                            keyspace: str = "",
                            consistency: str = "THREE",
-                           replication: int = 3):
+                           replication: int = 3,
+                           tags: List[str] = [],
+                           properties: dict = {}):
+        """Register a Cassandra provider.
+
+        **Examples**:
+        ```
+        cassandra = ff.register_cassandra(
+                name = "cassandra",
+                description = "Example inference store",
+                team = "Featureform",
+                host = "0.0.0.0",
+                port = 9042,
+                username = "cassandra",
+                password = "cassandra",
+                consistency = "THREE",
+                replication = 3
+            )
+        ```
+        Args:
+            name (str): Name of Cassandra provider to be registered
+            description (str): Description of Cassandra provider to be registered
+            team (str): Name of team
+            host (str): DNS name of Cassandra
+            port (str): Port
+            user (str): User
+            password (str): Password
+            consistency (str): Consistency
+            replication (int): Replication
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
+
+        Returns:
+            cassandra (OnlineProvider): Provider
+        """
         config = CassandraConfig(host=host, port=port, username=username, password=password, keyspace=keyspace,
                                  consistency=consistency, replication=replication)
         provider = Provider(name=name,
                             function="ONLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return OnlineProvider(self, provider)
 
@@ -1621,7 +1742,9 @@ class Registrar:
                           team: str = "",
                           access_key: str = None,
                           secret_key: str = None,
-                          region: str = None):
+                          region: str = None,
+                          tags: List[str] = [],
+                          properties: dict = {}):
         """Register a DynamoDB provider.
 
         **Examples**:
@@ -1641,6 +1764,8 @@ class Registrar:
             access_key (str): Access key
             secret_key (str): Secret key
             region (str): Region
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             dynamodb (OnlineProvider): Provider
@@ -1650,7 +1775,9 @@ class Registrar:
                             function="ONLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return OnlineProvider(self, provider)
 
@@ -1663,8 +1790,9 @@ class Registrar:
                          database: str = None,
                          host: str = None,
                          port: str = None,
-                         throughput: int = 1000
-
+                         throughput: int = 1000,
+                         tags: List[str] = [],
+                         properties: dict = {}
                          ):
         """Register a MongoDB provider.
 
@@ -1692,6 +1820,8 @@ class Registrar:
             host (str): MongoDB hostname
             port (str): MongoDB port
             throughput (int): The maximum RU limit for autoscaling
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             mongodb (OnlineProvider): Provider
@@ -1702,23 +1832,26 @@ class Registrar:
                             function="ONLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return OnlineProvider(self, provider)
 
     def register_snowflake_legacy(
-            self,
-            name: str,
-            username: str,
-            password: str,
-            account_locator: str,
-            database: str,
-            schema: str = "PUBLIC",
-            description: str = "",
-            team: str = "",
-            warehouse: str = "",
-            role: str = "",
-    ):
+                self,
+                name: str,
+                username: str,
+                password: str,
+                account_locator: str,
+                database: str,
+                schema: str = "PUBLIC",
+                description: str = "",
+                team: str = "",
+                warehouse: str = "",
+                role: str = "",
+                tags: List[str] = [],
+                properties: dict = {}):
         """Register a Snowflake provider using legacy credentials.
 
         **Examples**:
@@ -1744,6 +1877,8 @@ class Registrar:
             team (str): Name of team
             warehouse (str): Specifies the virtual warehouse to use by default for queries, loading, etc.
             role (str): Specifies the role to use by default for accessing Snowflake objects in the client session
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             snowflake (OfflineSQLProvider): Provider
@@ -1759,7 +1894,9 @@ class Registrar:
                             function="OFFLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return OfflineSQLProvider(self, provider)
 
@@ -1776,8 +1913,8 @@ class Registrar:
             team: str = "",
             warehouse: str = "",
             role: str = "",
-
-    ):
+            tags: List[str] = [],
+            properties: dict = {}):
         """Register a Snowflake provider.
 
         **Examples**:
@@ -1805,6 +1942,8 @@ class Registrar:
             team (str): Name of team
             warehouse (str): Specifies the virtual warehouse to use by default for queries, loading, etc.
             role (str): Specifies the role to use by default for accessing Snowflake objects in the client session
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             snowflake (OfflineSQLProvider): Provider
@@ -1821,7 +1960,9 @@ class Registrar:
                             function="OFFLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return OfflineSQLProvider(self, provider)
 
@@ -1833,7 +1974,9 @@ class Registrar:
                           port: str = "5432",
                           user: str = "postgres",
                           password: str = "password",
-                          database: str = "postgres"):
+                          database: str = "postgres",
+                          tags: List[str] = [],
+                          properties: dict = {}):
         """Register a Postgres provider.
 
         **Examples**:
@@ -1857,6 +2000,8 @@ class Registrar:
             user (str): User
             password (str): Password
             database (str): Database
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             postgres (OfflineSQLProvider): Provider
@@ -1870,7 +2015,9 @@ class Registrar:
                             function="OFFLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return OfflineSQLProvider(self, provider)
 
@@ -1882,7 +2029,9 @@ class Registrar:
                           port: int = 5432,
                           user: str = "redshift",
                           password: str = "password",
-                          database: str = "dev"):
+                          database: str = "dev",
+                          tags: List[str] = [],
+                          properties: dict = {}):
         """Register a Redshift provider.
 
         **Examples**:
@@ -1906,6 +2055,8 @@ class Registrar:
             user (str): User
             password (str): Password
             database (str): Database
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             redshift (OfflineSQLProvider): Provider
@@ -1919,7 +2070,9 @@ class Registrar:
                             function="OFFLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return OfflineSQLProvider(self, provider)
 
@@ -1929,7 +2082,9 @@ class Registrar:
                           team: str = "",
                           project_id: str = "",
                           dataset_id: str = "",
-                          credentials_path: str = ""):
+                          credentials_path: str = "",
+                          tags: List[str] = [],
+                          properties: dict = {}):
         """Register a BigQuery provider.
 
         **Examples**:
@@ -1948,6 +2103,8 @@ class Registrar:
             project_id (str): The Project name in GCP
             dataset_id (str): The Dataset name in GCP under the Project Id
             credentials_path (str): A path to a Google Credentials file with access permissions for BigQuery
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             bigquery (OfflineSQLProvider): Provider
@@ -1959,7 +2116,9 @@ class Registrar:
                             function="OFFLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return OfflineSQLProvider(self, provider)
 
@@ -1969,7 +2128,8 @@ class Registrar:
                        filestore: FileStoreProvider,
                        description: str = "",
                        team: str = "",
-                       ):
+                       tags: List[str] = [],
+                       properties: dict = {}):
         """Register a Spark on Executor provider.
         **Examples**:
         ```
@@ -1987,6 +2147,8 @@ class Registrar:
             filestore: (FileStoreProvider): a FileStoreProvider used for storage of data
             description (str): Description of Spark provider to be registered
             team (str): Name of team
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             spark (OfflineSparkProvider): Provider
@@ -2002,7 +2164,9 @@ class Registrar:
                             function="OFFLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return OfflineSparkProvider(self, provider)
 
@@ -2011,8 +2175,9 @@ class Registrar:
                      store: FileStoreProvider,
                      description: str = "",
                      team: str = "",
-                     docker_image: str = ""
-                     ):
+                     docker_image: str = "",
+                     tags: List[str] = [],
+                     properties: dict = {}):
         """
         Register an offline store provider to run on featureform's own k8s deployment
         
@@ -2022,6 +2187,8 @@ class Registrar:
             description (str): Description of primary data to be registered
             team (str): A string parameter describing the team that owns the provider
             docker_image (str): A custom docker image using the base image featureformcom/k8s_runner
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
         **Examples**:
         ```
         k8s = ff.register_k8s(
@@ -2043,7 +2210,9 @@ class Registrar:
                             function="OFFLINE",
                             description=description,
                             team=team,
-                            config=config)
+                            config=config,
+                            tags=tags,
+                            properties=properties)
         self.__resources.append(provider)
         return OfflineK8sProvider(self, provider)
 
@@ -2062,7 +2231,9 @@ class Registrar:
                             function="LOCAL_ONLINE",
                             description="This is local mode",
                             team="team",
-                            config=config)
+                            config=config,
+                            tags=['local-mode'],
+                            properties={"resource_type": "Provider"})
         self.__resources.append(provider)
         local_provider = LocalProvider(self, provider)
         local_provider.insert_provider()
@@ -2073,6 +2244,8 @@ class Registrar:
                               variant: str,
                               location: Location,
                               provider: Union[str, OfflineProvider],
+                              tags: List[str],
+                              properties: dict,
                               owner: Union[str, UserRegistrar] = "",
                               description: str = ""):
         """Register a primary data source.
@@ -2099,7 +2272,9 @@ class Registrar:
                         definition=PrimaryData(location=location),
                         owner=owner,
                         provider=provider,
-                        description=description)
+                        description=description,
+                        tags=tags,
+                        properties=properties)
         self.__resources.append(source)
         return ColumnSourceRegistrar(self, source)
 
@@ -2111,8 +2286,9 @@ class Registrar:
                                     owner: Union[str, UserRegistrar] = "",
                                     description: str = "",
                                     schedule: str = "",
-                                    args: K8sArgs = None
-                                    ):
+                                    args: K8sArgs = None,
+                                    tags: List[str] = [],
+                                    properties: dict = {}):
         """Register a SQL transformation source.
 
         Args:
@@ -2124,6 +2300,8 @@ class Registrar:
             description (str): Description of primary data to be registered
             schedule (str): Kubernetes CronJob schedule string ("* * * * *")
             args (K8sArgs): Additional transformation arguments
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             source (ColumnSourceRegistrar): Source
@@ -2142,6 +2320,8 @@ class Registrar:
             schedule=schedule,
             provider=provider,
             description=description,
+            tags=tags,
+            properties=properties
         )
         self.__resources.append(source)
         return ColumnSourceRegistrar(self, source)
@@ -2153,8 +2333,9 @@ class Registrar:
                            schedule: str = "",
                            owner: Union[str, UserRegistrar] = "",
                            description: str = "",
-                           args: K8sArgs = None
-                           ):
+                           args: K8sArgs = None,
+                           tags: List[str] = [],
+                           properties: dict = {}):
         """SQL transformation decorator.
 
         Args:
@@ -2165,6 +2346,8 @@ class Registrar:
             owner (Union[str, UserRegistrar]): Owner
             description (str): Description of SQL transformation
             args (K8sArgs): Additional transformation arguments
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             decorator (SQLTransformationDecorator): decorator
@@ -2184,6 +2367,8 @@ class Registrar:
             owner=owner,
             description=description,
             args=args,
+            tags=tags,
+            properties=properties
         )
         self.__resources.append(decorator)
         return decorator
@@ -2197,8 +2382,9 @@ class Registrar:
                                    description: str = "",
                                    inputs: list = [],
                                    schedule: str = "",
-                                   args: K8sArgs = None
-                                   ):
+                                   args: K8sArgs = None,
+                                   tags: List[str] = [],
+                                   properties: dict = {}):
         """Register a Dataframe transformation source.
 
         Args:
@@ -2212,6 +2398,8 @@ class Registrar:
             inputs (list): Inputs to transformation
             schedule (str): Kubernetes CronJob schedule string ("* * * * *")
             args (K8sArgs): Additional transformation arguments
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             source (ColumnSourceRegistrar): Source
@@ -2233,12 +2421,16 @@ class Registrar:
             schedule=schedule,
             provider=provider,
             description=description,
+            tags=tags,
+            properties=properties
         )
         self.__resources.append(source)
         return ColumnSourceRegistrar(self, source)
 
     def df_transformation(self,
                           provider: Union[str, OfflineProvider],
+                          tags: List[str],
+                          properties: dict,
                           variant: str = "default",
                           name: str = "",
                           owner: Union[str, UserRegistrar] = "",
@@ -2256,6 +2448,8 @@ class Registrar:
             description (str): Description of SQL transformation
             inputs (list): Inputs to transformation
             args (K8sArgs): Additional transformation arguments
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             decorator (DFTransformationDecorator): decorator
@@ -2278,7 +2472,9 @@ class Registrar:
             owner=owner,
             description=description,
             inputs=inputs,
-            args=args
+            args=args,
+            tags=tags,
+            properties=properties
         )
         self.__resources.append(decorator)
         return decorator
@@ -2300,7 +2496,7 @@ class Registrar:
     def clear_state(self):
         self.__state = ResourceState()
 
-    def register_entity(self, name: str, description: str = ""):
+    def register_entity(self, name: str, description: str = "", tags: List[str] = [], properties: dict = {}):
         """Register an entity.
 
         **Examples**:
@@ -2310,11 +2506,13 @@ class Registrar:
         Args:
             name (str): Name of entity to be registered
             description (str): Description of entity to be registered
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             entity (EntityRegistrar): Entity
         """
-        entity = Entity(name=name, description=description)
+        entity = Entity(name=name, description=description, tags=tags, properties=properties)
         self.__resources.append(entity)
         return EntityRegistrar(self, entity)
 
@@ -2329,8 +2527,7 @@ class Registrar:
             labels: List[ColumnMapping] = None,
             timestamp_column: str = "",
             description: str = "",
-            schedule: str = "",
-    ):
+            schedule: str = "",):
         """Create features and labels from a source. Used in the register_resources function.
 
         Args:
@@ -2343,6 +2540,8 @@ class Registrar:
             labels (List[ColumnMapping]): List of ColumnMapping objects (dictionaries containing the keys: name, variant, column, resource_type)
             description (str): Description
             schedule (str): Kubernetes CronJob schedule string ("* * * * *")
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             resource (ResourceRegistrar): resource
@@ -2375,6 +2574,8 @@ class Registrar:
         for feature in features:
             variant = feature.get("variant", "default")
             desc = feature.get("description", "")
+            feature_tags = feature.get("tags", [])
+            feature_properties = feature.get("properties", {})
             resource = Feature(
                 name=feature["name"],
                 variant=variant,
@@ -2390,6 +2591,8 @@ class Registrar:
                     value=feature["column"],
                     timestamp=timestamp_column,
                 ),
+                tags=feature_tags,
+                properties=feature_properties
             )
             self.__resources.append(resource)
             feature_resources.append(resource)
@@ -2397,6 +2600,8 @@ class Registrar:
         for label in labels:
             variant = label.get("variant", "default")
             desc = label.get("description", "")
+            label_tags = label.get("tags", [])
+            label_properties = label.get("properties", {})
             resource = Label(
                 name=label["name"],
                 variant=variant,
@@ -2411,6 +2616,8 @@ class Registrar:
                     value=label["column"],
                     timestamp=timestamp_column,
                 ),
+                tags=label_tags,
+                properties=label_properties
             )
             self.__resources.append(resource)
             label_resources.append(resource)
@@ -2468,7 +2675,9 @@ class Registrar:
                               resources: list = [],
                               owner: Union[str, UserRegistrar] = "",
                               description: str = "",
-                              schedule: str = ""):
+                              schedule: str = "",
+                              tags: List[str] = [],
+                              properties: dict = {}):
         """Register a training set.
 
         Args:
@@ -2480,6 +2689,8 @@ class Registrar:
             owner (Union[str, UserRegistrar]): Owner
             description (str): Description of training set to be registered
             schedule (str): Kubernetes CronJob schedule string ("* * * * *")
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             resource (ResourceRegistrar): resource
@@ -2523,20 +2734,24 @@ class Registrar:
             schedule=schedule,
             label=label,
             features=features,
-            feature_lags=feature_lags
+            feature_lags=feature_lags,
+            tags=tags,
+            properties=properties,
         )
         self.__resources.append(resource)
 
-    def register_model(self, name: str) -> Model:
+    def register_model(self, name: str, tags: List[str] = [], properties: dict = {}) -> Model:
         """Register a model.
 
         Args:
             name (str): Model to be registered
+            tags (List[str]): Optional grouping mechanism for resources
+            properties (dict): Optional grouping mechanism for resources
 
         Returns:
             ModelRegistrar: Model
         """
-        model = Model(name)
+        model = Model(name, tags=tags, properties=properties)
         self.__resources.append(model)
         return model
 
@@ -2730,7 +2945,8 @@ class ResourceClient(Registrar):
             if model_proto is None:
                 model = None
             else:
-                model = Model(model_proto.name)
+                # TODO: apply values from proto
+                model = Model(model_proto.name, tags=[], properties={})
 
         return model
 
@@ -3077,6 +3293,9 @@ class ResourceClient(Registrar):
             features=[(f.name, f.variant) for f in ts.features],
             feature_lags=[],
             provider=ts.provider,
+            # TODO: apply values from proto
+            tags=[],
+            properties={},
         )
 
     def print_training_set(self, name, variant=None, local=False):
@@ -3625,10 +3844,11 @@ class ResourceClient(Registrar):
         models = []
         if local:
             rows = list_local("model", [ColumnName.NAME])
-            models = [Model(row["name"]) for row in rows]
+            models = [Model(row["name"], tags=[], properties={}) for row in rows]
         else:
             model_protos = list_name(self._stub, "model")
-            models = [Model(proto.name) for proto in model_protos]
+            # TODO: apply values from proto
+            models = [Model(proto.name, tags=[], properties={}) for proto in model_protos]
 
         return models
 

--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -666,6 +666,8 @@ class Provider:
     config: Config
     description: str
     team: str
+    tags: list
+    properties: dict
 
     def __post_init__(self):
         self.software = self.config.software()
@@ -701,6 +703,10 @@ class Provider:
                   "ready",
                   str(self.config.serialize(), 'utf-8')
                   )
+        if len(self.tags):
+            db.upsert("tags", self.name, "", "providers", json.dumps(self.tags))
+        if len(self.properties):
+            db.upsert("properties", self.name, "", "providers", json.dumps(self.properties))
 
     def __eq__(self, other):
         for attribute in vars(self):
@@ -713,6 +719,8 @@ class Provider:
 @dataclass
 class User:
     name: str
+    tags: list
+    properties: dict
 
     @staticmethod
     def operation_type() -> OperationType:
@@ -731,6 +739,10 @@ class User:
                   "User",
                   "ready"
                   )
+        if len(self.tags):
+            db.upsert("tags", self.name, "", "users", json.dumps(self.tags))
+        if len(self.properties):
+            db.upsert("properties", self.name, "", "users", json.dumps(self.properties))
 
     def __eq__(self, other):
         for attribute in vars(self):
@@ -829,6 +841,8 @@ class Source:
     owner: str
     provider: str
     description: str
+    tags: list
+    properties: dict
     variant: str = "default"
     schedule: str = ""
     schedule_obj: Schedule = None
@@ -885,6 +899,10 @@ class Source:
                          json.dumps(self.inputs),
                          self.definition
                          )
+        if len(self.tags):
+            db.upsert("tags", self.name, self.variant, "source_variant", json.dumps(self.tags))
+        if len(self.properties):
+            db.upsert("properties", self.name, self.variant, "source_variant", json.dumps(self.properties))
         self._create_source_resource(db)
 
     def _create_source_resource(self, db) -> None:
@@ -913,6 +931,8 @@ class Source:
 class Entity:
     name: str
     description: str
+    tags: list
+    properties: dict
 
     @staticmethod
     def operation_type() -> OperationType:
@@ -936,6 +956,10 @@ class Entity:
                   self.description,
                   "ready"
                   )
+        if len(self.tags):
+            db.upsert("tags", self.name, "", "entities", json.dumps(self.tags))
+        if len(self.properties):
+            db.upsert("properties", self.name, "", "entities", json.dumps(self.properties))
 
     def __eq__(self, other):
         for attribute in vars(self):
@@ -973,6 +997,8 @@ class Feature:
     provider: str
     location: ResourceLocation
     description: str
+    tags: list
+    properties: dict
     variant: str = "default"
     schedule: str = ""
     schedule_obj: Schedule = None
@@ -1030,6 +1056,10 @@ class Feature:
                   self.source[0],
                   self.source[1]
                   )
+        if len(self.tags):
+            db.upsert("tags", self.name, self.variant, "feature_variant", json.dumps(self.tags))
+        if len(self.properties):
+            db.upsert("properties", self.name, self.variant, "feature_variant", json.dumps(self.properties))
         self._create_feature_resource(db)
 
     def _create_feature_resource(self, db) -> None:
@@ -1063,6 +1093,8 @@ class Label:
     owner: str
     provider: str
     description: str
+    tags: list
+    properties: dict
     location: ResourceLocation
     variant: str = "default"
     status: str = "NO_STATUS"
@@ -1113,6 +1145,10 @@ class Label:
                   self.source[0],
                   self.source[1]
                   )
+        if len(self.tags):
+            db.upsert("tags", self.name, self.variant, "label_variant", json.dumps(self.tags))
+        if len(self.properties):
+            db.upsert("properties", self.name, self.variant, "label_variant", json.dumps(self.properties))
         self._create_label_resource(db)
 
     def _create_label_resource(self, db) -> None:
@@ -1233,6 +1269,8 @@ class TrainingSet:
     label: NameVariant
     features: List[NameVariant]
     description: str
+    tags: list
+    properties: dict
     feature_lags: list = field(default_factory=list)
     status: str = "NO_STATUS"
     variant: str = "default"
@@ -1300,6 +1338,10 @@ class TrainingSet:
                   self.label[1],
                   "ready"
                   )
+        if len(self.tags):
+            db.upsert("tags", self.name, self.variant, "training_set_variant", json.dumps(self.tags))
+        if len(self.properties):
+            db.upsert("properties", self.name, self.variant, "training_set_variant", json.dumps(self.properties))
         self._create_training_set_resource(db)
 
     def _create_training_set_resource(self, db) -> None:
@@ -1368,6 +1410,8 @@ class TrainingSet:
 @dataclass
 class Model:
     name: str
+    tags: list
+    properties: dict
 
     @staticmethod
     def operation_type() -> OperationType:
@@ -1385,6 +1429,10 @@ class Model:
                   self.name,
                   "Model",
                   )
+        if len(self.tags):
+            db.upsert("tags", self.name, "", "models", json.dumps(self.tags))
+        if len(self.properties):
+            db.upsert("properties", self.name, "", "models", json.dumps(self.properties))
 
     def __eq__(self, other):
         for attribute in vars(self):

--- a/client/src/featureform/type_objects.py
+++ b/client/src/featureform/type_objects.py
@@ -13,7 +13,9 @@ class FeatureVariantResource:
         variant="",
         status="",
         location=None,
-        source=None):
+        source=None,
+        tags=[],
+        properties={}):
 
           self.__dictionary = {
             "created": created,
@@ -26,7 +28,9 @@ class FeatureVariantResource:
             "variant": variant,
             "status": status,
             "location":location,
-            "source":source
+            "source":source,
+            "tags": tags,
+            "properties": properties,
             # Training Set[] is missing
         }
 
@@ -68,7 +72,9 @@ class TrainingSetVariantResource:
         variant="",
         label=None,
         status="",
-        features=None):
+        features=None,
+        tags=[],
+        properties={}):
 
           self.__dictionary = {
             "created" : created,
@@ -78,7 +84,9 @@ class TrainingSetVariantResource:
             "variant" : variant,
             "status" : status,
             "label" : label,
-            "features" : features
+            "features" : features,
+            "tags": tags,
+            "properties": properties,
         }
 
     def toDictionary(self):
@@ -122,7 +130,9 @@ class SourceVariantResource:
         definition="",
         labels=None,
         features=None,
-        trainingSets=None):
+        trainingSets=None,
+        tags=[],
+        properties={}):
 
         self.__dictionary = {
           "created":created,
@@ -136,7 +146,9 @@ class SourceVariantResource:
          "definition":definition,
          "labels":labels,
          "features":features,
-         "training-sets":trainingSets
+         "training-sets":trainingSets,
+         "tags": tags,
+         "properties": properties,
         }
 
     def toDictionary(self):
@@ -180,7 +192,9 @@ class LabelVariantResource:
         location=None,
         status="",
         source=None,
-        trainingSets=None):
+        trainingSets=None,
+        tags=[],
+        properties={}):
 
 
         self.__dictionary = {
@@ -195,7 +209,9 @@ class LabelVariantResource:
          "status":status,
          "location":location,
          "source":source,
-         "trainingSets":trainingSets
+         "trainingSets":trainingSets,
+         "tags": tags,
+         "properties": properties,
         #  source is missing
         }
 
@@ -235,7 +251,9 @@ class EntityResource:
         status="",
         features=None,
         labels=None,
-        trainingSets=None):
+        trainingSets=None,
+        tags=[],
+        properties={}):
 
         self.__dictionary = {
          "description":description,
@@ -244,7 +262,9 @@ class EntityResource:
          "features":features,
          "labels":labels,
          "training-sets":trainingSets,
-         "status":status
+         "status":status,
+         "tags": tags,
+         "properties": properties,
         }
 
     def toDictionary(self):
@@ -261,7 +281,9 @@ class UserResource:
         features=None,
         labels=None,
         trainingSets=None,
-        sources=None):
+        sources=None,
+        tags=[],
+        properties={}):
 
         self.__dictionary = {
          "name":name,
@@ -270,7 +292,9 @@ class UserResource:
          "labels":labels,
          "training-sets":trainingSets,
          "sources":sources,
-         "status":status
+         "status":status,
+         "tags": tags,
+         "properties": properties,
         }
 
     def toDictionary(self):
@@ -287,7 +311,9 @@ class ModelResource:
         status="",
         features=None,
         labels=None,
-        trainingSets=None):
+        trainingSets=None,
+        tags=[],
+        properties={}):
 
         self.__dictionary = {
          "name":name,
@@ -296,7 +322,9 @@ class ModelResource:
          "features":features,
          "labels":labels,
          "training-sets":trainingSets,
-         "status":status
+         "status":status,
+         "tags": tags,
+         "properties": properties,
         }
 
     def toDictionary(self):
@@ -317,7 +345,9 @@ class ProviderResource:
         status="",
         serializedConfig="",
         features=None,
-        labels=None
+        labels=None,
+        tags=[],
+        properties={}
         #trainingSets=None
         ):
 
@@ -334,7 +364,9 @@ class ProviderResource:
               #"training-sets":trainingSets,
               "status":status ,
             #   Seems like we dont need serialised config
-              "serializedConfig":serializedConfig
+              "serializedConfig":serializedConfig,
+              "tags": tags,
+              "properties": properties,
         }
 
     def toDictionary(self):

--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -45,7 +45,7 @@ def spark_provider():
     azure_blob = AzureFileStoreConfig(account_name="", account_key="", container_name="", root_path="")   
     
     config = SparkConfig(executor_type=databricks.type(), executor_config=databricks.config(), store_type=azure_blob.store_type(), store_config=azure_blob.config())
-    provider = Provider(name="spark", function="OFFLINE", description="", team="", config=config)
+    provider = Provider(name="spark", function="OFFLINE", description="", team="", config=config, tags=[], properties={})
     
     return OfflineSparkProvider(r, provider)
 

--- a/client/tests/register_test.py
+++ b/client/tests/register_test.py
@@ -38,7 +38,9 @@ def local():
                         function="LOCAL_ONLINE",
                         description="This is local mode",
                         team="team",
-                        config=config)
+                        config=config,
+                        tags=[],
+                        properties={})
     return LocalProvider(Registrar(), provider)
 
 
@@ -74,7 +76,7 @@ def test_sql_transformation_empty_description(registrar):
     def my_function():
         return "SELECT * FROM X"
 
-    dec = SQLTransformationDecorator(registrar=registrar, owner="", provider="", variant="sql")
+    dec = SQLTransformationDecorator(registrar=registrar, owner="", provider="", variant="sql", tags=[], properties={})
     dec.__call__(my_function)
 
     # Checks that Transformation definition does not error when converting to source
@@ -85,7 +87,7 @@ def test_df_transformation_empty_description(registrar):
     def my_function(df):
         return df
 
-    dec = DFTransformationDecorator(registrar=registrar, owner="", provider="", variant="df")
+    dec = DFTransformationDecorator(registrar=registrar, owner="", provider="", variant="df", tags=[], properties={})
     dec.__call__(my_function)
 
     # Checks that Transformation definition does not error when converting to source

--- a/client/tests/resources_test.py
+++ b/client/tests/resources_test.py
@@ -151,6 +151,8 @@ def postgres_provider(postgres_config):
         function="fn2",
         team="team2",
         config=postgres_config,
+        tags=[],
+        properties={}
     )
 
 
@@ -162,6 +164,8 @@ def snowflake_provider(snowflake_config):
         function="fn3",
         team="team3",
         config=snowflake_config,
+        tags=[],
+        properties={}
     )
 
 
@@ -173,6 +177,8 @@ def redis_provider(redis_config):
         function="fn3",
         team="team3",
         config=redis_config,
+        tags=[],
+        properties={}
     )
 
 
@@ -184,6 +190,8 @@ def redshift_provider(redshift_config):
         function="fn2",
         team="team2",
         config=redshift_config,
+        tags=[],
+        properties={}
     )
 
 
@@ -195,6 +203,8 @@ def bigquery_provider(bigquery_config):
         function="fn2",
         team="team2",
         config=bigquery_config,
+        tags=[],
+        properties={}
     )
 
 @pytest.mark.parametrize('image', ["", "my/docker_image:latest"])
@@ -257,7 +267,9 @@ def mock_provider(kubernetes_config):
         function="OFFLINE",
         description="provider-description",
         team="team",
-        config=kubernetes_config
+        config=kubernetes_config,
+        tags=[],
+        properties={}
     )
 
 
@@ -335,7 +347,9 @@ def init_feature(input):
                 value="def",
                 timestamp="ts",
             ),
-            provider="redis-name")
+            provider="redis-name",
+            tags=[],
+            properties={})
 
 
 @pytest.mark.parametrize("input,fail", [
@@ -363,7 +377,9 @@ def init_label(input):
               value="def",
               timestamp="ts",
           ),
-          provider="redis-name")
+          provider="redis-name", 
+          tags=[], 
+          properties={})
 
 
 @pytest.mark.parametrize("input,fail", [
@@ -382,14 +398,21 @@ def test_valid_label_column_types(input, fail):
 def all_resources_set(redis_provider):
     return [
         redis_provider,
-        User(name="Featureform"),
-        Entity(name="user", description="A user"),
+        User(name="Featureform",
+             tags=[],
+             properties={}),
+        Entity(name="user",
+               description="A user",
+               tags=[],
+               properties={}),
         Source(name="primary",
                variant="abc",
                definition=PrimaryData(location=SQLTable("table")),
                owner="someone",
                description="desc",
-               provider="redis-name"),
+               provider="redis-name",
+               tags=[],
+               properties={}),
         Feature(name="feature",
                 variant="v1",
                 source=("a", "b"),
@@ -402,7 +425,9 @@ def all_resources_set(redis_provider):
                     value="def",
                     timestamp="ts",
                 ),
-                provider="redis-name"),
+                provider="redis-name",
+                tags=[],
+                properties={}),
         Label(
             name="label",
             variant="v1",
@@ -416,7 +441,9 @@ def all_resources_set(redis_provider):
             ),
             entity="user",
             owner="Owner",
-            provider="redis-name"
+            provider="redis-name",
+            tags=[],
+            properties={}
         ),
         TrainingSet(name="training-set",
                     variant="v1",
@@ -424,7 +451,9 @@ def all_resources_set(redis_provider):
                     owner="featureform",
                     label=("label", "var"),
                     feature_lags=[],
-                    features=[("f1", "var")]),
+                    features=[("f1", "var")],
+                    tags=[],
+                    properties={})
     ]
 
 
@@ -437,7 +466,9 @@ def all_resources_strange_order(redis_provider):
                     owner="featureform",
                     feature_lags=[],
                     label=("label", "var"),
-                    features=[("f1", "var")]),
+                    features=[("f1", "var")],
+                    tags=[],
+                    properties={}),
         Label(
             name="label",
             variant="v1",
@@ -451,7 +482,9 @@ def all_resources_strange_order(redis_provider):
             value_type="float32",
             entity="user",
             owner="Owner",
-            provider="redis-name"
+            provider="redis-name",
+            tags=[],
+            properties={}
         ),
         Feature(name="feature",
                 variant="v1",
@@ -465,16 +498,23 @@ def all_resources_strange_order(redis_provider):
                     timestamp="ts",
                 ),
                 owner="Owner",
-                provider="redis-name"),
-        Entity(name="user", description="A user"),
+                provider="redis-name",
+                tags=[],
+                properties={}),
+        Entity(name="user",
+               description="A user",
+               tags=[],
+               properties={}),
         Source(name="primary",
                variant="abc",
                definition=PrimaryData(location=SQLTable("table")),
                owner="someone",
                description="desc",
-               provider="redis-name"),
+               provider="redis-name",
+               tags=[],
+               properties={}),
         redis_provider,
-        User(name="Featureform"),
+        User(name="Featureform", tags=[], properties={}),
     ]
 
 
@@ -498,12 +538,16 @@ def test_redefine_provider(redis_config, snowflake_config):
                  description="desc",
                  function="fn",
                  team="team",
-                 config=redis_config),
+                 config=redis_config,
+                 tags=[],
+                 properties={}),
         Provider(name="name",
                  description="desc2",
                  function="fn2",
                  team="team2",
-                 config=snowflake_config),
+                 config=snowflake_config,
+                 tags=[],
+                 properties={})
     ]
     state = ResourceState()
     state.add(providers[0])
@@ -516,21 +560,25 @@ def test_add_all_resource_types(all_resources_strange_order, redis_config):
     for resource in all_resources_strange_order:
         state.add(resource)
     assert state.sorted_list() == [
-        User(name="Featureform"),
+        User(name="Featureform", tags=[], properties={}),
         Provider(
             name="redis",
             description="desc3",
             function="fn3",
             team="team3",
             config=redis_config,
+            tags=[],
+            properties={}
         ),
         Source(name="primary",
                variant="abc",
                definition=PrimaryData(location=SQLTable("table")),
                owner="someone",
                description="desc",
-               provider="redis-name"),
-        Entity(name="user", description="A user"),
+               provider="redis-name",
+               tags=[],
+               properties={}),
+        Entity(name="user", description="A user", tags=[], properties={}),
         Feature(name="feature",
                 variant="v1",
                 source=("a", "b"),
@@ -543,7 +591,9 @@ def test_add_all_resource_types(all_resources_strange_order, redis_config):
                 ),
                 entity="user",
                 owner="Owner",
-                provider="redis-name"),
+                provider="redis-name",
+                tags=[],
+                properties={}),
         Label(
             name="label",
             variant="v1",
@@ -557,7 +607,9 @@ def test_add_all_resource_types(all_resources_strange_order, redis_config):
             ),
             entity="user",
             owner="Owner",
-            provider="redis-name"
+            provider="redis-name",
+            tags=[],
+            properties={}
         ),
         TrainingSet(name="training-set",
                     variant="v1",
@@ -565,7 +617,9 @@ def test_add_all_resource_types(all_resources_strange_order, redis_config):
                     owner="featureform",
                     label=("label", "var"),
                     features=[("f1", "var")],
-                    feature_lags=[]),
+                    feature_lags=[],
+                    tags=[],
+                    properties={}),
     ]
 
 
@@ -672,13 +726,15 @@ def test_add_all_resources_with_schedule(all_resources_strange_order, redis_conf
             resource.update_schedule("* * * * *")
         state.add(resource)
     assert state.sorted_list() == [
-        User(name="Featureform"),
+        User(name="Featureform", tags=[], properties={}),
         Provider(
             name="redis",
             description="desc3",
             function="fn3",
             team="team3",
             config=redis_config,
+            tags=[],
+            properties={}
         ),
         Source(name="primary",
                variant="abc",
@@ -687,8 +743,10 @@ def test_add_all_resources_with_schedule(all_resources_strange_order, redis_conf
                description="desc",
                provider="redis-name",
                schedule="* * * * *",
-               schedule_obj=Schedule(name="primary", variant="abc", resource_type=7, schedule_string="* * * * *")),
-        Entity(name="user", description="A user"),
+               schedule_obj=Schedule(name="primary", variant="abc", resource_type=7, schedule_string="* * * * *"),
+               tags=[],
+               properties={}),
+        Entity(name="user", description="A user", tags=[], properties={}),
         Feature(name="feature",
                 variant="v1",
                 source=("a", "b"),
@@ -703,7 +761,9 @@ def test_add_all_resources_with_schedule(all_resources_strange_order, redis_conf
                 owner="Owner",
                 provider="redis-name",
                 schedule="* * * * *",
-                schedule_obj=Schedule(name="feature", variant="v1", resource_type=4, schedule_string="* * * * *")),
+                schedule_obj=Schedule(name="feature", variant="v1", resource_type=4, schedule_string="* * * * *"),
+                tags=[],
+                properties={}),
         Label(
             name="label",
             variant="v1",
@@ -717,7 +777,9 @@ def test_add_all_resources_with_schedule(all_resources_strange_order, redis_conf
             ),
             entity="user",
             owner="Owner",
-            provider="redis-name"
+            provider="redis-name",
+            tags=[],
+            properties={}
         ),
         TrainingSet(name="training-set",
                     variant="v1",
@@ -728,7 +790,9 @@ def test_add_all_resources_with_schedule(all_resources_strange_order, redis_conf
                     feature_lags=[],
                     schedule="* * * * *",
                     schedule_obj=Schedule(name="training-set", variant="v1", resource_type=6,
-                                          schedule_string="* * * * *")),
+                                          schedule_string="* * * * *"),
+                    tags=[],
+                    properties={}),
         Schedule(name="feature",
                  variant="v1",
                  resource_type=4,

--- a/client/tests/status_test.py
+++ b/client/tests/status_test.py
@@ -97,6 +97,8 @@ def test_feature_status(mocker, status, expected, ready):
             location=ResourceColumnMapping("", "", ""),
             description="",
             status=get_pb_status(status),
+            tags=[],
+            properties={}
         ))
     client = ResourceClient("host")
     feature = client.get_feature("", "")
@@ -126,6 +128,8 @@ def test_label_status(mocker, status, expected, ready):
             location=ResourceColumnMapping("", "", ""),
             description="",
             status=get_pb_status(status),
+            tags=[],
+            properties={}
         ))
     client = ResourceClient("host")
     label = client.get_label("", "")
@@ -153,6 +157,8 @@ def test_training_set_status(mocker, status, expected, ready):
             feature_lags=[],
             description="",
             status=get_pb_status(status),
+            tags=[],
+            properties={}
         ))
     client = ResourceClient("host")
     ts = client.get_training_set("", "")
@@ -179,6 +185,8 @@ def test_source_status(mocker, status, expected, ready):
             provider="provider",
             description="",
             status=get_pb_status(status),
+            tags=[],
+            properties={}
         ))
     client = ResourceClient("host")
     source = client.get_source("", "")

--- a/client/tests/test_spark_provider.py
+++ b/client/tests/test_spark_provider.py
@@ -23,7 +23,7 @@ def test_create_provider(executor_fixture, filestore_fixture, request):
     r = Registrar() 
     
     config = SparkConfig(executor_type=executor.type(), executor_config=executor.config(), store_type=filestore.store_type(), store_config=filestore.config())
-    provider = Provider(name=provider_name, function="OFFLINE", description="", team="", config=config)
+    provider = Provider(name=provider_name, function="OFFLINE", description="", team="", config=config, tags=[], properties={})
     
     offline_spark_provider = OfflineSparkProvider(r, provider)
     assert type(offline_spark_provider) == OfflineSparkProvider
@@ -81,6 +81,8 @@ def test_sql_transformation(name, variant, sql, spark_provider):
         owner="tester",
         provider="spark",
         description="doc string",
+        tags=[],
+        properties={}
     )
 
 
@@ -107,6 +109,8 @@ def test_df_transformation(name, variant, transformation, spark_provider, reques
         owner="tester",
         provider="spark",
         description="doc string",
+        tags=[],
+        properties={}
     )
     
     assert decorator_src.name == expected_src.name

--- a/client/tests/test_tags_and_properties.py
+++ b/client/tests/test_tags_and_properties.py
@@ -1,0 +1,607 @@
+import featureform as ff
+from featureform.resources import Model
+import os
+import pytest
+import time
+
+real_path = os.path.realpath(__file__)
+dir_path = os.path.dirname(real_path)
+
+@pytest.mark.parametrize(
+    "is_local,is_insecure",
+    [
+        pytest.param(True, True, marks=pytest.mark.local),
+        pytest.param(False, False, marks=pytest.mark.hosted),
+        pytest.param(False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_adding_tags_and_properties_to_provider(is_local, is_insecure, request):
+    name = "postgres_docs"
+    tags = ["pg_offline_provider", "ff_team"]
+    properties = {"primary_offline_provider": "true"}
+
+    ff.register_postgres(
+        name = name,
+        description = "Example offline store store",
+        team = "Featureform",
+        host = "0.0.0.0",
+        port = "5432",
+        user = "postgres",
+        password = "password",
+        database = "postgres",
+        tags=tags,
+        properties=properties
+    )
+
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply()
+
+    postgres = resource_client.get_provider(name, is_local)
+
+    assert postgres["tags"] == tags and postgres["properties"] == properties
+
+
+@pytest.mark.parametrize(
+    "is_local,is_insecure",
+    [
+        pytest.param(True, True, marks=pytest.mark.local),
+        pytest.param(False, False, marks=pytest.mark.hosted),
+        pytest.param(False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_updating_tags_and_properties_for_provider(is_local, is_insecure, request):
+    name = "postgres_docs"
+    tags = ["pg_offline_provider", "ff_team"]
+    properties = {"primary_offline_provider": "true"}
+
+    ff.register_postgres(
+        name = name,
+        description = "Example offline store store",
+        team = "Featureform",
+        host = "0.0.0.0",
+        port = "5432",
+        user = "postgres",
+        password = "password",
+        database = "postgres",
+        tags=tags,
+        properties=properties
+    )
+
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply()
+
+    ff.clear_state()
+
+    additional_tags = ["training_data"]
+    additional_properties = {"is_active": "true"}
+
+    ff.register_postgres(
+        name = name,
+        description = "Example offline store store",
+        team = "Featureform",
+        host = "0.0.0.0",
+        port = "5432",
+        user = "postgres",
+        password = "password",
+        database = "postgres",
+        tags=additional_tags,
+        properties=additional_properties
+    )
+    resource_client.apply()
+    postgres = resource_client.get_provider(name, is_local)
+
+    assert set(postgres["tags"]) == set(tags + additional_tags) and postgres["properties"] == {**properties, **additional_properties}
+
+
+@pytest.mark.parametrize(
+    "is_local,is_insecure",
+    [
+        pytest.param(True, True, marks=pytest.mark.local),
+        pytest.param(False, False, marks=pytest.mark.hosted),
+        pytest.param(False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_adding_tags_and_properties_to_user(is_local, is_insecure, request):
+    username = "ff_user"
+    tags = ["primary_user"]
+    properties = {"rotated_credentials": "yes"}
+
+    ff.register_user(username,tags=tags, properties=properties)
+
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply()
+
+    user = resource_client.get_user(username, is_local)
+
+    assert user["tags"] == tags and user["properties"] == properties
+
+
+@pytest.mark.parametrize(
+    "is_local,is_insecure",
+    [
+        pytest.param(True, True, marks=pytest.mark.local),
+        pytest.param(False, False, marks=pytest.mark.hosted),
+        pytest.param(False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_updating_tags_and_properties_for_user(is_local, is_insecure, request):
+    username = "ff_user"
+    tags = ["primary_user"]
+    properties = {"rotated_credentials": "yes"}
+
+    ff.register_user(username,tags=tags, properties=properties)
+
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply()
+
+    ff.clear_state()
+
+    additional_tags = ["shared_credentials"]
+    additional_properties = {"credential_location": "secret_vault"}
+
+    ff.register_user(username,tags=additional_tags, properties=additional_properties)
+    resource_client.apply()
+
+    user = resource_client.get_user(username, is_local)
+
+    assert set(user["tags"]) == set(tags + additional_tags) and user["properties"] == {**properties, **additional_properties}
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local,is_insecure",
+    [
+        pytest.param("local_provider_source", True, True, marks=pytest.mark.local),
+        pytest.param("hosted_sql_provider_and_source", False, False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_adding_tags_and_properties_to_source(provider_source_fxt, is_local, is_insecure, request):
+    custom_marks = [mark.name for mark in request.node.own_markers if mark.name != 'parametrize']
+    provider, source, inference_store = request.getfixturevalue(provider_source_fxt)(custom_marks)
+
+    name = "transactions"
+    variant = "quickstart_v2"
+    tags = ["fraud_project", "primary_source"]
+    properties = {"project_type": "fraud_prediction"}
+
+    if is_local:
+        provider.register_file(
+            name=name,
+            variant=variant,
+            description="A dataset of fraudulent transactions.",
+            path=f"{dir_path}/test_files/input_files/transactions.csv",
+            tags=tags,
+            properties=properties
+        )
+    else:
+        provider.register_table(
+            name=name,
+            table="Transactions", # This is the table's name in Postgres
+            variant=variant,
+            tags=tags,
+            properties=properties
+        )
+
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply()
+
+    source = resource_client.print_source(name, variant, is_local)
+
+    assert source["tags"] == tags and source["properties"] == properties
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local,is_insecure",
+    [
+        pytest.param("local_provider_source", True, True, marks=pytest.mark.local),
+        pytest.param("hosted_sql_provider_and_source", False, False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_updating_tags_and_properties_for_source(provider_source_fxt, is_local, is_insecure, request):
+    custom_marks = [mark.name for mark in request.node.own_markers if mark.name != 'parametrize']
+    provider, source, inference_store = request.getfixturevalue(provider_source_fxt)(custom_marks)
+
+    name = "transactions"
+    variant = "quickstart_v2"
+    tags = ["fraud_project", "primary_source"]
+    properties = {"project_type": "fraud_prediction"}
+
+    if is_local:
+        provider.register_file(
+            name=name,
+            variant=variant,
+            description="A dataset of fraudulent transactions.",
+            path=f"{dir_path}/test_files/input_files/transactions.csv",
+            tags=tags,
+            properties=properties
+        )
+    else:
+        provider.register_table(
+            name=name,
+            table="Transactions", # This is the table's name in Postgres
+            variant=variant,
+            tags=tags,
+            properties=properties
+        )
+
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply()
+
+    ff.clear_state()
+
+    additional_tags = ["v2"]
+    additional_properties = {"version": "2"}
+
+    if is_local:
+        provider.register_file(
+            name=name,
+            variant=variant,
+            description="A dataset of fraudulent transactions.",
+            path=f"{dir_path}/test_files/input_files/transactions.csv",
+            tags=additional_tags,
+            properties=additional_properties
+        )
+    else:
+        provider.register_table(
+            name=name,
+            table="Transactions", # This is the table's name in Postgres
+            variant=variant,
+            tags=additional_tags,
+            properties=additional_properties
+        )
+
+    resource_client.apply()
+
+    source = resource_client.print_source(name, variant, is_local)
+
+    assert set(source["tags"]) == set(tags + additional_tags) and source["properties"] == {**properties, **additional_properties}
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local,is_insecure",
+    [
+        pytest.param("local_provider_source", True, True, marks=pytest.mark.local),
+        pytest.param("hosted_sql_provider_and_source", False, False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_adding_tags_and_properties_to_transformation(provider_source_fxt, is_local, is_insecure, request):
+    custom_marks = [mark.name for mark in request.node.own_markers if mark.name != 'parametrize']
+    provider, source, inference_store = request.getfixturevalue(provider_source_fxt)(custom_marks)
+    tags=["user_avg"]
+    properties={"aggregate_type": "avg"}
+    variant = "quickstart"
+    if is_local:
+        @provider.df_transformation(variant=variant, inputs=[("transactions", "quickstart")], tags=tags, properties=properties)
+        def average_user_transaction(transactions):
+            return transactions.groupby("CustomerID")["TransactionAmount"].mean()
+    else:
+        @provider.sql_transformation(variant=variant, tags=tags, properties=properties)
+        def average_user_transaction():
+            return "SELECT customerid as user_id, avg(transactionamount) as avg_transaction_amt from {{transactions.quickstart}} GROUP BY user_id"
+
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply()
+
+    source = resource_client.print_source("average_user_transaction", variant, is_local)
+
+    assert source["tags"] == tags and source["properties"] == properties
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local,is_insecure",
+    [
+        pytest.param("local_provider_source", True, True, marks=pytest.mark.local),
+        pytest.param("hosted_sql_provider_and_source", False, False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_updating_tags_and_properties_for_transformation(provider_source_fxt, is_local, is_insecure, request):
+    custom_marks = [mark.name for mark in request.node.own_markers if mark.name != 'parametrize']
+    provider, source, inference_store = request.getfixturevalue(provider_source_fxt)(custom_marks)
+    tags=["user_avg"]
+    properties={"aggregate_type": "avg"}
+    variant = "quickstart"
+    if is_local:
+        @provider.df_transformation(variant=variant, inputs=[("transactions", "quickstart")], tags=tags, properties=properties)
+        def average_user_transaction(transactions):
+            return transactions.groupby("CustomerID")["TransactionAmount"].mean()
+    else:
+        @provider.sql_transformation(variant=variant, tags=tags, properties=properties)
+        def average_user_transaction():
+            return "SELECT customerid as user_id, avg(transactionamount) as avg_transaction_amt from {{transactions.quickstart}} GROUP BY user_id"
+
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply()
+
+    ff.clear_state()
+
+    additional_tags = ["avg_user_transaction_v2"]
+    additional_properties = {"version": "2"}
+
+    if is_local:
+        @provider.df_transformation(variant=variant, inputs=[("transactions", "quickstart")], tags=additional_tags, properties=additional_properties)
+        def average_user_transaction(transactions):
+            return transactions.groupby("CustomerID")["TransactionAmount"].mean()
+    else:
+        @provider.sql_transformation(variant=variant, tags=additional_tags, properties=additional_properties)
+        def average_user_transaction():
+            return "SELECT customerid as user_id, avg(transactionamount) as avg_transaction_amt from {{transactions.quickstart}} GROUP BY user_id"
+
+    resource_client.apply()
+    source = resource_client.print_source("average_user_transaction", variant, is_local)
+
+    assert set(source["tags"]) == set(tags + additional_tags) and source["properties"] == {**properties, **additional_properties}
+
+
+@pytest.mark.parametrize(
+    "is_local,is_insecure",
+    [
+        pytest.param(True, True, marks=pytest.mark.local),
+        pytest.param(False, False, marks=pytest.mark.hosted),
+        pytest.param(False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_adding_tags_and_properties_to_entity(is_local, is_insecure, request):
+    name = "cc_user"
+    tags = ["customers", "user_ent"]
+    properties = {"entity_name": "user", "is_user_data": "yes",}
+
+    ff.register_entity(name, tags=tags, properties=properties)
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply()
+
+    entity = resource_client.get_entity(name, is_local)
+
+    assert entity["tags"] == tags and entity["properties"] == properties
+
+
+@pytest.mark.parametrize(
+    "is_local,is_insecure",
+    [
+        pytest.param(True, True, marks=pytest.mark.local),
+        pytest.param(False, False, marks=pytest.mark.hosted),
+        pytest.param(False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_updating_tags_and_properties_for_entity(is_local, is_insecure, request):
+    name = "cc_user"
+    tags = ["customers", "user_ent"]
+    properties = {"entity_name": "user", "is_user_data": "yes",}
+
+    ff.register_entity(name, tags=tags, properties=properties)
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply()
+
+    ff.clear_state()
+
+    additional_tags = ["entity_v2"]
+    additional_properties = {"ent_version": "2", "updated_at": "2023-03-12"}
+
+    ff.register_entity(name, tags=additional_tags, properties=additional_properties)
+    resource_client.apply()
+
+    entity = resource_client.get_entity(name, is_local)
+
+    assert set(entity["tags"]) == set(tags + additional_tags) and entity["properties"] == {**properties, **additional_properties}
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local,is_insecure",
+    [
+        pytest.param("local_provider_source", True, True, marks=pytest.mark.local),
+        pytest.param("hosted_sql_provider_and_source", False, False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_adding_tags_and_properties_to_feature(provider_source_fxt, is_local, is_insecure, request):
+    custom_marks = [mark.name for mark in request.node.own_markers if mark.name != 'parametrize']
+    provider, source, inference_store = request.getfixturevalue(provider_source_fxt)(custom_marks)
+    tags = ["tag_1", "tag_2", "tag_3"]
+    properties = {"prop_key_1": "prop_val_1", "prop_key_2": "prop_val_2"}
+    # Arranges the resources context following the Quickstart pattern
+    resource_client = arrange_resources(provider, source, inference_store, tags, properties, is_local, is_insecure)
+
+    feature = resource_client.print_feature("avg_transactions", "quickstart", is_local)
+
+    assert feature["tags"] == tags and feature["properties"] == properties
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local,is_insecure",
+    [
+        pytest.param("local_provider_source", True, True, marks=pytest.mark.local),
+        pytest.param("hosted_sql_provider_and_source", False, False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_updating_tags_and_properties_for_feature(provider_source_fxt, is_local, is_insecure, request):
+    custom_marks = [mark.name for mark in request.node.own_markers if mark.name != 'parametrize']
+    provider, source, inference_store = request.getfixturevalue(provider_source_fxt)(custom_marks)
+    tags = ["tag_1", "tag_2", "tag_3"]
+    properties = {"prop_key_1": "prop_val_1", "prop_key_2": "prop_val_2"}
+    # Arranges the resources context following the Quickstart pattern
+    resource_client = arrange_resources(provider, source, inference_store, tags, properties, is_local, is_insecure)
+
+    ff.clear_state()
+
+    additional_tags = ["tag_4", "tag_5"]
+    additional_properties = {"prop_key_3": "prop_val_3"}
+
+    resource_client = arrange_resources(provider, source, inference_store, additional_tags, additional_properties, is_local, is_insecure)
+
+    feature = resource_client.print_feature("avg_transactions", "quickstart", is_local)
+
+    assert set(feature["tags"]) == set(tags + additional_tags) and feature["properties"] == {**properties, **additional_properties}
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local,is_insecure",
+    [
+        pytest.param("local_provider_source", True, True, marks=pytest.mark.local),
+        pytest.param("hosted_sql_provider_and_source", False, False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_adding_tags_and_properties_to_label(provider_source_fxt, is_local, is_insecure, request):
+    custom_marks = [mark.name for mark in request.node.own_markers if mark.name != 'parametrize']
+    provider, source, inference_store = request.getfixturevalue(provider_source_fxt)(custom_marks)
+    tags = ["tag_1", "tag_2", "tag_3"]
+    properties = {"prop_key_1": "prop_val_1", "prop_key_1": "prop_val_2"}
+    # Arranges the resources context following the Quickstart pattern
+    resource_client = arrange_resources(provider, source, inference_store, tags, properties, is_local, is_insecure)
+
+    label = resource_client.print_label("fraudulent", "quickstart", is_local)
+
+    assert label["tags"] == tags and label["properties"] == properties
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local,is_insecure",
+    [
+        pytest.param("local_provider_source", True, True, marks=pytest.mark.local),
+        pytest.param("hosted_sql_provider_and_source", False, False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_updating_tags_and_properties_for_label(provider_source_fxt, is_local, is_insecure, request):
+    custom_marks = [mark.name for mark in request.node.own_markers if mark.name != 'parametrize']
+    provider, source, inference_store = request.getfixturevalue(provider_source_fxt)(custom_marks)
+    tags = ["tag_1", "tag_2", "tag_3"]
+    properties = {"prop_key_1": "prop_val_1", "prop_key_1": "prop_val_2"}
+    # Arranges the resources context following the Quickstart pattern
+    resource_client = arrange_resources(provider, source, inference_store, tags, properties, is_local, is_insecure)
+
+    ff.clear_state()
+
+    additional_tags = ["tag_4", "tag_5"]
+    additional_properties = {"prop_key_3": "prop_val_3"}
+
+    resource_client = arrange_resources(provider, source, inference_store, additional_tags, additional_properties, is_local, is_insecure)
+
+    label = resource_client.print_label("fraudulent", "quickstart", is_local)
+
+    assert set(label["tags"]) == set(tags + additional_tags) and label["properties"] == {**properties, **additional_properties}
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local,is_insecure",
+    [
+        pytest.param("local_provider_source", True, True, marks=pytest.mark.local),
+        pytest.param("hosted_sql_provider_and_source", False, False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_adding_tags_and_properties_to_training_set(provider_source_fxt, is_local, is_insecure, request):
+    custom_marks = [mark.name for mark in request.node.own_markers if mark.name != 'parametrize']
+    provider, source, inference_store = request.getfixturevalue(provider_source_fxt)(custom_marks)
+    tags = ["tag_1", "tag_2", "tag_3"]
+    properties = {"prop_key_1": "prop_val_1", "prop_key_1": "prop_val_2"}
+    # Arranges the resources context following the Quickstart pattern
+    resource_client = arrange_resources(provider, source, inference_store, tags, properties, is_local, is_insecure, True)
+
+    training_set = resource_client.print_training_set("fraud_training", "quickstart", is_local)
+
+    assert training_set["tags"] == tags and training_set["properties"] == properties
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local,is_insecure",
+    [
+        pytest.param("local_provider_source", True, True, marks=pytest.mark.local),
+        pytest.param("hosted_sql_provider_and_source", False, False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, True, marks=pytest.mark.docker),
+    ]
+)
+def test_updating_tags_and_properties_for_training_set(provider_source_fxt, is_local, is_insecure, request):
+    custom_marks = [mark.name for mark in request.node.own_markers if mark.name != 'parametrize']
+    provider, source, inference_store = request.getfixturevalue(provider_source_fxt)(custom_marks)
+    tags = ["tag_1", "tag_2", "tag_3"]
+    properties = {"prop_key_1": "prop_val_1", "prop_key_1": "prop_val_2"}
+    # Arranges the resources context following the Quickstart pattern
+    resource_client = arrange_resources(provider, source, inference_store, tags, properties, is_local, is_insecure, True)
+
+    ff.clear_state()
+
+    additional_tags = ["tag_4", "tag_5"]
+    additional_properties = {"prop_key_3": "prop_val_3"}
+
+    resource_client = arrange_resources(provider, source, inference_store, additional_tags, additional_properties, is_local, is_insecure, True)
+
+    training_set = resource_client.print_training_set("fraud_training", "quickstart", is_local)
+
+    assert set(training_set["tags"]) == set(tags + additional_tags) and training_set["properties"] == {**properties, **additional_properties}
+
+
+@pytest.fixture(autouse=True)
+def before_and_after_each(setup_teardown):
+    setup_teardown()
+    yield
+    setup_teardown()
+
+
+def arrange_resources(provider, source, online_store, tags, properties, is_local, is_insecure, should_register_training_set=False):
+    if is_local:
+        @provider.df_transformation(variant="quickstart", inputs=[("transactions", "quickstart")])
+        def average_user_transaction(transactions):
+            return transactions.groupby("CustomerID")["TransactionAmount"].mean()
+    else:
+        @provider.sql_transformation(variant="quickstart")
+        def average_user_transaction():
+            return "SELECT customerid as user_id, avg(transactionamount) as avg_transaction_amt from {{transactions.quickstart}} GROUP BY user_id"
+
+    user = ff.register_entity("user")
+    feature_column = "TransactionAmount" if is_local else "avg_transaction_amt"
+    label_column = "IsFraud" if is_local else "isfraud"
+    inference_store = provider if is_local else online_store
+
+    average_user_transaction.register_resources(
+        entity=user,
+        entity_column="CustomerID" if is_local else "user_id",
+        inference_store=inference_store,
+        features=[
+            {"name": "avg_transactions", "variant": "quickstart", "column": feature_column, "type": "float32", "tags": tags, "properties": properties},
+        ],
+    )
+
+    source.register_resources(
+        entity=user,
+        entity_column="CustomerID" if is_local else "customerid",
+        labels=[
+            {"name": "fraudulent", "variant": "quickstart", "column": label_column, "type": "bool", "tags": tags, "properties": properties},
+        ],
+    )
+
+    training_set_name = "fraud_training"
+    training_set_variant = "quickstart"
+
+    if should_register_training_set:
+        ff.register_training_set(
+            training_set_name, training_set_variant,
+            label=("fraudulent", "quickstart"),
+            features=[("avg_transactions", "quickstart")],
+            tags=tags,
+            properties=properties
+        )
+
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply()
+
+    if not is_local and should_register_training_set:
+        start = time.time()
+        while True:
+            time.sleep(3)
+            ts = resource_client.get_training_set(training_set_name, training_set_variant)
+            elapsed_wait = time.time() - start
+            if (elapsed_wait >= 60) and ts.status != "READY":
+                print(f"Wait time for training set status exceeded; status is {ts.status}")
+                break
+            elif ts.status == "READY":
+                print(f"Training set is ready")
+                break
+            else:
+                print(f"Training set status is currently {ts.status} after {elapsed_wait} seconds ...")
+                continue
+
+    return resource_client

--- a/dashboard/src/components/entitypage/EntityPageView.js
+++ b/dashboard/src/components/entitypage/EntityPageView.js
@@ -24,7 +24,7 @@ import json from "react-syntax-highlighter/dist/cjs/languages/prism/json";
 import { okaidia } from "react-syntax-highlighter/dist/cjs/styles/prism";
 
 import VariantControl from "./elements/VariantControl";
-import TagBox from "./elements/TagBox";
+import AttributeBox from "./elements/AttributeBox";
 import MetricsDropdown from "./elements/MetricsDropdown";
 import StatsDropdown from "./elements/StatsDropdown";
 import Resource from "../../api/resources/Resource.js";
@@ -337,7 +337,7 @@ const EntityPageView = ({ entity, setVariant, activeVariants }) => {
           {(Object.keys(metadata).length > 0 && metadata["status"] != "NO_STATUS")&& (
             <div className={classes.resourcesData}>
               <Grid container spacing={0}>
-                <Grid item xs={7} className={classes.resourceMetadata}>
+                <Grid item xs={6} className={classes.resourceMetadata}>
                   {metadata["description"] && (
                     <Typography variant="body1" className={classes.description}>
                       <b>Description:</b> {metadata["description"]}
@@ -519,13 +519,19 @@ const EntityPageView = ({ entity, setVariant, activeVariants }) => {
                     </div>
                   )}
                 </Grid>
-                <Grid item xs={2}></Grid>
-                {enableTags && (
-                  <Grid item xs={3}>
-                    {metadata["tags"] && <TagBox tags={metadata["tags"]} />}
+                {metadata["tags"]?.length > 0 && (
+                  <Grid item xs>
+                    <AttributeBox attributes={metadata["tags"]} title={"Tags"} />
                   </Grid>
                 )}
-              </Grid>
+                {Object.keys(metadata["properties"] || {}).length > 0 && (
+                  <Grid item xs>
+                    {<AttributeBox
+                      attributes={Object.entries(metadata["properties"]).map(([k, v]) => `${k}:${v}`)}
+                      title={"Properties"} />}
+                  </Grid>
+                )}
+                </Grid>
             </div>
           )}
           {metadata["config"] && (

--- a/dashboard/src/components/entitypage/elements/AttributeBox.js
+++ b/dashboard/src/components/entitypage/elements/AttributeBox.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme) => ({
   selectEmpty: {
     marginTop: theme.spacing(2),
   },
-  tags: {
+  attributeContainer: {
     padding: theme.spacing(2),
     borderRadius: "16px",
     border: `1px solid ${theme.palette.border.main}`,
@@ -22,19 +22,25 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const TagBox = ({ tags }) => {
+/**
+ * 
+ * @param {attributes} param0 - ([]string) A list attributes string (e.g. resource tags)
+ * @param {title} param1 - (string) The attributes' title (e.g. "Tags")
+ * @returns {Container}
+ */
+const AttributeBox = ({ attributes, title }) => {
   const classes = useStyles();
 
   return (
-    <Container className={classes.tags}>
+    <Container className={classes.attributeContainer}>
       <Typography variant="h6" component="h5" gutterBottom>
-        Tags
+        {title}
       </Typography>
-      {tags ? (
-        tags.map((tag) => (
+      {attributes ? (
+        attributes.map((attr) => (
           <Chip
-            label={tag}
-            key={tag}
+            label={attr}
+            key={attr}
             className={classes.chip}
             variant="outlined"
           />
@@ -46,4 +52,4 @@ const TagBox = ({ tags }) => {
   );
 };
 
-export default TagBox;
+export default AttributeBox;


### PR DESCRIPTION
# Description

This PR introduces the ability to add tags (i.e. `List[str]`) and properties (i.e. `dict`) to resources. Additionally, users may modify the tags/properties on a previously registered resource (i.e. append only).

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
