### PR TITLE
Bug: Resource Status in CLI List Command

### DIFF
--- a/client/src/featureform/get.py
+++ b/client/src/featureform/get.py
@@ -83,7 +83,8 @@ def get_feature_variant_info(stub, name, variant):
     searchNameVariant = metadata_pb2.NameVariant(name=name, variant=variant)
     try:
         for x in stub.GetFeatureVariants(iter([searchNameVariant])):
-            format_rows([("NAME: ", x.name), 
+            status = x.status.Status._enum_type.values[x.status.status].name
+            rows = [("NAME: ", x.name),
             ("VARIANT: ", x.variant), 
             ("TYPE:", x.type), 
             ("ENTITY:", x.entity),
@@ -91,7 +92,10 @@ def get_feature_variant_info(stub, name, variant):
             ("DESCRIPTION:", x.description),
             ("PROVIDER:", x.provider),
             ("STATUS: ", x.status.Status._enum_type.values[x.status.status].name)
-            ])
+            ]
+            if status == "FAILED":
+                rows.append(("ERROR: ", x.status.error_message))
+            format_rows(rows)
             format_tags_and_properties(x.tags, x.properties)
             format_pg("SOURCE: ")
             format_rows([("NAME", "VARIANT"), (x.source.name, x.source.variant)])
@@ -108,14 +112,18 @@ def get_label_variant_info(stub, name, variant):
     searchNameVariant = metadata_pb2.NameVariant(name=name, variant=variant)
     try:
         for x in stub.GetLabelVariants(iter([searchNameVariant])):
-            format_rows([("NAME: ", x.name),
+            status = x.status.Status._enum_type.values[x.status.status].name
+            rows = [("NAME: ", x.name),
             ("VARIANT: ", x.variant), 
             ("TYPE:", x.type), 
             ("ENTITY:", x.entity), 
             ("OWNER:", x.owner), 
             ("DESCRIPTION:", x.description),
             ("PROVIDER:", x.provider),
-            ("STATUS: ", x.status.Status._enum_type.values[x.status.status].name)])
+            ("STATUS: ", x.status.Status._enum_type.values[x.status.status].name)]
+            if status == "FAILED":
+                rows.append(("ERROR: ", x.status.error_message))
+            format_rows(rows)
             format_tags_and_properties(x.tags, x.properties)
             format_pg("SOURCE: ")
             format_rows([("NAME", "VARIANT"), (x.source.name, x.source.variant)])
@@ -132,13 +140,17 @@ def get_source_variant_info(stub, name, variant):
     searchNameVariant = metadata_pb2.NameVariant(name=name, variant=variant)
     try:
         for x in stub.GetSourceVariants(iter([searchNameVariant])):
-            format_rows([("NAME: ", x.name),
+            status = x.status.Status._enum_type.values[x.status.status].name
+            rows = [("NAME: ", x.name),
             ("VARIANT: ", x.variant), 
             ("OWNER:", x.owner),
             ("DESCRIPTION:", x.description),
             ("PROVIDER:", x.provider),
             ("TABLE:", x.table),
-            ("STATUS: ", x.status.Status._enum_type.values[x.status.status].name)])
+            ("STATUS: ", x.status.Status._enum_type.values[x.status.status].name)]
+            if status == "FAILED":
+                rows.append(("ERROR: ", x.status.error_message))
+            format_rows(rows)
             format_tags_and_properties(x.tags, x.properties)
             format_pg("DEFINITION:")
             print("TRANSFORMATION")
@@ -170,12 +182,16 @@ def get_training_set_variant_info(stub, name, variant):
     searchNameVariant = metadata_pb2.NameVariant(name=name, variant=variant)
     try:
         for x in stub.GetTrainingSetVariants(iter([searchNameVariant])):
-            format_rows([("NAME: ", x.name),
+            status = x.status.Status._enum_type.values[x.status.status].name
+            rows = [("NAME: ", x.name),
             ("VARIANT: ", x.variant),
             ("OWNER:", x.owner),
             ("DESCRIPTION:", x.description),
             ("PROVIDER:", x.provider),
-            ("STATUS: ", x.status.Status._enum_type.values[x.status.status].name)])
+            ("STATUS: ", x.status.Status._enum_type.values[x.status.status].name)]
+            if status == "FAILED":
+                rows.append(("ERROR: ", x.status.error_message))
+            format_rows(rows)
             format_tags_and_properties(x.tags, x.properties)
             format_pg("LABEL: ")
             format_rows([("NAME", "VARIANT"), (x.label.name, x.label.variant)])
@@ -192,12 +208,16 @@ def get_provider_info(stub, name):
     searchName = metadata_pb2.Name(name=name)
     try:
         for x in stub.GetProviders(iter([searchName])):
-            format_rows([("NAME: ", x.name),
+            status = x.status.Status._enum_type.values[x.status.status].name
+            rows = [("NAME: ", x.name),
             ("DESCRIPTION: ", x.description),
             ("TYPE: ", x.type),
             ("SOFTWARE: ", x.software),
             ("TEAM: ", x.team),
-            ("STATUS: ", x.status.Status._enum_type.values[x.status.status].name)])
+            ("STATUS: ", x.status.Status._enum_type.values[x.status.status].name)]
+            if status == "FAILED":
+                rows.append(("ERROR: ", x.status.error_message))
+            format_rows(rows)
             format_tags_and_properties(x.tags, x.properties)
             format_pg("SOURCES:")
             format_rows("NAME", "VARIANT")

--- a/client/src/featureform/list.py
+++ b/client/src/featureform/list.py
@@ -48,7 +48,7 @@ def list_name_variant_status(stub, resource_type):
             searchNameVariant = metadata_pb2.NameVariant(name=f.name, variant=v)
             for x in stub_list_functions[resource_type][1](iter([searchNameVariant])):
                 if x.variant == f.default_variant:
-                    format_rows(f.name, f"{f.default_variant} (default)", f.status.Status._enum_type.values[f.status.status].name)
+                    format_rows(f.name, f"{f.default_variant} (default)", x.status.Status._enum_type.values[x.status.status].name)
                 else:
                     format_rows(x.name, x.variant, x.status.Status._enum_type.values[x.status.status].name)
     return res
@@ -67,7 +67,7 @@ def list_name_variant_status_desc(stub, resource_type):
             searchNameVariant = metadata_pb2.NameVariant(name=f.name, variant=v)
             for x in stub_list_functions[resource_type][1](iter([searchNameVariant])):
                 if x.variant == f.default_variant:
-                    format_rows(f.name, f"{f.default_variant} (default)", f.status.Status._enum_type.values[f.status.status].name, x.description)
+                    format_rows(f.name, f"{f.default_variant} (default)", x.status.Status._enum_type.values[x.status.status].name, x.description)
                 else:
                     format_rows(x.name, x.variant, x.status.Status._enum_type.values[x.status.status].name, x.description)
     return res


### PR DESCRIPTION
# Description

This PR introduces a fix that correctly displays a resource's status in the CLI list command. Additionally, it adds the error message in the CLI get command if the resource has a `FAILED` status.

## Type of change

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
