### PR TITLE
Bugfix: Issue with not allowing Python objects as input to DF Transformation

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2527,7 +2527,7 @@ class Registrar:
             provider = provider.name()
         for i, nv in enumerate(inputs):
             if not isinstance(nv, tuple):
-                inputs[i] = nv.name_variant()
+                inputs[i] = nv.id()
         source = Source(
             name=name,
             variant=variant,
@@ -2578,7 +2578,7 @@ class Registrar:
             provider = provider.name()
         for i, nv in enumerate(inputs):
             if not isinstance(nv, tuple):
-                inputs[i] = nv.name_variant()
+                inputs[i] = nv.id()
         decorator = DFTransformationDecorator(
             registrar=self,
             name=name,

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -601,6 +601,9 @@ class SourceRegistrar:
     def id(self) -> NameVariant:
         return self.__source.name, self.__source.variant
 
+    def name_variant(self) -> NameVariant:
+        return self.id()
+
     def registrar(self):
         return self.__registrar
 
@@ -2527,7 +2530,7 @@ class Registrar:
             provider = provider.name()
         for i, nv in enumerate(inputs):
             if not isinstance(nv, tuple):
-                inputs[i] = nv.id()
+                inputs[i] = nv.name_variant()
         source = Source(
             name=name,
             variant=variant,
@@ -2578,7 +2581,7 @@ class Registrar:
             provider = provider.name()
         for i, nv in enumerate(inputs):
             if not isinstance(nv, tuple):
-                inputs[i] = nv.id()
+                inputs[i] = nv.name_variant()
         decorator = DFTransformationDecorator(
             registrar=self,
             name=name,

--- a/client/tests/test_spark_provider.py
+++ b/client/tests/test_spark_provider.py
@@ -87,16 +87,19 @@ def test_sql_transformation(name, variant, sql, spark_provider):
 
 
 @pytest.mark.parametrize(
-    "name,variant,transformation",
+    "name,variant,inputs,transformation",
     [
-        ("test_name", "test_variant","avg_user_transaction"),
+        ("test_input", "primary_dataset", "primary_dataset", "avg_user_transaction"),
+        ("test_input", "df_transformation", "df_transformation_src", "avg_user_transaction"),
+        ("test_input", "sql_transformation", "sql_transformation_src", "avg_user_transaction"),
+        ("test_input", "tuples", "tuple_inputs", "avg_user_transaction"),
     ]
 )
-def test_df_transformation(name, variant, transformation, spark_provider, request):
+def test_df_transformation(name, variant, inputs, transformation, spark_provider, request):
     df_transformation = request.getfixturevalue(transformation)
+    inputs = request.getfixturevalue(inputs)
 
-    src_variant = f"{variant}_src"
-    decorator = spark_provider.df_transformation(name=name, variant=variant, inputs=[(name, src_variant)])
+    decorator = spark_provider.df_transformation(name=name, variant=variant, inputs=inputs)
     decorator(df_transformation)
 
     query = dill.dumps(df_transformation.__code__)
@@ -105,7 +108,7 @@ def test_df_transformation(name, variant, transformation, spark_provider, reques
     expected_src = Source(
         name=name,
         variant=variant,
-        definition=DFTransformation(query=query, inputs=[(name, src_variant)]),
+        definition=DFTransformation(query=query, inputs=inputs),
         owner="tester",
         provider="spark",
         description="doc string",

--- a/tests/end_to_end/definitions/kcf_custom_image_definitions.py
+++ b/tests/end_to_end/definitions/kcf_custom_image_definitions.py
@@ -67,7 +67,7 @@ ice_cream = k8s.register_file(
 
 @k8s.df_transformation(name=f"ice_cream_entity_{VERSION}",
                        variant=VERSION,
-                       inputs=[(f"ice_cream_{VERSION}", VERSION)])
+                       inputs=[ice_cream])
 def ice_cream_entity_transformation(df):
     """ the ice cream dataset with entity """
     df["entity"] = "farm"

--- a/tests/end_to_end/definitions/ondemand_features_definitions.py
+++ b/tests/end_to_end/definitions/ondemand_features_definitions.py
@@ -79,7 +79,7 @@ ice_cream_dataset = spark.register_parquet_file(
 
 @spark.df_transformation(name=f"ice_cream_transformation_{VERSION}",
                         variant=VERSION,
-                        inputs=[(f"ice_cream_{VERSION}", VERSION)])
+                        inputs=[ice_cream_dataset])
 def ice_cream_transformation(df):
     """the ice cream dataset """
     return df


### PR DESCRIPTION
# Description
Previously, there was an issue with using Python objects as inputs to DF Transformation. The issue has been resolved with this PR. 

Now, we can use the following: 
```
transactions = spark.register_file(
    name="transactions",
    file_path=".......",
)

@spark.df_transformation(inputs=[transactions])
def outlier_transactions(df):
    return df
```

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->
Closes #695

### Select type(s) of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
