### PR TITLE
Localmode Caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ pytest:
 	pytest -m 'local' client/tests/test_getting_model.py
 	pytest -m 'local' client/tests/test_search.py
 	pytest -m 'local' client/tests/test_tags_and_properties.py
+	pytest client/tests/test_localmode_caching.py
 	pytest -m 'local' client/tests/test_class_api.py
 	pytest -m 'local' client/tests/test_ondemand_features.py
 	-rm -r .featureform
@@ -373,7 +374,6 @@ test_e2e: update_python					## Runs End-to-End tests on minikube
 	pytest -m 'hosted' client/tests/test_serving_model.py
 	pytest -m 'hosted' client/tests/test_getting_model.py
 	pytest -m 'hosted' client/tests/test_updating_provider.py
-	pytest -m 'hosted' client/tests/test_class_api.py
 #	pytest -m 'hosted' client/tests/test_search.py
 
 	 echo "Starting end to end tests"

--- a/Makefile
+++ b/Makefile
@@ -223,9 +223,9 @@ pytest:
 	pytest -m 'local' client/tests/test_getting_model.py
 	pytest -m 'local' client/tests/test_search.py
 	pytest -m 'local' client/tests/test_tags_and_properties.py
-	pytest client/tests/test_localmode_caching.py
 	pytest -m 'local' client/tests/test_class_api.py
 	pytest -m 'local' client/tests/test_ondemand_features.py
+	pytest client/tests/test_localmode_caching.py
 	-rm -r .featureform
 	-rm -f transactions.csv
 

--- a/Makefile
+++ b/Makefile
@@ -374,6 +374,7 @@ test_e2e: update_python					## Runs End-to-End tests on minikube
 	pytest -m 'hosted' client/tests/test_serving_model.py
 	pytest -m 'hosted' client/tests/test_getting_model.py
 	pytest -m 'hosted' client/tests/test_updating_provider.py
+	pytest -m 'hosted' client/tests/test_class_api.py
 #	pytest -m 'hosted' client/tests/test_search.py
 
 	 echo "Starting end to end tests"

--- a/client/src/featureform/local_cache.py
+++ b/client/src/featureform/local_cache.py
@@ -1,0 +1,199 @@
+import json
+import os
+from functools import lru_cache
+from typing import Callable, Set
+
+import pandas as pd
+from featureform import SQLiteMetadata  # fix to do client.source.import
+from featureform.local_utils import get_sql_transformation_sources
+from featureform.resources import SourceType  # fix to do client.source.import
+from pandas.core.generic import NDFrame
+from typeguard import typechecked
+
+
+class LocalCache:
+    def __init__(self, db: SQLiteMetadata):
+        self.db = db
+        feature_form_dir = os.environ.get("FEATUREFORM_DIR", ".featureform")
+        self.cache_dir = os.environ.get(
+            "FEATUREFORM_CACHE_DIR", os.path.join(feature_form_dir, "cache")
+        )
+
+    @typechecked
+    def get_or_put(
+        self,
+        resource_type: str,
+        resource_name: str,
+        resource_variant: str,
+        source_name: str,
+        source_variant: str,
+        func: Callable[[], NDFrame],
+    ) -> NDFrame:
+        """
+        Caches the result of a callable to a local file. If the source files have changed, the cache is invalidated.
+        """
+        cache_file_path = self._cache_file_path(
+            resource_type, resource_name, resource_variant
+        )
+
+        # check db for source files
+        source_files_from_db = self.db.get_source_files_for_resource(
+            resource_type, resource_name, resource_variant
+        )
+        if source_files_from_db:
+            self._invalidate_cache_if_source_files_changed(
+                source_files_from_db, cache_file_path
+            )
+
+        # get source files from db or compute the sources
+        source_files: Set[str] = (
+            set(map(lambda x: x["file_path"], source_files_from_db))
+            if source_files_from_db
+            else self.get_source_files_for_source(source_name, source_variant)
+        )
+
+        return self._get_or_put(
+            resource_type,
+            resource_name,
+            resource_variant,
+            cache_file_path,
+            source_files,
+            func,
+        )
+
+    @typechecked
+    def get_or_put_training_set(
+        self,
+        training_set_name: str,
+        training_set_variant: str,
+        func: Callable[[], NDFrame],
+    ) -> NDFrame:
+        """
+        Caches the result of a training set to a local file. Difference between this one and the one above
+        is how this needs to fetch all the source files for the training set.
+        """
+        file_path = self._cache_file_path(
+            "training_set", training_set_name, training_set_variant
+        )
+
+        source_files = set()
+
+        ts_variant = self.db.get_training_set_variant(
+            training_set_name, training_set_variant
+        )
+        label_variant = self.db.get_label_variant(
+            ts_variant["label_name"], ts_variant["label_variant"]
+        )
+        source_files.update(
+            self.get_source_files_for_source(
+                label_variant["source_name"], label_variant["source_variant"]
+            )
+        )
+
+        features = self.db.get_training_set_features(
+            training_set_name, training_set_variant
+        )
+        for feature in features:
+            feature_variant = self.db.get_feature_variant(
+                feature["feature_name"], feature["feature_variant"]
+            )
+            source_files.update(
+                self.get_source_files_for_source(
+                    feature_variant["source_name"],
+                    feature_variant["source_variant"],
+                )
+            )
+
+        return self._get_or_put(
+            "training_set",
+            training_set_name,
+            training_set_variant,
+            file_path,
+            source_files,
+            func,
+        )
+
+    def _get_or_put(
+        self,
+        resource_type,
+        resource_name,
+        resource_variant,
+        file_path,
+        source_files,
+        func,
+    ) -> NDFrame:
+        if os.path.exists(file_path):
+            return pd.read_pickle(file_path)
+        else:
+            # create the dir if not exists and write the file
+            df = func()
+            os.makedirs(self.cache_dir, exist_ok=True)
+            df.to_pickle(file_path)
+            for source_file in source_files:
+                self.db.insert_or_update(
+                    "resource_source_files",
+                    ["resource_type", "name", "variant", "file_path"],
+                    ["updated_at"],
+                    resource_type,
+                    resource_name,
+                    resource_variant,
+                    source_file,
+                    os.path.getmtime(source_file),
+                )
+            return df
+
+    @lru_cache(maxsize=128)
+    def get_source_files_for_source(self, source_name, source_variant) -> Set[str]:
+        """
+        Recursively gets the source files for a given source. Each call is cached.
+        """
+        source = self.db.get_source_variant(source_name, source_variant)
+        transform_type = self.db.is_transformation(source_name, source_variant)
+
+        sources = set()
+        if transform_type == SourceType.PRIMARY_SOURCE.value:
+            return {source["definition"]}
+        elif transform_type == SourceType.SQL_TRANSFORMATION.value:
+            query = source["definition"]
+            transformation_sources = get_sql_transformation_sources(query)
+            for source_name, source_variant in transformation_sources:
+                sources.update(
+                    self.get_source_files_for_source(source_name, source_variant)
+                )
+        elif transform_type == SourceType.DF_TRANSFORMATION.value:
+            dependencies = json.loads(source["inputs"])
+            for name, variant in dependencies:
+                sources.update(self.get_source_files_for_source(name, variant))
+        else:
+            raise Exception(f"Unknown source type: {transform_type}")
+
+        return sources
+
+    def _invalidate_cache_if_source_files_changed(
+        self, source_files_from_db, cache_file_path
+    ):
+        if any(
+            self._file_has_changed(source_file["updated_at"], source_file["file_path"])
+            for source_file in source_files_from_db
+        ):
+            self._delete_cache_file(cache_file_path)
+
+    def _delete_cache_file(self, key):
+        file_path = f"{self.cache_dir}/{key}.pkl"
+        if os.path.exists(file_path):
+            os.remove(file_path)
+
+    def _cache_file_path(self, resource_type: str, name: str, variant: str):
+        key = f"{resource_type}__{name}__{variant}"
+        return f"{self.cache_dir}/{key}.pkl"
+
+    @staticmethod
+    def _file_has_changed(last_updated_at, file_path):
+        """
+        Currently using last updated at for determining if a file has changed. We can consider using the file hash
+        if this becomes a performance issue.
+        """
+        os_last_updated = os.path.getmtime(file_path)
+        if os_last_updated <= float(last_updated_at):
+            return False
+        return True

--- a/client/src/featureform/local_cache.py
+++ b/client/src/featureform/local_cache.py
@@ -176,12 +176,8 @@ class LocalCache:
             self._file_has_changed(source_file["updated_at"], source_file["file_path"])
             for source_file in source_files_from_db
         ):
-            self._delete_cache_file(cache_file_path)
-
-    def _delete_cache_file(self, key):
-        file_path = f"{self.cache_dir}/{key}.pkl"
-        if os.path.exists(file_path):
-            os.remove(file_path)
+            if os.path.exists(cache_file_path):
+                os.remove(cache_file_path)
 
     def _cache_file_path(self, resource_type: str, name: str, variant: str):
         key = f"{resource_type}__{name}__{variant}"
@@ -194,6 +190,4 @@ class LocalCache:
         if this becomes a performance issue.
         """
         os_last_updated = os.path.getmtime(file_path)
-        if os_last_updated <= float(last_updated_at):
-            return False
-        return True
+        return os_last_updated > float(last_updated_at)

--- a/client/src/featureform/local_cache.py
+++ b/client/src/featureform/local_cache.py
@@ -138,7 +138,7 @@ class LocalCache:
                     resource_name,
                     resource_variant,
                     source_file,
-                    os.path.getmtime(source_file),
+                    str(os.path.getmtime(source_file)),
                 )
             return df
 

--- a/client/src/featureform/local_utils.py
+++ b/client/src/featureform/local_utils.py
@@ -1,0 +1,147 @@
+import re
+
+import pandas as pd
+
+
+def get_sql_transformation_sources(query_string):
+    # Use regex to parse query inputs in double curly braces {{ }}
+    return [ts[2:-2].split(".") for ts in re.findall("(?={{).*?(?<=}})", query_string)]
+
+
+def merge_feature_into_ts(feature_row, label_row, df, trainingset_df):
+    if feature_row["source_timestamp"] != "":
+        trainingset_df = pd.merge_asof(
+            trainingset_df,
+            df.sort_values(feature_row["source_timestamp"]),
+            direction="backward",
+            left_on=label_row["source_timestamp"],
+            right_on=feature_row["source_timestamp"],
+            left_by=label_row["source_entity"],
+            right_by=feature_row["source_entity"],
+        )
+        if feature_row["source_timestamp"] != label_row["source_timestamp"]:
+            trainingset_df.drop(columns=feature_row["source_timestamp"], inplace=True)
+    else:
+        df.drop_duplicates(
+            subset=[feature_row["source_entity"]], keep="last", inplace=True
+        )
+        trainingset_df.reset_index(inplace=True)
+        trainingset_df[label_row["source_entity"]] = trainingset_df[
+            label_row["source_entity"]
+        ].astype("string")
+        df[label_row["source_entity"]] = df[label_row["source_entity"]].astype("string")
+        trainingset_df = trainingset_df.join(
+            df.set_index(label_row["source_entity"]),
+            how="left",
+            on=label_row["source_entity"],
+            lsuffix="_left",
+        )
+        if "index" in trainingset_df.columns:
+            trainingset_df.drop(columns="index", inplace=True)
+    return trainingset_df
+
+
+def list_to_combined_df(features_list, entity_id):
+    all_feature_df = None
+    try:
+        for feature in features_list:
+            if all_feature_df is None:
+                all_feature_df = feature
+            else:
+                all_feature_df = all_feature_df.join(
+                    feature.set_index(entity_id), on=entity_id, lsuffix="_left"
+                )
+        return all_feature_df
+    except TypeError:
+        print("Set is empty")
+
+
+def get_features_for_entity(entity_id, entity_value, all_feature_df):
+    entity = all_feature_df.loc[all_feature_df[entity_id] == entity_value].copy()
+    entity.drop(columns=entity_id, inplace=True)
+    if len(entity.values) > 0:
+        return entity.values[0]
+    else:
+        raise Exception(f"No matching entities for {entity_id}: {entity_value}")
+
+
+def feature_df_with_entity(source_path, entity_id, feature):
+    name_variant = f"{feature['name']}.{feature['variant']}"
+    df = pd.read_csv(str(source_path))
+    check_missing_values(feature, df)
+    if feature["source_timestamp"] != "":
+        df = df[
+            [
+                feature["source_entity"],
+                feature["source_value"],
+                feature["source_timestamp"],
+            ]
+        ]
+        df = df.sort_values(by=feature["source_timestamp"], ascending=True)
+        df = df.drop(columns=feature["source_timestamp"])
+    else:
+        df = df[[feature["source_entity"], feature["source_value"]]]
+    df.set_index(feature["source_entity"])
+    df.rename(
+        columns={
+            feature["source_entity"]: entity_id,
+            feature["source_value"]: name_variant,
+        },
+        inplace=True,
+    )
+    df.drop_duplicates(subset=[entity_id], keep="last", inplace=True)
+    return df
+
+
+def check_missing_values(resource, df):
+    if resource["source_entity"] not in df.columns:
+        raise KeyError(f"Entity column does not exist: {resource['source_entity']}")
+    if resource["source_value"] not in df.columns:
+        raise KeyError(f"Value column does not exist: {resource['source_value']}")
+    if (
+        resource["source_timestamp"] not in df.columns
+        and resource["source_timestamp"] != ""
+    ):
+        raise KeyError(
+            f"Timestamp column does not exist: {resource['source_timestamp']}"
+        )
+
+
+def label_df_from_csv(label, file_name):
+    df = pd.read_csv(file_name)
+    check_missing_values(label, df)
+    if label["source_timestamp"] != "":
+        df = df[
+            [label["source_entity"], label["source_value"], label["source_timestamp"]]
+        ]
+        df[label["source_timestamp"]] = pd.to_datetime(df[label["source_timestamp"]])
+        df.sort_values(by=label["source_timestamp"], inplace=True)
+        df.drop_duplicates(
+            subset=[label["source_entity"], label["source_timestamp"]],
+            keep="last",
+            inplace=True,
+        )
+    else:
+        df = df[[label["source_entity"], label["source_value"]]]
+    df.set_index(label["source_entity"], inplace=True)
+    return df
+
+
+def feature_df_from_csv(feature, filename):
+    df = pd.read_csv(str(filename))
+    check_missing_values(feature, df)
+    if feature["source_timestamp"] != "":
+        df = df[
+            [
+                feature["source_entity"],
+                feature["source_value"],
+                feature["source_timestamp"],
+            ]
+        ]
+        df[feature["source_timestamp"]] = pd.to_datetime(
+            df[feature["source_timestamp"]]
+        )
+        df = df.sort_values(by=feature["source_timestamp"], ascending=True)
+    else:
+        df = df[[feature["source_entity"], feature["source_value"]]]
+    return df

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -482,7 +482,7 @@ class LocalClientImpl:
             feature_df = self.process_non_primary_df_transformation(feature, source_name, source_variant, entity_id)
         else:
             source = self.db.get_source_variant(source_name, source_variant)
-            feature_df = self.feature_df_with_entity(source['definition'], entity_id, feature)
+            feature_df = feature_df_with_entity(source['definition'], entity_id, feature)
 
         return feature_df
 

--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -5,6 +5,7 @@ import sys
 import shutil
 import stat
 from tempfile import NamedTemporaryFile
+
 sys.path.insert(0, 'client/src/')
 
 
@@ -180,6 +181,7 @@ def emr(aws_credentials):
 def azure_blob():
     return AzureFileStoreConfig(account_name="", account_key="", container_name="", root_path="")
 
+
 @pytest.fixture(scope="module")
 def s3(aws_credentials):
     return S3StoreConfig("bucket_path", "bucket_region", aws_credentials)
@@ -187,6 +189,7 @@ def s3(aws_credentials):
 
 @pytest.fixture(scope="module")
 def local_provider_source():
+    # empty param to match the signature of the other fixtures
     def get_local(_):
         ff.register_user("test_user").make_default_owner()
         provider = ff.register_local()
@@ -204,8 +207,8 @@ def local_provider_source():
 @pytest.fixture(scope="module")
 def serving_client():
     def get_clients_for_context(is_local, is_insecure):
-            return ff.ServingClient(local=is_local, insecure=is_insecure)
-    
+        return ff.ServingClient(local=is_local, insecure=is_insecure)
+
     return get_clients_for_context
 
 
@@ -231,26 +234,26 @@ def hosted_sql_provider_and_source():
         redis_host = "host.docker.internal" if "docker" in custom_marks else "quickstart-redis"
 
         provider = ff.register_postgres(
-            name = "postgres-quickstart",
+            name="postgres-quickstart",
             # The host name for postgres is different between Docker and Minikube
-            host= "host.docker.internal" if "docker" in custom_marks else "quickstart-postgres",
+            host="host.docker.internal" if "docker" in custom_marks else "quickstart-postgres",
             port="5432",
             user="postgres",
             password="password",
             database="postgres",
-            description = "A Postgres deployment we created for the Featureform quickstart"
+            description="A Postgres deployment we created for the Featureform quickstart"
         )
 
         redis = ff.register_redis(
-            name = "redis-quickstart",
+            name="redis-quickstart",
             # The host name for postgres is different between Docker and Minikube
             host="host.docker.internal" if "docker" in custom_marks else "quickstart-redis",
             port=6379,
         )
 
         source = provider.register_table(
-            name = "transactions",
-            table = "Transactions", # This is the table's name in Postgres
+            name="transactions",
+            table="Transactions",  # This is the table's name in Postgres
             variant="quickstart"
         )
 

--- a/client/tests/serving_cases.py
+++ b/client/tests/serving_cases.py
@@ -556,10 +556,10 @@ training_set = {
         'entity': 'user',
         'entity_loc': 'entity',
         'expected': [
-            [[4, np.NAN, np.NAN, np.NAN, np.NAN], 1],
-            [[2, np.NAN, np.NAN, "first", np.NAN], 9],
-            [[2, np.NAN, np.NAN, "second", np.NAN], 5],
-            [[3, np.NAN, "real value second", np.NAN, np.NAN], 3]
+            [[4, 'NaN', 'NaN', 'NaN', 'NaN'], 1],
+            [[2, 'NaN', 'NaN', "first", 'NaN'], 9],
+            [[2, 'NaN', 'NaN', "second", 'NaN'], 5],
+            [[3, 'NaN', "real value second", 'NaN', 'NaN'], 3]
         ],
     },
 }

--- a/client/tests/test_class_api.py
+++ b/client/tests/test_class_api.py
@@ -116,9 +116,11 @@ def test_indexing_with_fewer_than_two_columns(
 
 
 @pytest.fixture(autouse=True)
-def before_and_after_each(setup_teardown):
+def before_and_after_each(setup_teardown, is_local):
     setup_teardown()
     yield
+    if is_local:
+        ff.ServingClient(local=True).impl.db.close()
     setup_teardown()
 
 

--- a/client/tests/test_class_api.py
+++ b/client/tests/test_class_api.py
@@ -116,11 +116,9 @@ def test_indexing_with_fewer_than_two_columns(
 
 
 @pytest.fixture(autouse=True)
-def before_and_after_each(setup_teardown, is_local):
+def before_and_after_each(setup_teardown):
     setup_teardown()
     yield
-    if is_local:
-        ff.ServingClient(local=True).impl.db.close()
     setup_teardown()
 
 

--- a/client/tests/test_localmode_caching.py
+++ b/client/tests/test_localmode_caching.py
@@ -2,6 +2,7 @@ import os.path
 import shutil
 import stat
 
+import featureform as ff
 import pandas as pd
 import pytest
 from dataclasses import dataclass

--- a/client/tests/test_localmode_caching.py
+++ b/client/tests/test_localmode_caching.py
@@ -99,6 +99,12 @@ def before_after(clear_state):
 
 
 @pytest.fixture(scope="class")
+def close_db(setup):
+    yield
+    setup.serving_client.impl.db.close()
+
+
+@pytest.fixture(scope="class")
 def clear_state():
     def clear_state_and_reset():
         ff.clear_state()

--- a/client/tests/test_localmode_caching.py
+++ b/client/tests/test_localmode_caching.py
@@ -14,9 +14,6 @@ dir_path = os.path.dirname(real_path)
 SOURCE_FILE = f"{dir_path}/test_files/input_files/transactions.csv"
 
 
-# TODO Ali, create clean setup for local mode fixture that anyone can use
-
-
 @dataclass
 class SetupFixture:
     transactions_file: str

--- a/client/tests/test_localmode_caching.py
+++ b/client/tests/test_localmode_caching.py
@@ -1,0 +1,211 @@
+import os.path
+import shutil
+import stat
+
+import featureform as ff
+import pandas as pd
+import pytest
+from dataclasses import dataclass
+from featureform import local, ServingClient
+
+real_path = os.path.realpath(__file__)
+dir_path = os.path.dirname(real_path)
+SOURCE_FILE = f"{dir_path}/test_files/input_files/transactions.csv"
+
+
+# TODO Ali, create clean setup for local mode fixture that anyone can use
+
+
+@dataclass
+class SetupFixture:
+    transactions_file: str
+    serving_client: ServingClient
+
+
+@pytest.fixture()
+def setup(tmp_path, before_after) -> SetupFixture:
+    temp_transactions = tmp_path / "transactions.csv"
+    shutil.copy(SOURCE_FILE, temp_transactions)
+    transactions = local.register_file(
+        name="transactions",
+        variant="quickstart",
+        description="A dataset of fraudulent transactions",
+        path=str(temp_transactions),
+    )
+
+    @local.df_transformation(
+        variant="quickstart", inputs=[("transactions", "quickstart")]
+    )
+    def average_user_transaction(transactions):
+        """the average transaction amount for a user"""
+        return transactions.groupby("CustomerID")["TransactionAmount"].mean()
+
+    user = ff.register_entity("user")
+
+    # Register a column from our transformation as a feature
+    average_user_transaction.register_resources(
+        entity=user,
+        entity_column="CustomerID",
+        inference_store=local,
+        features=[
+            {
+                "name": "avg_transactions",
+                "variant": "quickstart",
+                "column": "TransactionAmount",
+                "type": "float32",
+            },
+        ],
+    )
+
+    # Register label from our base Transactions table
+    transactions.register_resources(
+        entity=user,
+        entity_column="CustomerID",
+        timestamp_column="Timestamp",
+        labels=[
+            {
+                "name": "fraudulent",
+                "variant": "quickstart",
+                "column": "IsFraud",
+                "type": "bool",
+            },
+        ],
+    )
+
+    ff.register_training_set(
+        "fraud_training",
+        "quickstart",
+        label=("fraudulent", "quickstart"),
+        features=[("avg_transactions", "quickstart")],
+    )
+
+    resource_client = ff.ResourceClient(local=True)
+    resource_client.apply()
+
+    serving_client = ff.ServingClient(local=True)
+    serving_client.training_set("fraud_training", "quickstart")
+
+    return SetupFixture(
+        transactions_file=str(temp_transactions), serving_client=serving_client
+    )
+
+
+@pytest.fixture()
+def before_after(clear_state):
+    clear_state()
+    yield
+    clear_state()
+
+
+@pytest.fixture()
+def clear_state():
+    def clear_state_and_reset():
+        ff.clear_state()
+        shutil.rmtree(".featureform", onerror=del_rw)
+
+    return clear_state_and_reset
+
+
+def del_rw(action, name, exc):
+    if os.path.exists(name):
+        os.chmod(name, stat.S_IWRITE)
+        os.remove(name)
+
+
+class TestLocalCache:
+    def test_cache_files_are_created(self, setup):
+        """
+        Sets up local mode with transactions.csv. Registers a transformation, a feature, and a label.
+        Ensures all cached files are created
+        """
+
+        cache_files = os.listdir(".featureform/cache")
+
+        expected_cache_files = [
+            "transformation__average_user_transaction__quickstart.pkl",
+            "feature__avg_transactions__quickstart.pkl",
+            "label__fraudulent__quickstart.pkl",
+            "training_set__fraud_training__quickstart.pkl",
+        ]
+
+        assert os.path.exists(".featureform/cache")
+
+        for expected_file in expected_cache_files:
+            assert (
+                expected_file in cache_files
+            ), f"{expected_file} not found in cache_files"
+
+    def test_label_cached_file_is_read_from(self, setup):
+        fixture = setup
+
+        # make a change to the cached file
+        label_df = pd.read_pickle(
+            ".featureform/cache/label__fraudulent__quickstart.pkl"
+        )
+        label_df["label"] = None
+        label_df.to_pickle(".featureform/cache/label__fraudulent__quickstart.pkl")
+
+        label = fixture.serving_client.impl.db.get_label_variant(
+            "fraudulent", "quickstart"
+        )
+        label_df = fixture.serving_client.impl.get_label_dataframe(label)
+
+        # ensure all label values are null
+        assert label_df["label"].isnull().all()
+
+    def test_transformation_cached_file_is_read_from(self, setup):
+        fixture = setup
+
+        # make a change to the cached file
+        transformation_df = pd.read_pickle(
+            ".featureform/cache/transformation__average_user_transaction__quickstart.pkl"
+        )
+        transformation_df["TransactionAmount"] = 0
+        transformation_df.to_pickle(
+            ".featureform/cache/transformation__average_user_transaction__quickstart.pkl"
+        )
+
+        transformation_df = fixture.serving_client.impl.process_transformation(
+            "average_user_transaction", "quickstart"
+        )
+
+        # ensure all values are 0
+        assert transformation_df["TransactionAmount"].all() == 0
+
+    def test_training_set_cached_file_is_read_from(self, setup):
+        fixture = setup
+
+        # make a change to the cached file
+        training_set_df = pd.read_pickle(
+            ".featureform/cache/training_set__fraud_training__quickstart.pkl"
+        )
+        training_set_df["fraudulent"] = None
+        training_set_df.to_pickle(
+            ".featureform/cache/training_set__fraud_training__quickstart.pkl"
+        )
+
+        training_set = fixture.serving_client.training_set(
+            "fraud_training", "quickstart"
+        )
+        training_set_df = training_set.pandas()
+
+        assert training_set_df["fraudulent"].isnull().all()
+
+    def test_cached_files_are_reset(self, setup):
+        """
+        Ensures all cached files are reset when the files are modified.
+        """
+        fixture = setup
+
+        # modify the file. This should reset the cache
+        transactions = pd.read_csv(fixture.transactions_file)
+        transactions["IsFraud"] = None
+        transactions.to_csv(fixture.transactions_file, index=False)
+
+        label = fixture.serving_client.impl.db.get_label_variant(
+            "fraudulent", "quickstart"
+        )
+        label_df = fixture.serving_client.impl.get_label_dataframe(label)
+
+        # ensure all values are null
+        assert label_df["label"].isnull().all()

--- a/client/tests/test_localmode_caching.py
+++ b/client/tests/test_localmode_caching.py
@@ -220,7 +220,7 @@ class TestLocalCache:
         )
         training_set_df = training_set.pandas()
 
-        assert training_set_df["fraudulent"].isnull().all()
+        assert training_set_df["label"].isnull().all()
 
     def test_transformation_cached_files_are_reset(self, setup):
         """

--- a/client/tests/test_localmode_caching.py
+++ b/client/tests/test_localmode_caching.py
@@ -2,7 +2,6 @@ import os.path
 import shutil
 import stat
 
-import featureform as ff
 import pandas as pd
 import pytest
 from dataclasses import dataclass
@@ -22,9 +21,10 @@ class SetupFixture:
     serving_client: ServingClient
 
 
-@pytest.fixture()
-def setup(tmp_path, before_after) -> SetupFixture:
-    temp_transactions = tmp_path / "transactions.csv"
+@pytest.fixture(scope="class")
+def setup(tmp_path_factory, before_after) -> SetupFixture:
+    temp_dir = tmp_path_factory.mktemp("test_inputs")
+    temp_transactions = temp_dir / "transactions.csv"
     shutil.copy(SOURCE_FILE, temp_transactions)
     transactions = local.register_file(
         name="transactions",
@@ -90,14 +90,14 @@ def setup(tmp_path, before_after) -> SetupFixture:
     )
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def before_after(clear_state):
     clear_state()
     yield
     clear_state()
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def clear_state():
     def clear_state_and_reset():
         ff.clear_state()

--- a/client/tests/test_localmode_caching.py
+++ b/client/tests/test_localmode_caching.py
@@ -23,7 +23,7 @@ class SetupFixture:
     serving_client: ServingClient
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def setup(tmp_path_factory):
     temp_dir = tmp_path_factory.mktemp("test_inputs")
     temp_transactions = temp_dir / "transactions.csv"

--- a/client/tests/test_localmode_include_label_ts.py
+++ b/client/tests/test_localmode_include_label_ts.py
@@ -18,12 +18,6 @@ def setup():
         """the average transaction amount for a user """
         return transactions.groupby("CustomerID")["TransactionAmount"].mean()
 
-    @local.sql_transformation(variant="quickstart")
-    def sql_average_user_transaction():
-        """the average transaction amount for a user """
-        return "SELECT CustomerID as user_id, avg(TransactionAmount) " \
-            "as avg_transaction_amt from {{transactions.kaggle}} GROUP BY user_id"
-
     user = ff.register_entity("user")
 
     # Register a column from our transformation as a feature
@@ -33,15 +27,6 @@ def setup():
         inference_store=local,
         features=[
             {"name": "avg_transactions", "variant": "quickstart", "column": "TransactionAmount", "type": "float32"},
-        ],
-    )
-
-    sql_average_user_transaction.register_resources(
-        entity=user,
-        entity_column="CustomerID",
-        inference_store=local,
-        features=[
-            {"name": "avg_transactions", "variant": "sql", "column": "TransactionAmount", "type": "float32"},
         ],
     )
 

--- a/client/tests/test_ondemand_features.py
+++ b/client/tests/test_ondemand_features.py
@@ -12,6 +12,7 @@ from featureform.resources import OnDemandFeatureDecorator, ResourceStatus
 def before_and_after_each(setup_teardown):
     setup_teardown()
     yield
+    ff.ServingClient(local=True).impl.db.close()  # TODO automatically do this
     setup_teardown()
 
 @pytest.mark.local

--- a/client/tests/test_ondemand_features.py
+++ b/client/tests/test_ondemand_features.py
@@ -9,10 +9,11 @@ from featureform.resources import OnDemandFeatureDecorator, ResourceStatus
 
 
 @pytest.fixture(autouse=True)
-def before_and_after_each(setup_teardown):
+def before_and_after_each(setup_teardown, is_local):
     setup_teardown()
     yield
-    ff.ServingClient(local=True).impl.db.close()  # TODO automatically do this
+    if is_local:
+        ff.ServingClient(local=True).impl.db.close()  # TODO automatically do this
     setup_teardown()
 
 @pytest.mark.local

--- a/client/tests/test_serving_model.py
+++ b/client/tests/test_serving_model.py
@@ -2,6 +2,8 @@ import time
 import featureform as ff
 from featureform.resources import Model
 import pytest
+from featureform.serving import LocalClientImpl
+
 
 @pytest.mark.parametrize(
     "provider_source_fxt,serving_client_fxt,is_local,is_insecure",
@@ -24,6 +26,10 @@ def test_no_models_registered_while_serving_training_set(provider_source_fxt,ser
     models = resource_client.list_models(is_local)
 
     assert len(models) == 0
+
+    # TODO: Shouldn't have to do this
+    if is_local:
+        serving_client.impl.db.close()
 
 
 @pytest.mark.parametrize(
@@ -50,6 +56,9 @@ def test_registering_model_while_serving_training_set(provider_source_fxt,servin
     model = resource_client.get_model(model_name_a, is_local)
 
     assert isinstance(model, Model) and model.name == model_name_a and model.type() == "model"
+
+    if is_local:
+        serving_client.impl.db.close()
 
 
 @pytest.mark.parametrize(
@@ -84,6 +93,9 @@ def test_registering_two_models_while_serving_training_set(provider_source_fxt,s
 
     assert contains_expected_names and are_models_instances
 
+    if is_local:
+        serving_client.impl.db.close()
+
 
 @pytest.mark.parametrize(
     "provider_source_fxt,serving_client_fxt,is_local,is_insecure",
@@ -113,6 +125,9 @@ def test_registering_same_model_twice_while_serving_training_set(provider_source
 
     assert model_name_d in expected and len(expected) == 1 and all([isinstance(model, Model) for model in models])
 
+    if is_local:
+        serving_client.impl.db.close()
+
 
 @pytest.mark.parametrize(
     "provider_source_fxt,serving_client_fxt,is_local,is_insecure",
@@ -137,6 +152,9 @@ def test_registering_model_while_serving_features(provider_source_fxt,serving_cl
     model = resource_client.get_model(model_name_e, is_local)
 
     assert isinstance(model, Model) and model.name == model_name_e and model.type() == "model"
+
+    if is_local:
+        serving_client.impl.db.close()
 
 
 @pytest.mark.parametrize(
@@ -169,6 +187,9 @@ def test_registering_two_models_while_serving_features(provider_source_fxt,servi
 
     assert contains_expected_names and are_models_instances
 
+    if is_local:
+        serving_client.impl.db.close()
+
 
 @pytest.mark.parametrize(
     "provider_source_fxt,serving_client_fxt,is_local,is_insecure",
@@ -195,6 +216,9 @@ def test_registering_same_model_twice_while_serving_features(provider_source_fxt
     expected = [model.name for model in models if model.name == model_name_h]
 
     assert model_name_h in expected and len(expected) == 1 and all([isinstance(model, Model) for model in models])
+
+    if is_local:
+        serving_client.impl.db.close()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
# Description

Added local mode caching

- On serve, all features, labels, transformations, and training sets are cached as .pkl files (we can do parquet too). If the cache file exists the fetch is done from that.
- When requesting a resource, if the source file for that resource has changed, the cache is deleted.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
