### PR TITLE
Hotfix/register unsorted resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,6 @@ test_e2e: update_python					## Runs End-to-End tests on minikube
 	pytest -m 'hosted' client/tests/test_getting_model.py
 	pytest -m 'hosted' client/tests/test_updating_provider.py
 	pytest -m 'hosted' client/tests/test_class_api.py
-	pytest -m 'hosted' client/tests/test_resource_registration.py
 #	pytest -m 'hosted' client/tests/test_search.py
 
 	 echo "Starting end to end tests"

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,7 @@ pytest:
 	pytest -m 'local' client/tests/test_class_api.py
 	pytest -m 'local' client/tests/test_ondemand_features.py
 	pytest client/tests/test_localmode_caching.py
+	pytest -m 'local' client/tests/test_resource_registration.py
 	-rm -r .featureform
 	-rm -f transactions.csv
 
@@ -375,6 +376,7 @@ test_e2e: update_python					## Runs End-to-End tests on minikube
 	pytest -m 'hosted' client/tests/test_getting_model.py
 	pytest -m 'hosted' client/tests/test_updating_provider.py
 	pytest -m 'hosted' client/tests/test_class_api.py
+	pytest -m 'hosted' client/tests/test_resource_registration.py
 #	pytest -m 'hosted' client/tests/test_search.py
 
 	 echo "Starting end to end tests"

--- a/client/src/featureform/local_dash_test.py
+++ b/client/src/featureform/local_dash_test.py
@@ -1976,8 +1976,12 @@ def check_objs(path, test_obj, client):
     assert response.status == "200 OK"
     json_resource = json.loads(response.data.decode())
     removed_created_json = remove_keys(json_resource, ["created", "definition"])
-    print("++++++++++ ACTUAL", removed_created_json)
-    assert removed_created_json == test_obj
+    if isinstance(removed_created_json, dict):
+        assert test_obj == removed_created_json
+    elif isinstance(removed_created_json, list):
+        actual = {obj["name"]: obj for obj in removed_created_json}
+        expected = {obj["name"]: obj for obj in test_obj}
+        assert actual == expected
 
 
 def test_features(client):

--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -1755,7 +1755,7 @@ class ResourceState:
         return sorted(self.__state.values(), key=to_sort_key)
 
     def create_all_dryrun(self) -> None:
-        for resource in self.__state.values():
+        for resource in self.sorted_list():
             if resource.operation_type() is OperationType.GET:
                 print("Getting", resource.type(), resource.name)
             if resource.operation_type() is OperationType.CREATE:
@@ -1764,7 +1764,7 @@ class ResourceState:
     def create_all_local(self) -> None:
         db = SQLiteMetadata()
         check_up_to_date(True, "register")
-        for resource in self.__state.values():
+        for resource in self.sorted_list():
             if resource.operation_type() is OperationType.GET:
                 print("Getting", resource.type(), resource.name)
                 resource._get_local(db)
@@ -1776,19 +1776,19 @@ class ResourceState:
 
     def create_all(self, stub) -> None:
         check_up_to_date(False, "register")
-        for resource in self.__state.values():
+        for resource in self.sorted_list():
             if resource.type() == "provider" and resource.name == "local-mode":
                 continue
             try:
                 if resource.operation_type() is OperationType.GET:
-                    print("Getting", resource.type(), resource.name)
+                    print(f"Getting {resource.type()} {resource.name}")
                     resource._get(stub)
                 if resource.operation_type() is OperationType.CREATE:
-                    print("Creating", resource.type(), resource.name)
+                    print(f"Creating {resource.type()} {resource.name}")
                     resource._create(stub)
             except grpc.RpcError as e:
                 if e.code() == grpc.StatusCode.ALREADY_EXISTS:
-                    print(resource.name, "already exists.")
+                    print(f"{resource.name} already exists.")
                     continue
 
                 raise e

--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -1780,15 +1780,16 @@ class ResourceState:
             if resource.type() == "provider" and resource.name == "local-mode":
                 continue
             try:
+                resource_variant = resource.variant if hasattr(resource, 'variant') else ''
                 if resource.operation_type() is OperationType.GET:
-                    print(f"Getting {resource.type()} {resource.name}")
+                    print(f"Getting {resource.type()} {resource.name} {resource_variant}")
                     resource._get(stub)
                 if resource.operation_type() is OperationType.CREATE:
-                    print(f"Creating {resource.type()} {resource.name}")
+                    print(f"Creating {resource.type()} {resource.name} {resource_variant}")
                     resource._create(stub)
             except grpc.RpcError as e:
                 if e.code() == grpc.StatusCode.ALREADY_EXISTS:
-                    print(f"{resource.name} already exists.")
+                    print(f"{resource.name} {resource_variant} already exists.")
                     continue
 
                 raise e

--- a/client/tests/test_resource_registration.py
+++ b/client/tests/test_resource_registration.py
@@ -1,0 +1,150 @@
+import time
+import featureform as ff
+import pytest
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local,is_insecure",
+    [
+        pytest.param("local_provider_source", True, True, marks=pytest.mark.local),
+        pytest.param(
+            "hosted_sql_provider_and_source", False, False, marks=pytest.mark.hosted
+        ),
+        pytest.param(
+            "hosted_sql_provider_and_source", False, True, marks=pytest.mark.docker
+        ),
+    ],
+)
+def test_registering_resources_out_of_order(
+    provider_source_fxt, is_local, is_insecure, request
+):
+    custom_marks = [
+        mark.name for mark in request.node.own_markers if mark.name != "parametrize"
+    ]
+    provider, source, inference_store = request.getfixturevalue(provider_source_fxt)(
+        custom_marks
+    )
+    training_set_name = "fraud_training"
+    training_set_variant = "quickstart"
+
+    # Arranges the resources context following the Quickstart pattern
+    arrange_resources_out_of_order(
+        provider,
+        source,
+        inference_store,
+        is_local,
+        training_set_name,
+        training_set_variant,
+    )
+
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply(asynchronous=True)
+    wait_for_training_set(
+        resource_client, training_set_name, training_set_variant, is_local
+    )
+
+    training_set = resource_client.print_training_set(
+        training_set_name, training_set_variant, is_local
+    )
+
+    if is_local:
+        assert training_set is not None and training_set["status"] == "ready"
+    else:
+        assert (
+            training_set is not None
+            and training_set.status.Status._enum_type.values[
+                training_set.status.status
+            ].name
+            == "READY"
+        )
+
+
+@pytest.fixture(autouse=True)
+def before_and_after_each(setup_teardown):
+    setup_teardown()
+    yield
+    setup_teardown()
+
+
+def arrange_resources_out_of_order(
+    provider, source, online_store, is_local, training_set_name, training_set_variant
+):
+    ff.register_training_set(
+        training_set_name,
+        training_set_variant,
+        label=("fraudulent", "quickstart"),
+        features=[("avg_transactions", "quickstart")],
+    )
+
+    if is_local:
+
+        @provider.df_transformation(
+            variant="quickstart", inputs=[("transactions", "quickstart")]
+        )
+        def average_user_transaction(transactions):
+            return transactions.groupby("CustomerID")["TransactionAmount"].mean()
+
+    else:
+
+        @provider.sql_transformation(variant="quickstart")
+        def average_user_transaction():
+            return "SELECT customerid as user_id, avg(transactionamount) as avg_transaction_amt from {{transactions.quickstart}} GROUP BY user_id"
+
+    feature_column = "TransactionAmount" if is_local else "avg_transaction_amt"
+    label_column = "IsFraud" if is_local else "isfraud"
+    inference_store = provider if is_local else online_store
+
+    average_user_transaction.register_resources(
+        entity="user",
+        entity_column="CustomerID" if is_local else "user_id",
+        inference_store=inference_store,
+        features=[
+            {
+                "name": "avg_transactions",
+                "variant": "quickstart",
+                "column": feature_column,
+                "type": "float32",
+            },
+        ],
+    )
+
+    source.register_resources(
+        entity="user",
+        entity_column="CustomerID" if is_local else "customerid",
+        labels=[
+            {
+                "name": "fraudulent",
+                "variant": "quickstart",
+                "column": label_column,
+                "type": "bool",
+            },
+        ],
+    )
+
+    ff.register_entity("user")
+
+
+def wait_for_training_set(
+    resource_client, training_set_name, training_set_variant, is_local
+):
+    if not is_local:
+        start = time.time()
+        while True:
+            time.sleep(3)
+            ts = resource_client.get_training_set(
+                training_set_name, training_set_variant
+            )
+            elapsed_wait = time.time() - start
+            if (elapsed_wait >= 60) and ts.status != "READY":
+                print(
+                    f"Wait time for training set status exceeded; status is {ts.status}"
+                )
+                break
+            elif ts.status == "READY":
+                print(f"Training set is ready")
+                break
+            else:
+                print(
+                    f"Training set status is currently {ts.status} after {elapsed_wait} seconds ..."
+                )
+                continue


### PR DESCRIPTION
# Description

This PR introduces a fix for sorting resources by their graph dependency value prior to creating them in the metadata service, which addresses the issue of users defining resources in an arbitrary order.

## Type of change

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
