### PR TITLE
Bugfix: Accepting Feature object or (name, variant) tuple for nearest

### DIFF
--- a/client/src/featureform/client.py
+++ b/client/src/featureform/client.py
@@ -106,7 +106,7 @@ class Client(ResourceClient, ServingClient):
             variant = feature.variant
         else:
             raise Exception(
-                f"the feature '{feature}' of type '{type(feature)}' is not support." 
+                f"the feature '{feature}' of type '{type(feature)}' is not support."
                 "Feature must be a tuple of (name, variant) or a FeatureColumnResource"
             )
 

--- a/client/src/featureform/client.py
+++ b/client/src/featureform/client.py
@@ -4,6 +4,7 @@ from .register import (
     SourceRegistrar,
     LocalSource,
     SubscriptableTransformation,
+    FeatureColumnResource,
 )
 from .serving import ServingClient
 from .constants import NO_RECORD_LIMIT
@@ -81,7 +82,7 @@ class Client(ResourceClient, ServingClient):
         variant = get_random_name() if variant is None else variant
         return self.impl._get_source_as_df(name, variant, limit)
 
-    def nearest(self, name, variant, vector, k):
+    def nearest(self, feature, vector, k):
         """
         Query the K nearest neighbors of a provider vector in the index of a registered feature variant
 
@@ -98,6 +99,17 @@ class Client(ResourceClient, ServingClient):
         print(nearest_neighbors) # prints a list of entities (e.g. ["entity1", "entity2", "entity3", "entity4", "entity5"])
         ```
         """
+        if isinstance(feature, tuple):
+            name, variant = feature
+        elif isinstance(feature, FeatureColumnResource):
+            name = feature.name
+            variant = feature.variant
+        else:
+            raise Exception(
+                f"the feature '{feature}' of type '{type(feature)}' is not support." 
+                "Feature must be a tuple of (name, variant) or a FeatureColumnResource"
+            )
+
         if k < 1:
             raise ValueError(f"k must be a positive integer")
         return self.impl.nearest(name, variant, vector, k)


### PR DESCRIPTION
# Description
Modified nearest in Client to accept Feature object or (name, variant) tuple. 

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
