### PR TITLE
throwing an error if input tuple is not of type (str, str)

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2867,6 +2867,8 @@ class Registrar:
         for i, nv in enumerate(inputs):
             if not isinstance(nv, tuple):
                 inputs[i] = nv.name_variant()
+            if isinstance(nv, tuple):
+                self._verify_tuple(nv)
         decorator = DFTransformationDecorator(
             registrar=self,
             name=name,
@@ -2881,6 +2883,18 @@ class Registrar:
         )
         self.__resources.append(decorator)
         return decorator
+
+    def _verify_tuple(self, tuple):
+        if len(tuple) != 2:
+            raise TypeError(
+                "Tuple must be of length 2, got length {}".format(len(tuple))
+            )
+        if len(tuple) == 2:
+            not_string_tuples = not (isinstance(tuple[0], str) and isinstance(tuple[1], str))
+            if not_string_tuples:
+                first_position_type = type(tuple[0]).__name__
+                second_position_type = type(tuple[1]).__name__
+                raise TypeError(f"input tuple must be of type (str, str); got ({first_position_type}, {second_position_type})")
 
     def ondemand_feature(
         self,

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2876,7 +2876,7 @@ class Registrar:
                         transformation_message = f"with '{variant}' variant"
 
                     raise TypeError(
-                        f"DF transformation {transformation_message} requires correct inputs " \
+                        f"DF transformation {transformation_message} requires correct inputs "
                         f" '{nv}' is not a valid tuple: {e}"
                     )
 

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2884,20 +2884,23 @@ class Registrar:
         self.__resources.append(decorator)
         return decorator
 
-    def _verify_tuple(self, tuple):
-        if len(tuple) != 2:
+    def _verify_tuple(self, nv_tuple):
+        if not isinstance(nv_tuple, tuple):
+            raise TypeError(f"not a tuple; received: '{type(nv_tuple).__name__}' type")
+
+        if len(nv_tuple) != 2:
             raise TypeError(
-                "Tuple must be of length 2, got length {}".format(len(tuple))
+                "Tuple must be of length 2, got length {}".format(len(nv_tuple))
             )
-        if len(tuple) == 2:
+        if len(nv_tuple) == 2:
             not_string_tuples = not (
-                isinstance(tuple[0], str) and isinstance(tuple[1], str)
+                isinstance(nv_tuple[0], str) and isinstance(nv_tuple[1], str)
             )
             if not_string_tuples:
-                first_position_type = type(tuple[0]).__name__
-                second_position_type = type(tuple[1]).__name__
+                first_position_type = type(nv_tuple[0]).__name__
+                second_position_type = type(nv_tuple[1]).__name__
                 raise TypeError(
-                    f"input tuple must be of type (str, str); got ({first_position_type}, {second_position_type})"
+                    f"Tuple must be of type (str, str); got ({first_position_type}, {second_position_type})"
                 )
 
     def ondemand_feature(

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2868,7 +2868,18 @@ class Registrar:
             if not isinstance(nv, tuple):
                 inputs[i] = nv.name_variant()
             if isinstance(nv, tuple):
-                self._verify_tuple(nv)
+                try:
+                    self._verify_tuple(nv)
+                except TypeError as e:
+                    transformation_message = f"'{name}:{variant}'"
+                    if name == "":
+                        transformation_message = f"with '{variant}' variant"
+
+                    raise TypeError(
+                        f"DF transformation {transformation_message} requires correct inputs " \
+                        f" '{nv}' is not a valid tuple: {e}"
+                    )
+
         decorator = DFTransformationDecorator(
             registrar=self,
             name=name,

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2890,11 +2890,15 @@ class Registrar:
                 "Tuple must be of length 2, got length {}".format(len(tuple))
             )
         if len(tuple) == 2:
-            not_string_tuples = not (isinstance(tuple[0], str) and isinstance(tuple[1], str))
+            not_string_tuples = not (
+                isinstance(tuple[0], str) and isinstance(tuple[1], str)
+            )
             if not_string_tuples:
                 first_position_type = type(tuple[0]).__name__
                 second_position_type = type(tuple[1]).__name__
-                raise TypeError(f"input tuple must be of type (str, str); got ({first_position_type}, {second_position_type})")
+                raise TypeError(
+                    f"input tuple must be of type (str, str); got ({first_position_type}, {second_position_type})"
+                )
 
     def ondemand_feature(
         self,

--- a/client/tests/register_test.py
+++ b/client/tests/register_test.py
@@ -148,6 +148,38 @@ def test_get_snowflake_functions(provider_name, func):
     assert offlineSQLProvider.name() == provider_name
 
 
+@pytest.mark.parametrize(
+    "tuple,error",
+    [
+        (("name", "variant"), None),
+        (
+            ("name", "variant", "owner"),
+            TypeError("Tuple must be of length 2, got length 3"),
+        ),
+        (("name"), TypeError("not a tuple; received: 'str' type")),
+        (
+            ("name",),
+            TypeError("Tuple must be of length 2, got length 1"),
+        ),
+        (
+            ("name", [1, 2, 3]),
+            TypeError("Tuple must be of type (str, str); got (str, list)"),
+        ),
+        (
+            ([1, 2, 3], "variant"),
+            TypeError("Tuple must be of type (str, str); got (list, str)"),
+        ),
+    ],
+)
+def test_local_provider_verify_inputs(tuple, error):
+    try:
+        r = Registrar()
+        assert r._verify_tuple(tuple) is None and error is None
+    except Exception as e:
+        assert type(e).__name__ == type(error).__name__
+        assert str(e) == str(error)
+
+
 def del_rw(action, name, exc):
     os.chmod(name, stat.S_IWRITE)
     os.remove(name)


### PR DESCRIPTION
# Description
```
@local.df_transformation(
    variant="v1",
    inputs=[(compute_user_age, "v1")]
)
```
threw a useless error but now throws an error 
```
TypeError: input tuple must be of type (str, str); got (LocalSource, str)
```

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->
Closes #779 

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
