### PR TITLE
Docs: fixing issue with docs not being build or serve

### DIFF
--- a/client/docs/client.md
+++ b/client/docs/client.md
@@ -1,1 +1,1 @@
-:::src.featureform.client
+::: featureform.client.Client

--- a/client/docs/enums.md
+++ b/client/docs/enums.md
@@ -1,0 +1,1 @@
+::: featureform.enums

--- a/client/docs/local.md
+++ b/client/docs/local.md
@@ -1,10 +1,10 @@
 # Local
-::: src.featureform.register.LocalProvider
+::: featureform.register.LocalProvider
     handler: python
     options:
         show_root_heading: true
 
-::: src.featureform.register.LocalSource
+::: featureform.register.LocalSource
     handler: python
     options:
         show_root_heading: true

--- a/client/docs/register.md
+++ b/client/docs/register.md
@@ -1,20 +1,20 @@
 # Registering
-::: src.featureform.register.ResourceClient
+::: featureform.register.ResourceClient
     handler: python
     options:
       show_root_heading: true
 
-::: src.featureform.register.Registrar
+::: featureform.register.Registrar
     handler: python
     options:
         show_root_heading: true
 
-::: src.featureform.register.OfflineSQLProvider
+::: featureform.register.OfflineSQLProvider
     handler: python
     options:
         show_root_heading: true
 
-::: src.featureform.register.ColumnSourceRegistrar
+::: featureform.register.ColumnSourceRegistrar
     handler: python
     options:
         show_root_heading: true

--- a/client/docs/serve.md
+++ b/client/docs/serve.md
@@ -1,10 +1,10 @@
 # Serving
-::: src.featureform.serving.ServingClient
+::: featureform.serving.ServingClient
     handler: python
     options:
         show_root_heading: true
 
-::: src.featureform.serving.Dataset
+::: featureform.serving.Dataset
     handler: python
     options:
         show_root_heading: true

--- a/client/gen_pages.py
+++ b/client/gen_pages.py
@@ -35,7 +35,7 @@ excluded_files = [
     "version.py",
     "file_utils.py",
     "metadata.py",
-    "providers"
+    "providers",
 ]
 
 for filename in os.listdir("./src/featureform"):

--- a/client/gen_pages.py
+++ b/client/gen_pages.py
@@ -33,6 +33,9 @@ excluded_files = [
     "status_display.py",
     "local_cache.py",
     "version.py",
+    "file_utils.py",
+    "metadata.py",
+    "providers"
 ]
 
 for filename in os.listdir("./src/featureform"):
@@ -45,6 +48,6 @@ for filename in os.listdir("./src/featureform"):
     mdFile = f"{file}.md"
 
     with mkdocs_gen_files.open(mdFile, "w") as f:
-        print(f":::src.featureform.{file}", file=f)
+        print(f"::: featureform.{file}", file=f)
 
     mkdocs_gen_files.set_edit_path(mdFile, "gen_pages.py")

--- a/client/mkdocs.yml
+++ b/client/mkdocs.yml
@@ -7,7 +7,10 @@ theme:
         accent: "pink"
 plugins:
 - search
-- mkdocstrings
+- mkdocstrings:
+    handlers:
+        python:
+            paths: [src]
 - gen-files:
     scripts:
     - gen_pages.py

--- a/client/src/featureform/client.py
+++ b/client/src/featureform/client.py
@@ -88,8 +88,7 @@ class Client(ResourceClient, ServingClient):
         Query the K nearest neighbors of a provider vector in the index of a registered feature variant
 
         Args:
-            name (str): Feature name
-            variant (str): Feature variant
+            feature (Union[FeatureColumnResource, tuple(str, str)]): Feature object or tuple of Feature name and variant
             vector (List[float]): Query vector
             k (int): Number of nearest neighbors to return
 

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -870,7 +870,7 @@ class LocalSource:
         Returns the local source as a pandas datafame.
 
         Returns:
-        dataframe (pandas.Dataframe): A pandas Dataframe
+            dataframe (pandas.Dataframe): A pandas Dataframe
         """
         return pd.read_csv(self.path)
 
@@ -1478,7 +1478,7 @@ class LabelColumnResource(ColumnResource):
 
 
 class Registrar:
-    """These functions are used to register new resources and retrieving existing resources. Retrieved resources can be used to register additional resources. If information on these resources is needed (e.g. retrieve the names of all variants of a feature), use the [Resource Client](resource_client.md) instead.
+    """These functions are used to register new resources and retrieving existing resources. Retrieved resources can be used to register additional resources. If information on these resources is needed (e.g. retrieve the names of all variants of a feature), use the [Resource Client](client.md) instead.
 
     ``` py title="definitions.py"
     import featureform as ff
@@ -2171,7 +2171,6 @@ class Registrar:
             team (str): the name of the team registering the filestore
             account_name (str): Azure account name
             account_key (str): Secret azure account key
-            config (AzureConfig): an azure config object (can be used in place of container name and account name)
             tags (List[str]): Optional grouping mechanism for resources
             properties (dict): Optional grouping mechanism for resources
         Returns:
@@ -2456,7 +2455,7 @@ class Registrar:
             team (str): Name of team
             host (str): DNS name of Cassandra
             port (str): Port
-            user (str): User
+            username (str): Username
             password (str): Password
             consistency (str): Consistency
             replication (int): Replication
@@ -3513,9 +3512,7 @@ class Registrar:
             labels (List[ColumnMapping]): List of ColumnMapping objects (dictionaries containing the keys: name, variant, column, resource_type)
             description (str): Description
             schedule (str): Kubernetes CronJob schedule string ("* * * * *")
-            tags (List[str]): Optional grouping mechanism for resources
-            properties (dict): Optional grouping mechanism for resources
-
+            
         Returns:
             resource (ResourceRegistrar): resource
         """

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -3512,7 +3512,7 @@ class Registrar:
             labels (List[ColumnMapping]): List of ColumnMapping objects (dictionaries containing the keys: name, variant, column, resource_type)
             description (str): Description
             schedule (str): Kubernetes CronJob schedule string ("* * * * *")
-            
+
         Returns:
             resource (ResourceRegistrar): resource
         """

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -116,7 +116,7 @@ class ServingClient:
             variant (str): Variant of training set to be retrieved
 
         Returns:
-            training set (Dataset): A training set iterator
+            training_set (Dataset): A training set iterator
         """
         return self.impl.training_set(name, variant, include_label_timestamp, model)
 


### PR DESCRIPTION
# Description
There was an issue with docs not being able to be served locally or build using Github Actions. With this PR, we are able to build it locally. 

**Ask**: If you don't mind checking out this branch and running `mkdocs serve` from the `client` folder just to verify that you are able to serve it locally as well. 

_you might have to install the mkdocs packages_
```
pip install mkdocs mkdocs-material mkdocstrings-python mkdocs-gen-files mkdocs-literate-nav
``` 

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
