### PR TITLE
removes prompt symbol from shell code snippets

### DIFF
--- a/docs/getting-started/interact-with-the-cli.md
+++ b/docs/getting-started/interact-with-the-cli.md
@@ -9,7 +9,7 @@ The **apply** command submits resource definitions to the Featureform instance.&
 The argument can either be a path to a local file or the url of a hosted file. Multiple files can be included at a time.
 
 ```shell
-> featureform apply --host $FEATUREFORM_HOST --cert $FEATUREFORM_CERT <definitions.py>
+featureform apply --host $FEATUREFORM_HOST --cert $FEATUREFORM_CERT <definitions.py>
 ```
 
 Upon success, all definitions in the **definitions.py** (or whatever you choose to call it) file will be sent to the Featureform instance, logged in the metadata, and materialized with the registered providers.
@@ -19,7 +19,7 @@ After applying new resource definitions, you can use the **GET** command to see 
 ## DASH Command
 
 ```shell
-> featureform dash
+featureform dash
 ```
 
 The **DASH** command is used to access the featureform dashboard. It returns a URL to the locally hosted dashboard.
@@ -41,7 +41,7 @@ Each resource can then be clicked on to learn more.
 The **GET** command displays status, variants, and other metadata on a resource.
 
 ```shell
-> featureform get RESOURCE_TYPE NAME [VARIANT] --host $FEATUREFORM_HOST --cert $FEATUREFORM_CERT
+featureform get RESOURCE_TYPE NAME [VARIANT] --host $FEATUREFORM_HOST --cert $FEATUREFORM_CERT
 ```
 
 **RESOURCE\_TYPE** (required) can be:
@@ -66,8 +66,8 @@ The commands are both valid ways to retrieve information on the user **"featuref
 The first is with certification. The second without; the **--insecure** flag disables the need for the **--cert** flag
 
 ```shell
-> featureform get user featureformer --host $FEATUREFORM_HOST --cert $FEATUREFORM_CERT
-> featureform get user featureformer --insecure --host $FEATUREFORM_HOST
+featureform get user featureformer --host $FEATUREFORM_HOST --cert $FEATUREFORM_CERT
+featureform get user featureformer --insecure --host $FEATUREFORM_HOST
 ```
 
 Either command returns the following output.&#x20;
@@ -90,7 +90,7 @@ Listed below the user are all the resources registered to that user.
 The following command shows how to retrieve information on a specific resource, a **feature** named **"avg\_transactions"**.
 
 ```shell
-> featureform get feature avg_transactions --host $FEATUREFORM_HOST --cert $FEATUREFORM_CERT
+featureform get feature avg_transactions --host $FEATUREFORM_HOST --cert $FEATUREFORM_CERT
 
 NAME:  avg_transactions
 STATUS:  NO_STATUS
@@ -106,7 +106,7 @@ prodThis would be the output:
 The command below retrieves information on the specific variant of the **feature** "**avg\_transactions", "quickstart"**
 
 ```shell
-> featureform get feature avg_transactions quickstart --host $FEATUREFORM_HOST --cert $FEATUREFORM_CERT
+featureform get feature avg_transactions quickstart --host $FEATUREFORM_HOST --cert $FEATUREFORM_CERT
 
 NAME:                avg_transactions
 VARIANT:             quickstart     
@@ -133,7 +133,7 @@ Listed below are the metadata on that variant, as well as its source and the tra
 The **LIST** command displays the name, variant and status of all the resources of that resource type.
 
 ```shell
-> featureform list RESOURCE_TYPE --host $FEATUREFORM_HOST –cert $FEATUREFORM_CERT
+featureform list RESOURCE_TYPE --host $FEATUREFORM_HOST –cert $FEATUREFORM_CERT
 ```
 
 **RESOURCE\_TYPE** (required) can be:
@@ -161,7 +161,7 @@ The commands are both valid ways to retrieve a list of users. The first is when 
 The following uses the local flag to access resources created and stored in localmode:
 
 ``` shell
-> featureform list users –-local
+featureform list users –-local
 ```
 
 The above commands return the following list of users which have been registered:
@@ -175,14 +175,14 @@ featureformer      ready
 ### Example: Getting the list of resources of a given type
 
 ```shell
-> featureform list features --host $FEATUREFORM_HOST --cert $FEATUREFORM_CERT
-> featureform list features --insecure --host $FEATUREFORM_HOST
+featureform list features --host $FEATUREFORM_HOST --cert $FEATUREFORM_CERT
+featureform list features --insecure --host $FEATUREFORM_HOST
 ```
 
 In local mode:
 
 ```shell
-> featureform list features –-local
+featureform list features –-local
 ```
 
 The given commands return the list of registered features and their variants

--- a/docs/quickstart-docker.md
+++ b/docs/quickstart-docker.md
@@ -18,7 +18,7 @@ detection dataset using Postgres and Redis.
 ## Step 1: Install The Featureform CLI
 
 ```shell
-> pip install featureform
+pip install featureform
 ```
 
 ## Step 2: Pull Containers
@@ -30,15 +30,15 @@ we'll just be using a sample of it.
 We'll also run the Featureform container in the foreground so logs are available.
 
 ```shell
-> docker run -d -p 5432:5432 featureformcom/postgres
-> docker run -d -p 6379:6379 redis
-> docker run -p 7878:7878 -p 80:80 featureformcom/featureform
+docker run -d -p 5432:5432 featureformcom/postgres
+docker run -d -p 6379:6379 redis
+docker run -p 7878:7878 -p 80:80 featureformcom/featureform
 ```
 
 Note: If using an M1 Mac, run the following command instead for compatibility
 
 ```shell
-> docker run -p 7878:7878 -p 80:80 -e ETCD_ARCH="ETCD_UNSUPPORTED_ARCH=arm64" featureformcom/featureform
+docker run -p 7878:7878 -p 80:80 -e ETCD_ARCH="ETCD_UNSUPPORTED_ARCH=arm64" featureformcom/featureform
 ```
 
 Wait 30-60 seconds to allow the Postgres container to fully initialize the sample data.
@@ -48,7 +48,7 @@ Wait 30-60 seconds to allow the Postgres container to fully initialize the sampl
 We can store the address of our container endpoint for applying definitions and serving later.
 
 ```shell
-> export FEATUREFORM_HOST=localhost:7878 
+export FEATUREFORM_HOST=localhost:7878 
 ```
 
 ## Step 4: Apply Definitions
@@ -58,7 +58,7 @@ Featureform definitions can be stored as both a local file and URL. Multiple fil
 We'll set the `--insecure` flag since we're using an unencrypted endpoint on the container.
 
 ```shell
-> featureform apply https://featureform-demo-files.s3.amazonaws.com/definitions.py --insecure
+featureform apply https://featureform-demo-files.s3.amazonaws.com/definitions.py --insecure
 ```
 
 ## Step 5: Dashboard and Serving
@@ -70,14 +70,14 @@ In the dashboard you should be able to see that 2 Sources, 1 Feature, 1 Label, a
 You can check also check the status of the training set with:
 
 ```shell
-> featureform get training-set fraud_training default --insecure
+featureform get training-set fraud_training default --insecure
 ```
 
 When the status of these resources is READY, you can serve them with:
 
 ```shell
-> curl https://featureform-demo-files.s3.amazonaws.com/serving.py -o serving.py && python serving.py
-> curl https://featureform-demo-files.s3.amazonaws.com/training.py -o training.py && python training.py
+curl https://featureform-demo-files.s3.amazonaws.com/serving.py -o serving.py && python serving.py
+curl https://featureform-demo-files.s3.amazonaws.com/training.py -o training.py && python training.py
 ```
 
 This will download and run sample serving and training scripts, which will serve a single feature value and a sample
@@ -162,7 +162,7 @@ class User:
 
 ff.register_training_set(
     "fraud_training",
-    label="fraudulent",
+    label=("fraudulent", "quickstart"),
     features=["avg_transactions"],
 )
 ```

--- a/docs/quickstart-local.md
+++ b/docs/quickstart-local.md
@@ -16,7 +16,7 @@ description: >-
 Install the Featureform SDK via Pip.
 
 ```shell
-> pip install featureform
+pip install featureform
 ```
 
 ## Step 2: Download test data
@@ -142,7 +142,7 @@ ff.register_training_set(
 Now that our definitions are complete, we can apply it to our Featureform instance.
 
 ```shell
-> featureform apply definitions.py --local
+featureform apply definitions.py --local
 ```
 
 ## Step 4: Serve features for training and inference


### PR DESCRIPTION
# Description

This PR removes the prompt symbol from shell code snippets and corrects an oversight in the code example (e.g. missing label variant) for the Docker quickstart.

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
