### PR TITLE
[BUGFIX] Fix missing executor type in differing fields check for SparkProvider

### DIFF
--- a/provider/provider_config/spark_config.go
+++ b/provider/provider_config/spark_config.go
@@ -148,6 +148,8 @@ func (a SparkConfig) DifferingFields(b SparkConfig) (ss.StringSet, error) {
 		executorFields, err = a.ExecutorConfig.(*EMRConfig).DifferingFields(*b.ExecutorConfig.(*EMRConfig))
 	case Databricks:
 		executorFields, err = a.ExecutorConfig.(*DatabricksConfig).DifferingFields(*b.ExecutorConfig.(*DatabricksConfig))
+	case SparkGeneric:
+		executorFields, err = a.ExecutorConfig.(*SparkGenericConfig).DifferingFields(*b.ExecutorConfig.(*SparkGenericConfig))
 	default:
 		return nil, fmt.Errorf("unknown executor type: %v", a.ExecutorType)
 	}

--- a/provider/provider_config/spark_config_test.go
+++ b/provider/provider_config/spark_config_test.go
@@ -234,6 +234,69 @@ func TestSparkConfigDifferingFields(t *testing.T) {
 				"Store.AccountKey":  true,
 			}, false,
 		},
+		{"SparkGeneric + S3 No Differing Fields", args{
+			a: SparkConfig{
+				ExecutorType: SparkGeneric,
+				ExecutorConfig: &SparkGenericConfig{
+					Master:     "my.spark.cluster.io:7077",
+					DeployMode: "cluster",
+				},
+				StoreType: S3,
+				StoreConfig: &S3FileStoreConfig{
+					Credentials:  AWSCredentials{AWSAccessKeyId: "aws-key", AWSSecretKey: "aws-secret"},
+					BucketRegion: "us-east-1",
+					BucketPath:   "https://featureform.s3.us-east-1.amazonaws.com/transactions",
+					Path:         "https://featureform.s3.us-east-1.amazonaws.com/transactions",
+				},
+			},
+			b: SparkConfig{
+				ExecutorType: SparkGeneric,
+				ExecutorConfig: &SparkGenericConfig{
+					Master:     "my.spark.cluster.io:7077",
+					DeployMode: "cluster",
+				},
+				StoreType: S3,
+				StoreConfig: &S3FileStoreConfig{
+					Credentials:  AWSCredentials{AWSAccessKeyId: "aws-key", AWSSecretKey: "aws-secret"},
+					BucketRegion: "us-east-1",
+					BucketPath:   "https://featureform.s3.us-east-1.amazonaws.com/transactions",
+					Path:         "https://featureform.s3.us-east-1.amazonaws.com/transactions",
+				},
+			},
+		}, ss.StringSet{}, false},
+		{"SparkGeneric + S3 Differing Fields", args{
+			a: SparkConfig{
+				ExecutorType: SparkGeneric,
+				ExecutorConfig: &SparkGenericConfig{
+					Master:     "my.spark.cluster.io:7077",
+					DeployMode: "cluster",
+				},
+				StoreType: S3,
+				StoreConfig: &S3FileStoreConfig{
+					Credentials:  AWSCredentials{AWSAccessKeyId: "aws-key", AWSSecretKey: "aws-secret"},
+					BucketRegion: "us-east-1",
+					BucketPath:   "https://featureform.s3.us-east-1.amazonaws.com/transactions",
+					Path:         "https://featureform.s3.us-east-1.amazonaws.com/transactions",
+				},
+			},
+			b: SparkConfig{
+				ExecutorType: SparkGeneric,
+				ExecutorConfig: &SparkGenericConfig{
+					Master:     "my.other.spark.cluster.io:7077",
+					DeployMode: "cluster",
+				},
+				StoreType: S3,
+				StoreConfig: &S3FileStoreConfig{
+					Credentials:  AWSCredentials{AWSAccessKeyId: "aws-key", AWSSecretKey: "aws-secret"},
+					BucketRegion: "us-west-2",
+					BucketPath:   "https://featureform.s3.us-east-1.amazonaws.com/transactions",
+					Path:         "https://featureform.s3.us-east-1.amazonaws.com/transactions",
+				},
+			},
+		}, ss.StringSet{
+			"Executor.Master":    true,
+			"Store.BucketRegion": true,
+		}, false},
 		{"Executor Config Mismatch: EMR -> Databricks", args{
 			a: SparkConfig{
 				ExecutorType: EMR,


### PR DESCRIPTION
# Description

Currently unable to update spark provider with generic spark executor due to differing config check missing SparkGeneric as one of its possible executor options. This PR hopefully fixes that issue. 

Error thrown by client:
```
> featureform apply definitions.py --insecure
...
...
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
 status = StatusCode.UNKNOWN
 details = "unknown executor type: SPARK"
 debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2023-05-03T20:47:58.156508+08:00", grpc_status:2, grpc_message:"unknown executor type: SPARK"}"
```

## Type of change

### Does this correspond to an open issue?

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [NA] I have commented my code, particularly in hard-to-understand areas 
- [NA] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
