### PR TITLE
[WIP] add retry.py. apply retry combinator to provider calls. add unit tests.

### DIFF
--- a/client/setup.cfg
+++ b/client/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     dill>=0.3.6
     pandasql==0.7.3
     sqlalchemy<2.0.0
+    tenacity>=8.2.2
     requests
     rich
     pyarrow

--- a/client/src/featureform/retry.py
+++ b/client/src/featureform/retry.py
@@ -1,9 +1,13 @@
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 # Adds an exponential retry to any function/method.
+
+
 def add_exponential_retry(f, max_attempts=10, multiplier=1, max_wait=60):
-    @retry(stop=stop_after_attempt(max_attempts),
-           wait=wait_exponential(multiplier=multiplier, max=max_wait))
+    @retry(
+        stop=stop_after_attempt(max_attempts),
+        wait=wait_exponential(multiplier=multiplier, max=max_wait),
+    )
     def retried_f(*args, **kwargs):
         return f(*args, **kwargs)
 

--- a/client/src/featureform/retry.py
+++ b/client/src/featureform/retry.py
@@ -1,0 +1,10 @@
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+# Adds an exponential retry to any function/method.
+def add_exponential_retry(f, max_attempts=10, multiplier=1, max_wait=60):
+    @retry(stop=stop_after_attempt(max_attempts),
+           wait=wait_exponential(multiplier=multiplier, max=max_wait))
+    def retried_f(*args, **kwargs):
+        return f(*args, **kwargs)
+
+    return retried_f

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -693,15 +693,20 @@ class LocalClientImpl:
                 source["definition"], entity_name, feature
             )
 
+        from retry import add_exponential_retry
+
         if table_exists:
-            table = provider.get_table(f_name, f_variant)
+            get_table_with_retries = add_exponential_retry(provider.get_table)
+            table = get_table_with_retries(f_name, f_variant)
         else:
             if not feature["is_embedding"]:
-                table = provider.create_table(
+                create_table_with_retries = add_exponential_retry(provider.create_table)
+                table = create_table_with_retries(
                     f_name, f_variant, Scalar(ScalarType(feature["data_type"]))
                 )
             else:
-                table = provider.create_index(
+                create_index_with_retries = add_exponential_retry(provider.create_index)
+                table = create_index_with_retries(
                     f_name,
                     f_variant,
                     VectorType(

--- a/client/tests/test_retry.py
+++ b/client/tests/test_retry.py
@@ -45,7 +45,7 @@ def test_args_kwargs():
 
     retried_foo = add_exponential_retry(foo)
 
-    assert retried_foo('hello', 'world', c='!') == ('hello', 'world', '!')
+    assert retried_foo("hello", "world", c="!") == ("hello", "world", "!")
 
 
 def test_max_attempts():

--- a/client/tests/test_retry.py
+++ b/client/tests/test_retry.py
@@ -1,0 +1,59 @@
+import pytest
+import tenacity
+
+from featureform.retry import add_exponential_retry
+
+
+class TestClass:
+    def __init__(self):
+        self.counter = 0
+
+    def failing_method(self):
+        self.counter += 1
+        raise ValueError("This method always fails")
+
+    def eventually_succeeds(self):
+        self.counter += 1
+        if self.counter < 3:
+            raise ValueError("Fails for the first 2 attempts")
+        else:
+            return "Success"
+
+
+def test_always_fails():
+    test = TestClass()
+    retried_method = add_exponential_retry(test.failing_method, max_attempts=5)
+
+    with pytest.raises(tenacity.RetryError) as excinfo:
+        retried_method()
+
+    assert "This method always fails" == str(excinfo.value.last_attempt.exception())
+    assert test.counter == 5
+
+
+def test_eventually_succeeds():
+    obj = TestClass()
+    retried_method = add_exponential_retry(obj.eventually_succeeds, max_attempts=5)
+
+    assert retried_method() == "Success"
+    assert obj.counter == 3
+
+
+def test_args_kwargs():
+    def foo(a, b, c=None):
+        return (a, b, c)
+
+    retried_foo = add_exponential_retry(foo)
+
+    assert retried_foo('hello', 'world', c='!') == ('hello', 'world', '!')
+
+
+def test_max_attempts():
+    obj = TestClass()
+    retried_method = add_exponential_retry(obj.failing_method, max_attempts=3)
+
+    with pytest.raises(tenacity.RetryError) as excinfo:
+        retried_method()
+
+    assert "This method always fails" == str(excinfo.value.last_attempt.exception())
+    assert obj.counter == 3


### PR DESCRIPTION
# Description
- Adds retry.py which contains a `add_exponential_retry` combinator. 
- Applies the `add_exponential_retry` to provider calls in server.py
- adds unit tests

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
