### PR TITLE
Class API Enhancement: Optional `timestamp_column` when registering features/labels

### DIFF
--- a/client/tests/test_class_api.py
+++ b/client/tests/test_class_api.py
@@ -49,23 +49,15 @@ def test_class_api_syntax(provider_source_fxt, is_local, is_insecure, request):
     "provider_source_fxt,is_local",
     [
         pytest.param("local_provider_source", True, marks=pytest.mark.local),
-        pytest.param(
-            "hosted_sql_provider_and_source", False, marks=pytest.mark.hosted
-        ),
-        pytest.param(
-            "hosted_sql_provider_and_source", False, marks=pytest.mark.docker
-        ),
+        pytest.param("hosted_sql_provider_and_source", False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, marks=pytest.mark.docker),
     ],
 )
-def test_variants_naming_consistency(
-    provider_source_fxt, is_local, request
-):
+def test_variants_naming_consistency(provider_source_fxt, is_local, request):
     custom_marks = [
         mark.name for mark in request.node.own_markers if mark.name != "parametrize"
     ]
-    _, source, _ = request.getfixturevalue(provider_source_fxt)(
-        custom_marks
-    )
+    _, source, _ = request.getfixturevalue(provider_source_fxt)(custom_marks)
     label_column = "IsFraud" if is_local else "isfraud"
     label_entity_column = "CustomerID" if is_local else "customerid"
 
@@ -92,27 +84,74 @@ def test_variants_naming_consistency(
     "provider_source_fxt,is_local",
     [
         pytest.param("local_provider_source", True, marks=pytest.mark.local),
-        pytest.param(
-            "hosted_sql_provider_and_source", False, marks=pytest.mark.hosted
-        ),
-        pytest.param(
-            "hosted_sql_provider_and_source", False, marks=pytest.mark.docker
-        ),
+        pytest.param("hosted_sql_provider_and_source", False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, marks=pytest.mark.docker),
     ],
 )
-def test_indexing_with_fewer_than_two_columns(
-    provider_source_fxt, is_local, request
-):
+def test_indexing_with_fewer_than_two_columns(provider_source_fxt, is_local, request):
     custom_marks = [
         mark.name for mark in request.node.own_markers if mark.name != "parametrize"
     ]
-    _, source, _ = request.getfixturevalue(provider_source_fxt)(
-        custom_marks
-    )
+    _, source, _ = request.getfixturevalue(provider_source_fxt)(custom_marks)
     label_entity_column = "CustomerID" if is_local else "customerid"
 
     with pytest.raises(Exception, match="Expected 2 columns"):
         source[[label_entity_column]]
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local",
+    [
+        pytest.param("local_provider_source", True, marks=pytest.mark.local),
+        pytest.param("hosted_sql_provider_and_source", False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, marks=pytest.mark.docker),
+    ],
+)
+def test_indexing_with_more_than_three_columns(provider_source_fxt, is_local, request):
+    custom_marks = [
+        mark.name for mark in request.node.own_markers if mark.name != "parametrize"
+    ]
+    _, source, _ = request.getfixturevalue(provider_source_fxt)(custom_marks)
+    label_entity_column = "CustomerID" if is_local else "customerid"
+    label_entity_column = "CustomerID" if is_local else "customerid"
+    label_timestamp_column = "Timestamp" if is_local else "timestamp"
+
+    with pytest.raises(Exception, match="Found unrecognized columns"):
+        source[
+            [
+                label_entity_column,
+                label_entity_column,
+                label_timestamp_column,
+                "unknown_column",
+            ]
+        ]
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local",
+    [
+        pytest.param("local_provider_source", True, marks=pytest.mark.local),
+        pytest.param("hosted_sql_provider_and_source", False, marks=pytest.mark.hosted),
+        pytest.param("hosted_sql_provider_and_source", False, marks=pytest.mark.docker),
+    ],
+)
+def test_specifying_timestamp_column_twice(provider_source_fxt, is_local, request):
+    custom_marks = [
+        mark.name for mark in request.node.own_markers if mark.name != "parametrize"
+    ]
+    _, source, _ = request.getfixturevalue(provider_source_fxt)(custom_marks)
+    label_column = "IsFraud" if is_local else "isfraud"
+    label_entity_column = "CustomerID" if is_local else "customerid"
+    timestamp_column = "Timestamp" if is_local else "timestamp"
+
+    with pytest.raises(Exception, match="Timestamp column specified twice"):
+        ff.Label(
+            source[[label_entity_column, label_column, timestamp_column]],
+            description="Whether a user's transaction is fraudulent.",
+            variant="quickstart",
+            type=ff.Bool,
+            timestamp_column=timestamp_column,
+        )
 
 
 @pytest.fixture(autouse=True)
@@ -139,18 +178,19 @@ def arrange_resources(
         def average_user_transaction():
             return "SELECT customerid as user_id, avg(transactionamount) as avg_transaction_amt from {{transactions.quickstart}} GROUP BY user_id"
 
+    inference_store = provider if is_local else online_store
     feature_column = "TransactionAmount" if is_local else "avg_transaction_amt"
     label_column = "IsFraud" if is_local else "isfraud"
-    inference_store = provider if is_local else online_store
     feature_entity_column = "CustomerID" if is_local else "user_id"
     label_entity_column = "CustomerID" if is_local else "customerid"
+    timestamp_column = "Timestamp" if is_local else "timestamp"
 
     if is_class_api:
 
         @ff.entity
         class User:
             fraudulent = ff.Label(
-                source[[label_entity_column, label_column]],
+                source[[label_entity_column, label_column, timestamp_column]],
                 description="Whether a user's transaction is fraudulent.",
                 variant="quickstart",
                 type=ff.Bool,
@@ -219,4 +259,5 @@ def arrange_resources(
                     "description": "Whether a user's transaction is fraudulent.",
                 },
             ],
+            timestamp_column=timestamp_column,
         )

--- a/docs/getting-started/defining-features-labels-and-training-sets.md
+++ b/docs/getting-started/defining-features-labels-and-training-sets.md
@@ -2,15 +2,15 @@
 
 Once we have our fully transformed sources, we can register their columns as features and labels. We can then join a label with a set of features to create a training set.
 
-## Registering Entities
+## Registering Entities, Features and Labels
 
 Every feature must describe an entity. An entity can be thought of as a primary key table, and every feature must have at least a single foreign key entity field. Common entities include users, items, and purchases. Entities can be anything that a feature can describe.
 
 ```python
-passenger = ff.register_entity("passenger")
+@ff.entity
+class Passenger:
+    # ...
 ```
-
-## Registering Features and Labels
 
 Once our entities are specified, we can begin to associate features and labels with them.
 Features and labels are each made up of at least two columns, an entity column and a value column.
@@ -23,23 +23,19 @@ or a [Transformation.](transforming-data.md#defining-transformations)
 ### Without Timestamp
 
 ```python
-# Register a column from a transformation as a feature
-fare_per_family_member.register_resources(
-    entity=passenger,
-    entity_column="PassengerID",
-    inference_store=redis,
-    features=[
-        {"name": "fpf", "variant": "quickstart", "column": "Fare / Parch", "type": "float64"},
-    ],
-)
-# Register label from the original file
-titanic.register_resources(
-    entity=passenger,
-    entity_column="PassengerID",
-    labels=[
-        {"name": "survived", "variant": "quickstart", "column": "Survived", "type": "int"},
-    ],
-)
+@ff.entity
+class Passenger:
+    # Register a column from a transformation as a feature
+    fpf = ff.Feature(
+        fare_per_family_member[["PassengerID", "Fare / Parch"]],
+        variant="quickstart",
+        type=ff.Float64,
+        inference_store=redis,
+    )
+    # Register label from the original file
+    survived = ff.Label(
+        titanic[["PassengerID", "Survived"]], variant="quickstart", type=ff.Int
+    )
 ```
 
 ### With Timestamp
@@ -47,16 +43,15 @@ titanic.register_resources(
 This example is based off of a fraud training set with a CustomerID, TransactionID, Amount, and Transaction Time.
 
 ```python
-# Register a column from a transformation as a feature
-transactions.register_resources(
-    entity=customer,
-    entity_column="CustomerID",
-    inference_store=redis,
-    features=[
-        {"name": "transaction_amount", "variant": "quickstart", "column": "amount", "type": "float64"},
-    ],
-    timestamp_column="transaction_time"
-)
+@ff.entity
+class Customer:
+    # Register a column from a transformation as a feature
+    transaction_amount = ff.Feature(
+        fare_per_family_member[["CustomerID", "Amount", "Transaction Time"]],
+        variant="quickstart",
+        type=ff.Float64,
+        inference_store=redis,
+    )
 ```
 
 ## Registering Training Sets

--- a/docs/quickstart-docker.md
+++ b/docs/quickstart-docker.md
@@ -152,7 +152,7 @@ A Training Set can be created by joining our feature and label together.
 @ff.entity
 class User:
     avg_transactions = ff.Feature(
-        average_user_transaction[["user_id", "avg_transaction_amt"]],
+        average_user_transaction[["user_id", "avg_transaction_amt"]], # We can optional include the `timestamp_column` "timestamp" here
         type=ff.Float32,
         inference_store=redis,
     )

--- a/docs/quickstart-local.md
+++ b/docs/quickstart-local.md
@@ -83,7 +83,7 @@ Next, we'll register a passenger entity to associate with a feature and label.
 @ff.entity
 class User:
     avg_transactions = ff.Feature(
-        average_user_transaction[["CustomerID", "TransactionAmount"]],
+        average_user_transaction[["CustomerID", "TransactionAmount"]], # We can optional include the `timestamp_column` "Timestamp" here
         variant="quickstart",
         type=ff.Float32,
         inference_store=local,


### PR DESCRIPTION
# Description

This PR gives users the ability to optionally pass a `timestamp_column` when indexing into sources while registering features/labels.

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
