### PR TITLE
Optional TLS Cert

### DIFF
--- a/charts/featureform/charts/ingress/templates/grpc-ingress.yaml
+++ b/charts/featureform/charts/ingress/templates/grpc-ingress.yaml
@@ -16,7 +16,7 @@ metadata:
   name: grpc-ingress
 spec:
   rules:
-    {{ if not .Values.global.hostname }}
+    {{ if .Values.global.hostname }}
     - host: {{ .Values.global.hostname }}
     {{ end }}
     - http:

--- a/charts/featureform/charts/ingress/templates/grpc-ingress.yaml
+++ b/charts/featureform/charts/ingress/templates/grpc-ingress.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.global.embeddedIngress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -15,8 +16,10 @@ metadata:
   name: grpc-ingress
 spec:
   rules:
+    {{ if not .Values.global.hostname }}
     - host: {{ .Values.global.hostname }}
-      http:
+    {{ end }}
+    - http:
         paths:
           - path: /featureform.serving.metadata.proto.Api/
             pathType: Prefix
@@ -35,9 +38,10 @@ spec:
                   number: 7878
 
 
-
+{{ if .Values.global.tls.enabled }}
   tls:
     - hosts:
         -  {{ .Values.global.hostname }}
       secretName: featureform-ca-secret
-
+{{ end }}
+{{ end }}

--- a/charts/featureform/charts/ingress/templates/grpc-ingress.yaml
+++ b/charts/featureform/charts/ingress/templates/grpc-ingress.yaml
@@ -38,10 +38,10 @@ spec:
                   number: 7878
 
 
-{{ if .Values.global.tls.enabled }}
+  {{ if .Values.global.tls.enabled }}
   tls:
     - hosts:
         -  {{ .Values.global.hostname }}
       secretName: featureform-ca-secret
-{{ end }}
+  {{ end }}
 {{ end }}

--- a/charts/featureform/charts/ingress/templates/http-ingress.yaml
+++ b/charts/featureform/charts/ingress/templates/http-ingress.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.global.embeddedIngress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -18,8 +19,10 @@ spec:
       port:
         number: 80
   rules:
+    {{ if not .Values.global.hostname }}
     - host: {{ .Values.global.hostname }}
-      http:
+    {{ end }}
+    - http:
         paths:
           - path: /data/
             pathType: Prefix
@@ -51,4 +54,4 @@ spec:
                   number: 80
 
 
-
+{{ end }}

--- a/charts/featureform/charts/ingress/templates/http-ingress.yaml
+++ b/charts/featureform/charts/ingress/templates/http-ingress.yaml
@@ -19,7 +19,7 @@ spec:
       port:
         number: 80
   rules:
-    {{ if not .Values.global.hostname }}
+    {{ if .Values.global.hostname }}
     - host: {{ .Values.global.hostname }}
     {{ end }}
     - http:

--- a/charts/featureform/values.yaml
+++ b/charts/featureform/values.yaml
@@ -94,6 +94,8 @@ global:
   embeddedIngress:
     disabled: true
     enabled: false
+  tls:
+    enabled: true
 
 
 metadata:


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes tls certs optional by adding flags:
global.hostname=""
global.publicCert=false
global.localCert=false
global.tls.enabled=false

Then running:
`kubectl expose deployment featureform-api-server --type=LoadBalancer --name=api-service`

Which will create an insecure IP address that can be connected to. Dashboard works normally

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
