### PR TITLE
Improve Error Message for Feature Missing `timestamp_column`

### DIFF
--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -510,8 +510,9 @@ class LocalClientImpl:
             df.reset_index(inplace=True)
         if feature["source_timestamp"] != "" and feature["source_timestamp"] not in df:
             raise ValueError(
-                f"Provided timestamp column {feature['source_timestamp']} not found in feature {feature['name']}; "
-                f"either remove 'timestamp_column' from the feature registration or include it in the transformation."
+                f"Provided timestamp column '{feature['source_timestamp']}' for feature "
+                f"'{feature['name']}:{feature['variant']}' not found in source '{feature['source_name']}:{feature['source_variant']}'; "
+                f"either remove 'timestamp_column' from the feature registration or include it in the source."
             )
         elif feature["source_timestamp"] != "":
             df = df[

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -508,7 +508,12 @@ class LocalClientImpl:
         if isinstance(df, pd.Series):
             df = df.to_frame()
             df.reset_index(inplace=True)
-        if feature["source_timestamp"] != "":
+        if feature["source_timestamp"] != "" and feature["source_timestamp"] not in df:
+            raise ValueError(
+                f"Provided timestamp column {feature['source_timestamp']} not found in feature {feature['name']}; "
+                f"either remove 'timestamp_column' from the feature registration or include it in the transformation."
+            )
+        elif feature["source_timestamp"] != "":
             df = df[
                 [
                     feature["source_entity"],


### PR DESCRIPTION
# Description

If a user provides a value for `timestamp_column` when registering a feature, but the underlying transformation does not contain a column for it, the resulting error is like `KeyError: "['Timestamp'] not in index"`. This PR introduces a more helpful error message for the user.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
