### PR TITLE
Bugfix: Consistent global state (disallow resource client to register)

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2988,7 +2988,7 @@ class ResourceClient:
             resources = resource_state.sorted_list()
             display_statuses(self._stub, resources)
 
-        self.clear_state()
+        clear_state()
 
 
     def get_user(self, name, local=False):

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2920,7 +2920,7 @@ class Registrar:
         return model
 
 
-class ResourceClient(Registrar):
+class ResourceClient:
     """The resource client is used to retrieve information on specific resources (entities, providers, features, labels, training sets, models, users). If retrieved resources are needed to register additional resources (e.g. registering a feature from a source), use the [Client](client.md) functions instead.
 
     **Using the Resource Client:**

--- a/client/tests/connection_test.py
+++ b/client/tests/connection_test.py
@@ -1,4 +1,4 @@
-#from featureform import ServingClient, ResourceClient
+import featureform as ff
 import grpc
 import os
 import sys
@@ -12,7 +12,7 @@ def test_metadata_connection():
     metadata_host = os.getenv('METADATA_HOST')
     try:
         client = ResourceClient(host=host, insecure=True)
-        client.register_user("test")
+        ff.register_user("test")
         client.apply()
     # Expect error since metadata server behind api server is not running
     # Checks that the metadata server hostname failed to resolve

--- a/client/tests/serving_test.py
+++ b/client/tests/serving_test.py
@@ -537,16 +537,14 @@ def create_temp_file(test_values):
 
 
 def e2e_features(file, entity_name, entity_loc, name_variants, value_cols, entities, ts_col):
-    resource_client = ResourceClient(local=True)
-    resource_client.register_user("featureformer").make_default_owner()
-    local = resource_client.register_local()
-    transactions = local.register_file(
+    local = ff.local
+    transactions = ff.local.register_file(
         name="transactions",
         variant="v1",
         description="A dataset of fraudulent transactions",
         path=file
     )
-    entity = resource_client.register_entity(entity_name)
+    entity = ff.register_entity(entity_name)
     for i, variant in enumerate(name_variants):
         transactions.register_resources(
             entity=entity,
@@ -557,7 +555,7 @@ def e2e_features(file, entity_name, entity_loc, name_variants, value_cols, entit
             ],
             timestamp_column=ts_col
         )
-    resource_client.state().create_all_local()
+    ResourceClient(local=True).apply()
     client = ServingClient(local=True)
     results = []
     for entity in entities:


### PR DESCRIPTION
# Description

Resource Client had it's own local state separate from the global state. We're no longer providing the ability for the resource client to register resources.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
