### PR TITLE
Bugfix: Don't cleanup as setup for localdashtest

### DIFF
--- a/client/src/featureform/client.py
+++ b/client/src/featureform/client.py
@@ -114,3 +114,14 @@ class Client(ResourceClient, ServingClient):
         if k < 1:
             raise ValueError(f"k must be a positive integer")
         return self.impl.nearest(name, variant, vector, k)
+
+    def close(self):
+        self.impl.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+

--- a/client/src/featureform/client.py
+++ b/client/src/featureform/client.py
@@ -1,4 +1,7 @@
 from typing import Union
+
+from .constants import NO_RECORD_LIMIT
+from .names_generator import get_random_name
 from .register import (
     ResourceClient,
     SourceRegistrar,
@@ -7,8 +10,6 @@ from .register import (
     FeatureColumnResource,
 )
 from .serving import ServingClient
-from .constants import NO_RECORD_LIMIT
-from .names_generator import get_random_name
 
 
 class Client(ResourceClient, ServingClient):
@@ -123,5 +124,3 @@ class Client(ResourceClient, ServingClient):
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
-
-

--- a/client/src/featureform/client.py
+++ b/client/src/featureform/client.py
@@ -117,6 +117,9 @@ class Client(ResourceClient, ServingClient):
         return self.impl.nearest(name, variant, vector, k)
 
     def close(self):
+        """
+        Closes the client, closes channel for hosted mode and db for local mode
+        """
         self.impl.close()
 
     def __enter__(self):

--- a/client/src/featureform/dashboard_metadata.py
+++ b/client/src/featureform/dashboard_metadata.py
@@ -1,10 +1,14 @@
-from flask import Blueprint, Response, jsonify, request
-from flask_cors import CORS, cross_origin
 import json
-import importlib.resources as pkg_resources
-from .sqlite_metadata import SQLiteMetadata
-from .resources import SourceType
+import os
+
 import pandas as pd
+from featureform import ResourceClient
+from featureform.serving import LocalClientImpl
+from flask import Blueprint, Response, request
+from flask_cors import CORS, cross_origin
+
+from .resources import SourceType
+from .sqlite_metadata import SQLiteMetadata
 from .type_objects import (
     FeatureResource,
     FeatureVariantResource,
@@ -19,11 +23,7 @@ from .type_objects import (
     LabelVariantResource,
     ProviderResource,
 )
-import os
-from featureform import ResourceClient
 from .version import get_package_version
-from featureform.serving import LocalClientImpl
-
 
 path = os.path.join(os.path.dirname(__file__), "dashboard")
 
@@ -32,7 +32,6 @@ dashboard_app = Blueprint(
 )
 
 CORS(dashboard_app)
-sqlObject = SQLiteMetadata()
 
 
 @dashboard_app.route("/")
@@ -164,9 +163,12 @@ def feature_variant(variantData):
 
 
 def features(featureRow):
-    variantData = feature_variant(
-        sqlObject.query_resource_variant("feature_variant", "name", featureRow["name"])
-    )
+    with SQLiteMetadata() as sqlObject:
+        variantData = feature_variant(
+            sqlObject.query_resource_variant(
+                "feature_variant", "name", featureRow["name"]
+            )
+        )
 
     return FeatureResource(
         featureRow["name"],
@@ -183,9 +185,10 @@ def training_set_variant(variantData):
     variants = []
     for variantRow in variantData:
         try:
-            feature_list = sqlObject.get_training_set_features(
-                variantRow["name"], variantRow["variant"]
-            )
+            with SQLiteMetadata() as sqlObject:
+                feature_list = sqlObject.get_training_set_features(
+                    variantRow["name"], variantRow["variant"]
+                )
         except ValueError:
             feature_list = []
 
@@ -212,21 +215,23 @@ def training_set_variant(variantData):
 
 def getTrainingSetFeatures(feature_list):
     feature_variant_tuple = []
-    for feature in feature_list:
-        feature_variant_tuple.append(
-            sqlObject.get_feature_variant(
-                feature["feature_name"], feature["feature_variant"]
+    with SQLiteMetadata() as sqlObject:
+        for feature in feature_list:
+            feature_variant_tuple.append(
+                sqlObject.get_feature_variant(
+                    feature["feature_name"], feature["feature_variant"]
+                )
             )
-        )
-    return feature_variant_tuple
+        return feature_variant_tuple
 
 
 def training_sets(rowData):
-    variantData = training_set_variant(
-        sqlObject.query_resource_variant(
-            "training_set_variant", "name", rowData["name"]
+    with SQLiteMetadata() as sqlObject:
+        variantData = training_set_variant(
+            sqlObject.query_resource_variant(
+                "training_set_variant", "name", rowData["name"]
+            )
         )
-    )
     return TrainingSetResource(
         "TrainingSet",
         rowData["default_variant"],
@@ -240,78 +245,84 @@ def source_variant(variantData):
     variantDict = dict()
     allVariantList = []
     variants = []
-    for variantRow in variantData:
-        try:
-            feature_list = sqlObject.get_feature_variants_from_source(
-                variantRow["name"], variantRow["variant"]
-            )
-        except ValueError:
-            feature_list = []
-        training_set_list = set()
-        for f in feature_list:
+    with SQLiteMetadata() as sqlObject:
+        for variantRow in variantData:
             try:
-                features_training_set_list = sqlObject.get_training_set_from_features(
-                    f["name"], f["variant"]
+                feature_list = sqlObject.get_feature_variants_from_source(
+                    variantRow["name"], variantRow["variant"]
                 )
-                for training_set in features_training_set_list:
-                    training_set_list.add(
-                        sqlObject.get_training_set_variant(
-                            training_set["training_set_name"],
-                            training_set["training_set_variant"],
+            except ValueError:
+                feature_list = []
+            training_set_list = set()
+            for f in feature_list:
+                try:
+                    features_training_set_list = (
+                        sqlObject.get_training_set_from_features(
+                            f["name"], f["variant"]
                         )
                     )
-            except ValueError:
-                continue
-        try:
-            label_list = sqlObject.get_label_variants_from_source(
-                variantRow["name"], variantRow["variant"]
-            )
-        except ValueError:
-            label_list = []
-        for l in label_list:
+                    for training_set in features_training_set_list:
+                        training_set_list.add(
+                            sqlObject.get_training_set_variant(
+                                training_set["training_set_name"],
+                                training_set["training_set_variant"],
+                            )
+                        )
+                except ValueError:
+                    continue
             try:
-                labels_training_set_list = (
-                    sqlObject.get_training_set_variant_from_label(
-                        l["name"], l["variant"]
-                    )
+                label_list = sqlObject.get_label_variants_from_source(
+                    variantRow["name"], variantRow["variant"]
                 )
-                for training_set in labels_training_set_list:
-                    training_set_list.add(training_set)
             except ValueError:
-                continue
-        if variantRow["transformation"] == SourceType.DF_TRANSFORMATION.value:
-            definition = str(variantRow["definition"], "latin-1")
-        else:
-            definition = variantRow["definition"]
-        sourceVariant = SourceVariantResource(
-            variantRow["created"],
-            variantRow["description"],
-            variantRow["name"],
-            variantRow["source_type"],
-            variantRow["owner"],
-            variantRow["provider"],
-            variantRow["variant"],
-            variantRow["status"],
-            definition,
-            variant_organiser(label_variant(label_list)[2]),
-            variant_organiser(feature_variant(feature_list)[2]),
-            variant_organiser(training_set_variant(training_set_list)[2]),
-            json.loads(variantRow["tags"]) if variantRow["tags"] is not None else [],
-            json.loads(variantRow["properties"])
-            if variantRow["properties"] is not None
-            else {},
-        ).toDictionary()
-        allVariantList.append(variantRow["variant"])
-        variantDict[variantRow["variant"]] = sourceVariant
-        variants.append(sourceVariant)
+                label_list = []
+            for l in label_list:
+                try:
+                    labels_training_set_list = (
+                        sqlObject.get_training_set_variant_from_label(
+                            l["name"], l["variant"]
+                        )
+                    )
+                    for training_set in labels_training_set_list:
+                        training_set_list.add(training_set)
+                except ValueError:
+                    continue
+            if variantRow["transformation"] == SourceType.DF_TRANSFORMATION.value:
+                definition = str(variantRow["definition"], "latin-1")
+            else:
+                definition = variantRow["definition"]
+            sourceVariant = SourceVariantResource(
+                variantRow["created"],
+                variantRow["description"],
+                variantRow["name"],
+                variantRow["source_type"],
+                variantRow["owner"],
+                variantRow["provider"],
+                variantRow["variant"],
+                variantRow["status"],
+                definition,
+                variant_organiser(label_variant(label_list)[2]),
+                variant_organiser(feature_variant(feature_list)[2]),
+                variant_organiser(training_set_variant(training_set_list)[2]),
+                json.loads(variantRow["tags"])
+                if variantRow["tags"] is not None
+                else [],
+                json.loads(variantRow["properties"])
+                if variantRow["properties"] is not None
+                else {},
+            ).toDictionary()
+            allVariantList.append(variantRow["variant"])
+            variantDict[variantRow["variant"]] = sourceVariant
+            variants.append(sourceVariant)
 
-    return variantDict, allVariantList, variants
+        return variantDict, allVariantList, variants
 
 
 def sources(rowData):
-    variantData = source_variant(
-        sqlObject.query_resource_variant("source_variant", "name", rowData["name"])
-    )
+    with SQLiteMetadata() as sqlObject:
+        variantData = source_variant(
+            sqlObject.query_resource_variant("source_variant", "name", rowData["name"])
+        )
     return SourceResource(
         "Source",
         rowData["default_variant"],
@@ -326,50 +337,54 @@ def label_variant(variantData):
     allVariantList = []
     variants = []
 
-    for variantRow in variantData:
-        labelTuple = str((variantRow["name"], variantRow["variant"]))
-        labelVariant = LabelVariantResource(
-            variantRow["created"],
-            variantRow["description"],
-            variantRow["entity"],
-            variantRow["name"],
-            variantRow["owner"],
-            variantRow["provider"],
-            variantRow["data_type"],
-            variantRow["variant"],
-            {
-                "entity": variantRow["source_entity"],
-                "value": variantRow["source_value"],
-                "timestamp": variantRow["source_timestamp"],
-            },
-            variantRow["status"],
-            {
-                "Name": variantRow["source_name"],
-                "Variant": variantRow["source_variant"],
-            },
-            variant_organiser(
-                training_set_variant(
-                    sqlObject.get_training_set_variant_from_label(
-                        variantRow["name"], variantRow["variant"]
-                    )
-                )[2]
-            ),
-            json.loads(variantRow["tags"]) if variantRow["tags"] is not None else [],
-            json.loads(variantRow["properties"])
-            if variantRow["properties"] is not None
-            else {},
-        ).toDictionary()
+    with SQLiteMetadata() as sqlObject:
+        for variantRow in variantData:
+            labelTuple = str((variantRow["name"], variantRow["variant"]))
+            labelVariant = LabelVariantResource(
+                variantRow["created"],
+                variantRow["description"],
+                variantRow["entity"],
+                variantRow["name"],
+                variantRow["owner"],
+                variantRow["provider"],
+                variantRow["data_type"],
+                variantRow["variant"],
+                {
+                    "entity": variantRow["source_entity"],
+                    "value": variantRow["source_value"],
+                    "timestamp": variantRow["source_timestamp"],
+                },
+                variantRow["status"],
+                {
+                    "Name": variantRow["source_name"],
+                    "Variant": variantRow["source_variant"],
+                },
+                variant_organiser(
+                    training_set_variant(
+                        sqlObject.get_training_set_variant_from_label(
+                            variantRow["name"], variantRow["variant"]
+                        )
+                    )[2]
+                ),
+                json.loads(variantRow["tags"])
+                if variantRow["tags"] is not None
+                else [],
+                json.loads(variantRow["properties"])
+                if variantRow["properties"] is not None
+                else {},
+            ).toDictionary()
 
-        allVariantList.append(variantRow["variant"])
-        variantDict[variantRow["variant"]] = labelVariant
-        variants.append(labelVariant)
-    return variantDict, allVariantList, variants
+            allVariantList.append(variantRow["variant"])
+            variantDict[variantRow["variant"]] = labelVariant
+            variants.append(labelVariant)
+        return variantDict, allVariantList, variants
 
 
 def labels(rowData):
-    variantData = label_variant(
-        sqlObject.query_resource_variant("label_variant", "name", rowData["name"])
-    )
+    with SQLiteMetadata() as sqlObject:
+        variantData = label_variant(
+            sqlObject.query_resource_variant("label_variant", "name", rowData["name"])
+        )
     return LabelResource(
         "Label",
         rowData["default_variant"],
@@ -380,142 +395,154 @@ def labels(rowData):
 
 
 def entities(rowData):
-    try:
-        label_list = sqlObject.query_resource_variant(
-            "label_variant", "entity", rowData["name"]
-        )
-    except Exception as e:
-        print(f"No labels found for entity {rowData['name']} - {e}")
-        label_list = []
-    training_set_list = set()
-    for label in label_list:
-        for training_set in sqlObject.get_training_set_variant_from_label(
-            label["name"], label["variant"]
-        ):
-            training_set_list.add(training_set)
-    return EntityResource(
-        rowData["name"],
-        rowData["type"],
-        rowData["description"],
-        rowData["status"],
-        variant_organiser(
-            feature_variant(
-                sqlObject.query_resource_variant(
-                    "feature_variant", "entity", rowData["name"]
-                )
-            )[2]
-        ),
-        variant_organiser(label_variant(label_list)[2]),
-        variant_organiser(training_set_variant(training_set_list)[2]),
-        json.loads(rowData["tags"]) if rowData["tags"] is not None else [],
-        json.loads(rowData["properties"]) if rowData["properties"] is not None else {},
-    ).toDictionary()
+    with SQLiteMetadata() as sqlObject:
+        try:
+            label_list = sqlObject.query_resource_variant(
+                "label_variant", "entity", rowData["name"]
+            )
+        except Exception as e:
+            print(f"No labels found for entity {rowData['name']} - {e}")
+            label_list = []
+        training_set_list = set()
+        for label in label_list:
+            for training_set in sqlObject.get_training_set_variant_from_label(
+                label["name"], label["variant"]
+            ):
+                training_set_list.add(training_set)
+        return EntityResource(
+            rowData["name"],
+            rowData["type"],
+            rowData["description"],
+            rowData["status"],
+            variant_organiser(
+                feature_variant(
+                    sqlObject.query_resource_variant(
+                        "feature_variant", "entity", rowData["name"]
+                    )
+                )[2]
+            ),
+            variant_organiser(label_variant(label_list)[2]),
+            variant_organiser(training_set_variant(training_set_list)[2]),
+            json.loads(rowData["tags"]) if rowData["tags"] is not None else [],
+            json.loads(rowData["properties"])
+            if rowData["properties"] is not None
+            else {},
+        ).toDictionary()
 
 
 def models(rowData):
-    return ModelResource(
-        rowData["name"],
-        "Model",
-        rowData["description"],
-        rowData["status"],
-        variant_organiser(
-            feature_variant(
-                sqlObject.query_resource_variant(
-                    "feature_variant", "name", rowData["name"]
-                )
-            )[2]
-        ),
-        variant_organiser(
-            label_variant(
-                sqlObject.query_resource_variant(
-                    "label_variant", "variant", rowData["name"]
-                )
-            )[2]
-        ),
-        variant_organiser(
-            training_set_variant(
-                sqlObject.query_resource_variant(
-                    "training_set_variant", "name", rowData["name"]
-                )
-            )[2]
-        ),
-        json.loads(rowData["tags"]) if rowData["tags"] is not None else [],
-        json.loads(rowData["properties"]) if rowData["properties"] is not None else {},
-    ).toDictionary()
+    with SQLiteMetadata() as sqlObject:
+        return ModelResource(
+            rowData["name"],
+            "Model",
+            rowData["description"],
+            rowData["status"],
+            variant_organiser(
+                feature_variant(
+                    sqlObject.query_resource_variant(
+                        "feature_variant", "name", rowData["name"]
+                    )
+                )[2]
+            ),
+            variant_organiser(
+                label_variant(
+                    sqlObject.query_resource_variant(
+                        "label_variant", "variant", rowData["name"]
+                    )
+                )[2]
+            ),
+            variant_organiser(
+                training_set_variant(
+                    sqlObject.query_resource_variant(
+                        "training_set_variant", "name", rowData["name"]
+                    )
+                )[2]
+            ),
+            json.loads(rowData["tags"]) if rowData["tags"] is not None else [],
+            json.loads(rowData["properties"])
+            if rowData["properties"] is not None
+            else {},
+        ).toDictionary()
 
 
 def users(rowData):
-    return UserResource(
-        rowData["name"],
-        rowData["type"],
-        rowData["status"],
-        variant_organiser(
-            feature_variant(
-                sqlObject.query_resource_variant(
-                    "feature_variant", "owner", rowData["name"]
-                )
-            )[2]
-        ),
-        variant_organiser(
-            label_variant(
-                sqlObject.query_resource_variant(
-                    "label_variant", "owner", rowData["name"]
-                )
-            )[2]
-        ),
-        variant_organiser(
-            training_set_variant(
-                sqlObject.query_resource_variant(
-                    "training_set_variant", "owner", rowData["name"]
-                )
-            )[2]
-        ),
-        variant_organiser(
-            source_variant(
-                sqlObject.query_resource_variant(
-                    "source_variant", "owner", rowData["name"]
-                )
-            )[2]
-        ),
-        json.loads(rowData["tags"]) if rowData["tags"] is not None else [],
-        json.loads(rowData["properties"]) if rowData["properties"] is not None else {},
-    ).toDictionary()
+    with SQLiteMetadata() as sqlObject:
+        return UserResource(
+            rowData["name"],
+            rowData["type"],
+            rowData["status"],
+            variant_organiser(
+                feature_variant(
+                    sqlObject.query_resource_variant(
+                        "feature_variant", "owner", rowData["name"]
+                    )
+                )[2]
+            ),
+            variant_organiser(
+                label_variant(
+                    sqlObject.query_resource_variant(
+                        "label_variant", "owner", rowData["name"]
+                    )
+                )[2]
+            ),
+            variant_organiser(
+                training_set_variant(
+                    sqlObject.query_resource_variant(
+                        "training_set_variant", "owner", rowData["name"]
+                    )
+                )[2]
+            ),
+            variant_organiser(
+                source_variant(
+                    sqlObject.query_resource_variant(
+                        "source_variant", "owner", rowData["name"]
+                    )
+                )[2]
+            ),
+            json.loads(rowData["tags"]) if rowData["tags"] is not None else [],
+            json.loads(rowData["properties"])
+            if rowData["properties"] is not None
+            else {},
+        ).toDictionary()
 
 
 def providers(rowData):
-    try:
-        source_list = sqlObject.query_resource_variant(
-            "source_variant", "provider", rowData["name"]
-        )
-    except ValueError:
-        source_list = []
-    try:
-        feature_list = sqlObject.query_resource_variant(
-            "feature_variant", "provider", rowData["name"]
-        )
-    except ValueError:
-        feature_list = []
-    try:
-        label_list = sqlObject.query_resource_variant(
-            "label_variant", "provider", rowData["name"]
-        )
-    except ValueError:
-        label_list = []
-    return ProviderResource(
-        rowData["name"],
-        rowData["type"],
-        rowData["description"],
-        rowData["provider_type"],
-        rowData["software"],
-        rowData["team"],
-        variant_organiser(source_variant(source_list)[2]),
-        rowData["status"],
-        rowData["serialized_config"],
-        variant_organiser(feature_variant(feature_list)[2]),
-        variant_organiser(label_variant(label_list)[2]),
-        json.loads(rowData["tags"]) if rowData["tags"] is not None else [],
-        json.loads(rowData["properties"]) if rowData["properties"] is not None else {},
-    ).toDictionary()
+    with SQLiteMetadata() as sqlObject:
+        try:
+            source_list = sqlObject.query_resource_variant(
+                "source_variant", "provider", rowData["name"]
+            )
+        except ValueError:
+            source_list = []
+        try:
+            feature_list = sqlObject.query_resource_variant(
+                "feature_variant", "provider", rowData["name"]
+            )
+        except ValueError:
+            feature_list = []
+        try:
+            label_list = sqlObject.query_resource_variant(
+                "label_variant", "provider", rowData["name"]
+            )
+        except ValueError:
+            label_list = []
+        return ProviderResource(
+            rowData["name"],
+            rowData["type"],
+            rowData["description"],
+            rowData["provider_type"],
+            rowData["software"],
+            rowData["team"],
+            variant_organiser(source_variant(source_list)[2]),
+            rowData["status"],
+            rowData["serialized_config"],
+            variant_organiser(feature_variant(feature_list)[2]),
+            variant_organiser(label_variant(label_list)[2]),
+            json.loads(rowData["tags"]) if rowData["tags"] is not None else [],
+            json.loads(rowData["properties"])
+            if rowData["properties"] is not None
+            else {},
+        ).toDictionary()
 
 
 @dashboard_app.route("/data/<type>", methods=["POST", "GET"])
@@ -537,7 +564,8 @@ def GetMetadataList(type):
             response=json.dumps(errorData), status=400, mimetype="application/json"
         )
         return response
-    tableDataCursor = sqlObject.get_type_table(type)
+    with SQLiteMetadata() as sqlObject:
+        tableDataCursor = sqlObject.get_type_table(type)
     allData = []
     for row in tableDataCursor:
         if type == "features":
@@ -588,9 +616,10 @@ def GetMetadata(type, resource):
         "users",
         "providers",
     ]
-    row = sqlObject.query_resource(
-        type, "name", "".join(resource), should_fetch_tags_and_properties
-    )[0]
+    with SQLiteMetadata() as sqlObject:
+        row = sqlObject.query_resource(
+            type, "name", "".join(resource), should_fetch_tags_and_properties
+        )[0]
 
     if type == "features":
         dataAsList = features(row)

--- a/client/src/featureform/local_cache.py
+++ b/client/src/featureform/local_cache.py
@@ -4,17 +4,17 @@ from functools import lru_cache
 from typing import Callable, Set
 
 import pandas as pd
-from featureform import SQLiteMetadata  # fix to do client.source.import
+from featureform import SQLiteMetadata
 from featureform.local_utils import get_sql_transformation_sources
 from featureform.resources import SourceType  # fix to do client.source.import
 from pandas.core.generic import NDFrame
 from typeguard import typechecked
+
 from .file_utils import absolute_file_paths
 
 
 class LocalCache:
-    def __init__(self, db: SQLiteMetadata):
-        self.db = db
+    def __init__(self):
         feature_form_dir = os.environ.get("FEATUREFORM_DIR", ".featureform")
         self.cache_dir = os.environ.get(
             "FEATUREFORM_CACHE_DIR", os.path.join(feature_form_dir, "cache")
@@ -37,30 +37,32 @@ class LocalCache:
             resource_type, resource_name, resource_variant
         )
 
-        # check db for source files
-        source_files_from_db = self.db.get_source_files_for_resource(
-            resource_type, resource_name, resource_variant
-        )
-        if source_files_from_db:
-            self._invalidate_cache_if_source_files_changed(
-                source_files_from_db, cache_file_path
+        with SQLiteMetadata() as db:
+            # check db for source files
+            source_files_from_db = db.get_source_files_for_resource(
+                resource_type, resource_name, resource_variant
+            )
+            if source_files_from_db:
+                self._invalidate_cache_if_source_files_changed(
+                    source_files_from_db, cache_file_path
+                )
+
+            # get source files from db or compute the sources
+            source_files: Set[str] = (
+                set(map(lambda x: x["file_path"], source_files_from_db))
+                if source_files_from_db
+                else self.get_source_files_for_source(db, source_name, source_variant)
             )
 
-        # get source files from db or compute the sources
-        source_files: Set[str] = (
-            set(map(lambda x: x["file_path"], source_files_from_db))
-            if source_files_from_db
-            else self.get_source_files_for_source(source_name, source_variant)
-        )
-
-        return self._get_or_put(
-            resource_type,
-            resource_name,
-            resource_variant,
-            cache_file_path,
-            source_files,
-            func,
-        )
+            return self._get_or_put(
+                db,
+                resource_type,
+                resource_name,
+                resource_variant,
+                cache_file_path,
+                source_files,
+                func,
+            )
 
     @typechecked
     def get_or_put_training_set(
@@ -79,60 +81,66 @@ class LocalCache:
             resource_type, training_set_name, training_set_variant
         )
 
-        # check db for source files
-        source_files_from_db = self.db.get_source_files_for_resource(
-            resource_type, training_set_name, training_set_variant
-        )
-
-        # Only check to invalidate the cache if we have source files in the db
-        if source_files_from_db:
-            self._invalidate_cache_if_source_files_changed(
-                source_files_from_db, file_path
+        with SQLiteMetadata() as db:
+            # check db for source files
+            source_files_from_db = db.get_source_files_for_resource(
+                resource_type, training_set_name, training_set_variant
             )
 
-        source_files = set()
-        if source_files_from_db:
-            source_files.update(
-                set(map(lambda x: x["file_path"], source_files_from_db))
-            )
-        else:
-            ts_variant = self.db.get_training_set_variant(
-                training_set_name, training_set_variant
-            )
-            label_variant = self.db.get_label_variant(
-                ts_variant["label_name"], ts_variant["label_variant"]
-            )
-            source_files.update(
-                self.get_source_files_for_source(
-                    label_variant["source_name"], label_variant["source_variant"]
+            # Only check to invalidate the cache if we have source files in the db
+            if source_files_from_db:
+                self._invalidate_cache_if_source_files_changed(
+                    source_files_from_db, file_path
                 )
-            )
 
-            features = self.db.get_training_set_features(
-                training_set_name, training_set_variant
-            )
-            for feature in features:
-                feature_variant = self.db.get_feature_variant(
-                    feature["feature_name"], feature["feature_variant"]
+            source_files = set()
+            if source_files_from_db:
+                source_files.update(
+                    set(map(lambda x: x["file_path"], source_files_from_db))
+                )
+            else:
+                ts_variant = db.get_training_set_variant(
+                    training_set_name, training_set_variant
+                )
+                label_variant = db.get_label_variant(
+                    ts_variant["label_name"], ts_variant["label_variant"]
                 )
                 source_files.update(
                     self.get_source_files_for_source(
-                        feature_variant["source_name"],
-                        feature_variant["source_variant"],
+                        db,
+                        label_variant["source_name"],
+                        label_variant["source_variant"],
                     )
                 )
 
-        return self._get_or_put(
-            resource_type,
-            training_set_name,
-            training_set_variant,
-            file_path,
-            source_files,
-            func,
-        )
+                features = db.get_training_set_features(
+                    training_set_name, training_set_variant
+                )
+                for feature in features:
+                    feature_variant = db.get_feature_variant(
+                        feature["feature_name"], feature["feature_variant"]
+                    )
+                    source_files.update(
+                        self.get_source_files_for_source(
+                            db,
+                            feature_variant["source_name"],
+                            feature_variant["source_variant"],
+                        )
+                    )
+
+            return self._get_or_put(
+                db,
+                resource_type,
+                training_set_name,
+                training_set_variant,
+                file_path,
+                source_files,
+                func,
+            )
 
     def _get_or_put(
         self,
+        db,
         resource_type,
         resource_name,
         resource_variant,
@@ -148,7 +156,7 @@ class LocalCache:
             os.makedirs(self.cache_dir, exist_ok=True)
             df.to_pickle(file_path)
             for source_file in source_files:
-                self.db.insert_or_update(
+                db.insert_or_update(
                     "resource_source_files",
                     ["resource_type", "name", "variant", "file_path"],
                     ["updated_at"],
@@ -161,12 +169,12 @@ class LocalCache:
             return df
 
     @lru_cache(maxsize=128)
-    def get_source_files_for_source(self, source_name, source_variant) -> Set[str]:
+    def get_source_files_for_source(self, db, source_name, source_variant) -> Set[str]:
         """
         Recursively gets the source files for a given source. Each call is cached.
         """
-        source = self.db.get_source_variant(source_name, source_variant)
-        transform_type = self.db.is_transformation(source_name, source_variant)
+        source = db.get_source_variant(source_name, source_variant)
+        transform_type = db.is_transformation(source_name, source_variant)
 
         sources = set()
         if transform_type == SourceType.PRIMARY_SOURCE.value:
@@ -176,12 +184,12 @@ class LocalCache:
             transformation_sources = get_sql_transformation_sources(query)
             for source_name, source_variant in transformation_sources:
                 sources.update(
-                    self.get_source_files_for_source(source_name, source_variant)
+                    self.get_source_files_for_source(db, source_name, source_variant)
                 )
         elif transform_type == SourceType.DF_TRANSFORMATION.value:
             dependencies = json.loads(source["inputs"])
             for name, variant in dependencies:
-                sources.update(self.get_source_files_for_source(name, variant))
+                sources.update(self.get_source_files_for_source(db, name, variant))
         elif transform_type == SourceType.DIRECTORY.value:
             path = source["definition"]
             for absolute_file, _ in absolute_file_paths(path):

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -141,6 +141,10 @@ class ServingClient:
         features = check_feature_type(features)
         return self.impl.features(features, entities, model, params)
 
+    def close(self):
+        """Closes the connection to the Featureform instance."""
+        self.impl.close()
+
 
 class HostedClientImpl:
     def __init__(self, host=None, insecure=False, cert_path=None):
@@ -151,8 +155,8 @@ class HostedClientImpl:
                 " variable FEATUREFORM_HOST must be set."
             )
         check_up_to_date(False, "serving")
-        channel = self._create_channel(host, insecure, cert_path)
-        self._stub = serving_pb2_grpc.FeatureStub(channel)
+        self._channel = self._create_channel(host, insecure, cert_path)
+        self._stub = serving_pb2_grpc.FeatureStub(self._channel)
 
     def _create_channel(self, host, insecure, cert_path):
         if insecure:
@@ -229,6 +233,9 @@ class HostedClientImpl:
         req = serving_pb2.NearestRequest(id=id, vector=vec, k=k)
         resp = self._stub.Nearest(req)
         return resp.entities
+
+    def close(self):
+        self._channel.close()
 
 
 class LocalClientImpl:

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -234,7 +234,7 @@ class HostedClientImpl:
 class LocalClientImpl:
     def __init__(self):
         self.db = SQLiteMetadata()
-        self.local_cache = LocalCache(self.db)
+        self.local_cache = LocalCache()
         check_up_to_date(True, "serving")
 
     def __enter__(self):

--- a/client/src/featureform/sqlite_metadata.py
+++ b/client/src/featureform/sqlite_metadata.py
@@ -1,7 +1,7 @@
 import json
+import os
 import sqlite3
 from threading import Lock
-import os
 
 from .exceptions import FeatureNotFound
 
@@ -773,3 +773,9 @@ class SQLiteMetadata:
             is_update = True
 
         return (query, is_update)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()

--- a/client/tests/local_dash_test.py
+++ b/client/tests/local_dash_test.py
@@ -1957,7 +1957,6 @@ def remove_keys(obj, rubbish):
 
 @pytest.fixture(scope="module", autouse=True)
 def setup():
-    cleanup()
     import subprocess
 
     apply = subprocess.run(

--- a/client/tests/test_localmode_caching.py
+++ b/client/tests/test_localmode_caching.py
@@ -76,11 +76,11 @@ def setup(tmp_path_factory):
         features=[("avg_transactions", variant)],
     )
 
-    client = ff.Client(local=True)
-    client.apply()
-    client.training_set("fraud_training", variant)  # this will create the cache
+    with ff.Client(local=True) as client:
+        client.apply()
+        client.training_set("fraud_training", variant)  # this will create the cache
 
-    yield SetupFixture(transactions_file=str(temp_transactions), serving_client=client)
+        yield SetupFixture(transactions_file=str(temp_transactions), serving_client=client)
 
 
 @pytest.fixture(autouse=True)

--- a/client/tests/test_localmode_caching.py
+++ b/client/tests/test_localmode_caching.py
@@ -85,7 +85,6 @@ def setup(tmp_path_factory):
 
 @pytest.fixture(autouse=True)
 def cleanup():
-    shutil.rmtree(".featureform/cache", onerror=del_rw)
     yield
     shutil.rmtree(".featureform", onerror=del_rw)
 

--- a/client/tests/test_localmode_caching.py
+++ b/client/tests/test_localmode_caching.py
@@ -80,7 +80,9 @@ def setup(tmp_path_factory):
         client.apply()
         client.training_set("fraud_training", variant)  # this will create the cache
 
-        yield SetupFixture(transactions_file=str(temp_transactions), serving_client=client)
+        yield SetupFixture(
+            transactions_file=str(temp_transactions), serving_client=client
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/client/tests/test_localmode_caching.py
+++ b/client/tests/test_localmode_caching.py
@@ -1,7 +1,6 @@
 import os.path
 import shutil
 import stat
-from typing import Tuple, Callable, Any
 
 import featureform as ff
 import pandas as pd
@@ -22,18 +21,18 @@ class SetupFixture:
 
 @pytest.fixture(scope="function")
 def setup(tmp_path_factory):
+    variant = "cache_test"
+
     temp_dir = tmp_path_factory.mktemp("test_inputs")
     temp_transactions = temp_dir / "transactions.csv"
     shutil.copy(SOURCE_FILE, temp_transactions)
     transactions = local.register_file(
         name="transactions",
-        variant="quickstart",
+        variant=variant,
         path=str(temp_transactions),
     )
 
-    @local.df_transformation(
-        variant="quickstart", inputs=[("transactions", "quickstart")]
-    )
+    @local.df_transformation(variant=variant, inputs=[("transactions", variant)])
     def average_user_transaction(transactions):
         """the average transaction amount for a user"""
         return transactions.groupby("CustomerID")["TransactionAmount"].mean()
@@ -48,7 +47,7 @@ def setup(tmp_path_factory):
         features=[
             {
                 "name": "avg_transactions",
-                "variant": "quickstart",
+                "variant": variant,
                 "column": "TransactionAmount",
                 "type": "float32",
             },
@@ -63,7 +62,7 @@ def setup(tmp_path_factory):
         labels=[
             {
                 "name": "fraudulent",
-                "variant": "quickstart",
+                "variant": variant,
                 "column": "IsFraud",
                 "type": "bool",
             },
@@ -72,23 +71,22 @@ def setup(tmp_path_factory):
 
     ff.register_training_set(
         "fraud_training",
-        "quickstart",
-        label=("fraudulent", "quickstart"),
-        features=[("avg_transactions", "quickstart")],
+        variant,
+        label=("fraudulent", variant),
+        features=[("avg_transactions", variant)],
     )
 
     client = ff.Client(local=True)
     client.apply()
-
-    serving_client = ff.ServingClient(local=True)
-    serving_client.training_set("fraud_training", "quickstart")
+    client.training_set("fraud_training", variant)  # this will create the cache
 
     yield SetupFixture(transactions_file=str(temp_transactions), serving_client=client)
 
-    # serving_client.impl.db.close()
 
-
-def clear_state():
+@pytest.fixture(autouse=True)
+def cleanup():
+    shutil.rmtree(".featureform/cache", onerror=del_rw)
+    yield
     shutil.rmtree(".featureform", onerror=del_rw)
 
 
@@ -108,10 +106,10 @@ class TestLocalCache:
         cache_files = os.listdir(".featureform/cache")
 
         expected_cache_files = [
-            "transformation__average_user_transaction__quickstart.pkl",
-            "feature__avg_transactions__quickstart.pkl",
-            "label__fraudulent__quickstart.pkl",
-            "training_set__fraud_training__quickstart.pkl",
+            "transformation__average_user_transaction__cache_test.pkl",
+            "feature__avg_transactions__cache_test.pkl",
+            "label__fraudulent__cache_test.pkl",
+            "training_set__fraud_training__cache_test.pkl",
         ]
 
         assert os.path.exists(".featureform/cache")
@@ -126,13 +124,13 @@ class TestLocalCache:
 
         # make a change to the cached file
         label_df = pd.read_pickle(
-            ".featureform/cache/label__fraudulent__quickstart.pkl"
+            ".featureform/cache/label__fraudulent__cache_test.pkl"
         )
         label_df["label"] = None
-        label_df.to_pickle(".featureform/cache/label__fraudulent__quickstart.pkl")
+        label_df.to_pickle(".featureform/cache/label__fraudulent__cache_test.pkl")
 
         label = fixture.serving_client.impl.db.get_label_variant(
-            "fraudulent", "quickstart"
+            "fraudulent", "cache_test"
         )
         label_df = fixture.serving_client.impl.get_label_dataframe(label)
 
@@ -144,15 +142,15 @@ class TestLocalCache:
 
         # make a change to the cached file
         transformation_df = pd.read_pickle(
-            ".featureform/cache/transformation__average_user_transaction__quickstart.pkl"
+            ".featureform/cache/transformation__average_user_transaction__cache_test.pkl"
         )
         transformation_df["TransactionAmount"] = 0
         transformation_df.to_pickle(
-            ".featureform/cache/transformation__average_user_transaction__quickstart.pkl"
+            ".featureform/cache/transformation__average_user_transaction__cache_test.pkl"
         )
 
         transformation_df = fixture.serving_client.impl.process_transformation(
-            "average_user_transaction", "quickstart"
+            "average_user_transaction", "cache_test"
         )
 
         # ensure all values are 0
@@ -163,15 +161,15 @@ class TestLocalCache:
 
         # make a change to the cached file
         training_set_df = pd.read_pickle(
-            ".featureform/cache/training_set__fraud_training__quickstart.pkl"
+            ".featureform/cache/training_set__fraud_training__cache_test.pkl"
         )
         training_set_df["fraudulent"] = None
         training_set_df.to_pickle(
-            ".featureform/cache/training_set__fraud_training__quickstart.pkl"
+            ".featureform/cache/training_set__fraud_training__cache_test.pkl"
         )
 
         training_set = fixture.serving_client.training_set(
-            "fraud_training", "quickstart"
+            "fraud_training", "cache_test"
         )
         training_set_df = training_set.pandas()
 
@@ -189,7 +187,7 @@ class TestLocalCache:
         transactions.to_csv(fixture.transactions_file, index=False)
 
         label = fixture.serving_client.impl.db.get_label_variant(
-            "fraudulent", "quickstart"
+            "fraudulent", "cache_test"
         )
         label_df = fixture.serving_client.impl.get_label_dataframe(label)
 
@@ -208,7 +206,7 @@ class TestLocalCache:
         transactions.to_csv(fixture.transactions_file, index=False)
 
         training_set = fixture.serving_client.training_set(
-            "fraud_training", "quickstart"
+            "fraud_training", "cache_test"
         )
         training_set_df = training_set.pandas()
 
@@ -226,7 +224,7 @@ class TestLocalCache:
         transactions.to_csv(fixture.transactions_file, index=False)
 
         transformation_df = fixture.serving_client.impl.process_transformation(
-            "average_user_transaction", "quickstart"
+            "average_user_transaction", "cache_test"
         )
 
         # ensure all values are 0
@@ -244,9 +242,9 @@ class TestLocalCache:
         transactions.to_csv(fixture.transactions_file, index=False)
 
         feature = fixture.serving_client.impl.db.get_feature_variant(
-            "avg_transactions", "quickstart"
+            "avg_transactions", "cache_test"
         )
         feature_df = fixture.serving_client.impl.get_feature_dataframe(feature)
 
         # ensure all values are 0
-        assert feature_df["avg_transactions.quickstart"].all() == 0
+        assert feature_df["avg_transactions.cache_test"].all() == 0


### PR DESCRIPTION
# Description

The way the dashboard is run is through a single sqllitedb object that's instantiated on import. If that db file is deleted the db that it's pointing to is also deleted.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
