### PR TITLE
Training Sets as Dataframes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,7 @@ pytest:
 	pytest -m 'local' client/tests/test_ondemand_features.py
 	pytest -m 'local' client/tests/test_resource_registration.py
 	pytest -m 'local' client/tests/test_source_dataframe.py
+	pytest -m 'local' client/tests/test_training_set_dataframe.py
 	-rm -r .featureform
 	-rm -f transactions.csv
 
@@ -391,6 +392,7 @@ test_e2e: update_python					## Runs End-to-End tests on minikube
 	pytest -m 'hosted' client/tests/test_updating_provider.py
 	pytest -m 'hosted' client/tests/test_class_api.py
 	pytest -m 'hosted' client/tests/test_source_dataframe.py
+	pytest -m 'hosted' client/tests/test_training_set_dataframe.py
 #	pytest -m 'hosted' client/tests/test_search.py
 
 	 echo "Starting end to end tests"

--- a/api/main.go
+++ b/api/main.go
@@ -678,6 +678,11 @@ func (serv *OnlineServer) TrainingData(req *srv.TrainingDataRequest, stream srv.
 	}
 }
 
+func (serv *OnlineServer) TrainingDataColumns(ctx context.Context, req *srv.TrainingDataColumnsRequest) (*srv.TrainingColumns, error) {
+	serv.Logger.Infow("Serving Training Set Columns", "id", req.Id.String())
+	return serv.client.TrainingDataColumns(ctx, req)
+}
+
 func (serv *OnlineServer) SourceData(req *srv.SourceDataRequest, stream srv.Feature_SourceDataServer) error {
 	serv.Logger.Infow("Serving Source Data", "id", req.Id.String())
 	if req.Limit == 0 {

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -846,7 +846,9 @@ class Dataset:
             req = serving_pb2.TrainingDataRequest(id=id)
             cols = stub.TrainingDataColumns(req)
             data = [r.to_dict(cols.features, cols.label) for r in self._stream]
-            self._dataframe = pd.DataFrame(data=data, columns=[*cols.features, cols.label])
+            self._dataframe = pd.DataFrame(
+                data=data, columns=[*cols.features, cols.label]
+            )
             return self._dataframe
 
     def from_dataframe(dataframe, include_label_timestamp):

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -846,13 +846,16 @@ class Dataset:
             req = serving_pb2.TrainingDataRequest(id=id)
             cols = stub.TrainingDataColumns(req)
             data = [r.to_dict(cols.features, cols.label) for r in self._stream]
-            return pd.DataFrame(data=data, columns=[*cols.features, cols.label])
+            self._dataframe = pd.DataFrame(data=data, columns=[*cols.features, cols.label])
+            return self._dataframe
 
     def from_dataframe(dataframe, include_label_timestamp):
         stream = LocalStream(dataframe.values.tolist(), include_label_timestamp)
         return Dataset(stream, dataframe)
 
     def pandas(self):
+        if self._dataframe is None:
+            _ = self.dataframe()
         return self._dataframe
 
     def repeat(self, num):

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -856,6 +856,10 @@ class Dataset:
         return Dataset(stream, dataframe)
 
     def pandas(self):
+        warnings.warn(
+            "Dataset.pandas() is deprecated and will be removed in future versions; use Dataset.dataframe() instead.",
+            PendingDeprecationWarning,
+        )
         if self._dataframe is None:
             _ = self.dataframe()
         return self._dataframe

--- a/client/tests/test_training_set_dataframe.py
+++ b/client/tests/test_training_set_dataframe.py
@@ -1,0 +1,143 @@
+import time
+import pytest
+import pandas as pd
+import featureform as ff
+from featureform import Client
+
+
+@pytest.mark.parametrize(
+    "provider_source_fxt,is_local,is_insecure",
+    [
+        pytest.param(
+            "local_provider_source",
+            True,
+            True,
+            marks=pytest.mark.local,
+        ),
+        pytest.param(
+            "hosted_sql_provider_and_source",
+            False,
+            False,
+            marks=pytest.mark.hosted,
+        ),
+        pytest.param(
+            "hosted_sql_provider_and_source",
+            False,
+            True,
+            marks=pytest.mark.docker,
+        ),
+    ],
+)
+def test_training_set_as_dataframe(provider_source_fxt, is_local, is_insecure, request):
+    custom_marks = [
+        mark.name for mark in request.node.own_markers if mark.name != "parametrize"
+    ]
+    provider, source, inference_store = request.getfixturevalue(provider_source_fxt)(
+        custom_marks
+    )
+
+    # Arranges the resources context following the Quickstart pattern
+    ts_name, ts_variant = arrange_resources(
+        provider, source, inference_store, is_local, is_insecure
+    )
+
+    client = Client(local=is_local, insecure=is_insecure)
+    ts_df = client.training_set(ts_name, ts_variant).dataframe()
+
+    assert isinstance(ts_df, pd.DataFrame) and len(ts_df) > 0
+
+    # TODO: Shouldn't have to do this
+    if is_local:
+        client.impl.db.close()
+
+
+@pytest.fixture(autouse=True)
+def before_and_after_each(setup_teardown):
+    setup_teardown()
+    yield
+    setup_teardown()
+
+
+def arrange_resources(provider, source, online_store, is_local, is_insecure):
+    if is_local:
+
+        @provider.df_transformation(
+            variant="quickstart", inputs=[("transactions", "quickstart")]
+        )
+        def average_user_transaction(transactions):
+            return transactions.groupby("CustomerID")["TransactionAmount"].mean()
+
+    else:
+
+        @provider.sql_transformation(variant="quickstart")
+        def average_user_transaction():
+            return "SELECT customerid as user_id, avg(transactionamount) as avg_transaction_amt from {{transactions.quickstart}} GROUP BY user_id"
+
+    user = ff.register_entity("user")
+    feature_column = "TransactionAmount" if is_local else "avg_transaction_amt"
+    label_column = "IsFraud" if is_local else "isfraud"
+    inference_store = provider if is_local else online_store
+
+    average_user_transaction.register_resources(
+        entity=user,
+        entity_column="CustomerID" if is_local else "user_id",
+        inference_store=inference_store,
+        features=[
+            {
+                "name": "avg_transactions",
+                "variant": "quickstart",
+                "column": feature_column,
+                "type": "float32",
+            },
+        ],
+    )
+
+    source.register_resources(
+        entity=user,
+        entity_column="CustomerID" if is_local else "customerid",
+        labels=[
+            {
+                "name": "fraudulent",
+                "variant": "quickstart",
+                "column": label_column,
+                "type": "bool",
+            },
+        ],
+    )
+
+    training_set_name = "fraud_training"
+    training_set_variant = "quickstart"
+
+    ff.register_training_set(
+        training_set_name,
+        training_set_variant,
+        label=("fraudulent", "quickstart"),
+        features=[("avg_transactions", "quickstart")],
+    )
+
+    resource_client = ff.ResourceClient(local=is_local, insecure=is_insecure)
+    resource_client.apply(asynchronous=True)
+
+    if not is_local:
+        start = time.time()
+        while True:
+            time.sleep(3)
+            ts = resource_client.get_training_set(
+                training_set_name, training_set_variant
+            )
+            elapsed_wait = time.time() - start
+            if (elapsed_wait >= 60) and ts.status != "READY":
+                print(
+                    f"Wait time for training set status exceeded; status is {ts.status}"
+                )
+                break
+            elif ts.status == "READY":
+                print(f"Training set is ready")
+                break
+            else:
+                print(
+                    f"Training set status is currently {ts.status} after {elapsed_wait} seconds ..."
+                )
+                continue
+
+    return (training_set_name, training_set_variant)

--- a/proto/serving.proto
+++ b/proto/serving.proto
@@ -10,6 +10,7 @@ package featureform.serving.proto;
 
 service Feature {
   rpc TrainingData(TrainingDataRequest) returns (stream TrainingDataRow) {}
+  rpc TrainingDataColumns(TrainingDataColumnsRequest) returns (TrainingColumns) {}
   rpc FeatureServe(FeatureServeRequest) returns (FeatureRow) {}
   rpc SourceData(SourceDataRequest) returns (stream SourceDataRow) {}
   rpc SourceColumns(SourceColumnRequest) returns (SourceDataColumns) {}
@@ -87,4 +88,13 @@ message SourceDataRow {
 
 message SourceDataColumns {
   repeated string columns = 1;
+}
+
+message TrainingDataColumnsRequest {
+  TrainingDataID id = 1;
+}
+
+message TrainingColumns {
+  repeated string features = 1;
+  string label = 2;
 }

--- a/serving/serving.go
+++ b/serving/serving.go
@@ -75,6 +75,27 @@ func (serv *FeatureServer) TrainingData(req *pb.TrainingDataRequest, stream pb.F
 	return nil
 }
 
+func (serv *FeatureServer) TrainingDataColumns(ctx context.Context, req *pb.TrainingDataColumnsRequest) (*pb.TrainingColumns, error) {
+	id := req.GetId()
+	name, variant := id.GetName(), id.GetVersion()
+	serv.Logger.Infow("Getting training set columns", "Name", name, "Variant", variant)
+	ts, err := serv.Metadata.GetTrainingSetVariant(ctx, metadata.NameVariant{Name: name, Variant: variant})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get training set variant")
+	}
+	fv := ts.Features()
+	features := make([]string, len(fv))
+	for i, f := range fv {
+		features[i] = fmt.Sprintf("feature_%s_%s", f.Name, f.Variant)
+	}
+	lv := ts.Label()
+	label := fmt.Sprintf("label_%s_%s", lv.Name, lv.Variant)
+	return &pb.TrainingColumns{
+		Features: features,
+		Label:    label,
+	}, nil
+}
+
 func (serv *FeatureServer) SourceData(req *pb.SourceDataRequest, stream pb.Feature_SourceDataServer) error {
 	id := req.GetId()
 	name, variant := id.GetName(), id.GetVersion()

--- a/serving/serving.go
+++ b/serving/serving.go
@@ -86,10 +86,10 @@ func (serv *FeatureServer) TrainingDataColumns(ctx context.Context, req *pb.Trai
 	fv := ts.Features()
 	features := make([]string, len(fv))
 	for i, f := range fv {
-		features[i] = fmt.Sprintf("feature_%s_%s", f.Name, f.Variant)
+		features[i] = fmt.Sprintf("feature__%s__%s", f.Name, f.Variant)
 	}
 	lv := ts.Label()
-	label := fmt.Sprintf("label_%s_%s", lv.Name, lv.Variant)
+	label := fmt.Sprintf("label__%s__%s", lv.Name, lv.Variant)
 	return &pb.TrainingColumns{
 		Features: features,
 		Label:    label,

--- a/serving/serving_test.go
+++ b/serving/serving_test.go
@@ -1264,3 +1264,29 @@ func TestSimpleModelRegistrationTrainingSetServe(t *testing.T) {
 		t.Fatalf("Wrong training set associated with registered model: %v\nExpected %v", modelTrainingSet, trainingData)
 	}
 }
+
+func TestTrainingDataColumns(t *testing.T) {
+	ctx := onlineTestContext{
+		ResourceDefsFn: simpleResourceDefsFn,
+		FactoryFn:      createMockOfflineStoreFactory(simpleFeatureRecords(), simpleTrainingSetDefs()),
+	}
+	serv := ctx.Create(t)
+	defer ctx.Destroy()
+	req := &pb.TrainingDataColumnsRequest{
+		Id: &pb.TrainingDataID{
+			Name:    "training-set",
+			Version: "variant",
+		},
+	}
+	expectedColumns := &pb.TrainingColumns{
+		Features: []string{"feature_feature_variant"},
+		Label:    "label_label_variant",
+	}
+	resp, err := serv.TrainingDataColumns(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Failed to get training data columns: %s", err)
+	}
+	if !reflect.DeepEqual(expectedColumns, resp) {
+		t.Fatalf("Columns aren't equal: %v\n%v", expectedColumns, resp)
+	}
+}

--- a/serving/serving_test.go
+++ b/serving/serving_test.go
@@ -1279,8 +1279,8 @@ func TestTrainingDataColumns(t *testing.T) {
 		},
 	}
 	expectedColumns := &pb.TrainingColumns{
-		Features: []string{"feature_feature_variant"},
-		Label:    "label_label_variant",
+		Features: []string{"feature__feature__variant"},
+		Label:    "label__label__variant",
 	}
 	resp, err := serv.TrainingDataColumns(context.Background(), req)
 	if err != nil {


### PR DESCRIPTION
# Description

This PR introduces the ability to convert training sets into pandas Dataframes, with columns that follow these conventions:
* Features[1-n]: `feature_<NAME>_<VARIANT>`
* Label: `label_<NAME>_<VARIANT>`

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
