### PR TITLE
Bug fix: Checks existence of training set features prior to creation

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -637,6 +637,12 @@ func (serv *MetadataServer) CreateTrainingSetVariant(ctx context.Context, train 
 	if err != nil {
 		return nil, err
 	}
+	for _, protoFeature := range train.Features {
+		_, err := serv.client.GetFeatureVariant(ctx, metadata.NameVariant{protoFeature.Name, protoFeature.Variant})
+		if err != nil {
+			return nil, err
+		}
+	}
 	train.Provider = label.Provider()
 	return serv.meta.CreateTrainingSetVariant(ctx, train)
 }


### PR DESCRIPTION
# Description

This PR introduces a check on a training set's features prior to creating the training set in the metadata service.

## Type of change

Addresses [Issue #692](https://github.com/featureform/featureform/issues/692)

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
