### PR TITLE
Add option to continue on invalid file when reading directory

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -578,6 +578,7 @@ class LocalProvider:
         self,
         name,
         path,
+        continue_on_invalid_file: bool = True,
         description="",
         variant: str = "",
         owner="",
@@ -606,6 +607,7 @@ class LocalProvider:
             description (str): Description of the directory
             path (str): Path to directory
             variant (str): Directory variant
+            continue_on_invalid_file (bool): If true, will ignore invalid files and continue
             owner (str): Owner of the file
 
         Returns:
@@ -619,9 +621,12 @@ class LocalProvider:
             try:
                 Path(absolute_fn).read_text()
             except Exception as e:
-                raise IOError(
-                    f"Cannot read file {absolute_fn}: {e}\nFile must be a text file"
-                )
+                if continue_on_invalid_file:
+                    print(f"Ignoring file {absolute_fn}: {e}")
+                else:
+                    raise IOError(
+                        f"Cannot read file {absolute_fn}: {e}\nFile must be a text file"
+                    )
 
         if owner == "":
             owner = self.__registrar.must_get_default_owner()

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -636,7 +636,7 @@ class LocalProvider:
         self.__registrar.register_primary_data(
             name=name,
             variant=variant,
-            location=Directory(path),
+            location=Directory(path, continue_on_invalid_file),
             provider=self.__provider.name,
             owner=owner,
             description=description,

--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -873,6 +873,7 @@ class SQLTable:
 @dataclass
 class Directory:
     path: str
+    continue_on_invalid_file: bool
 
 
 Location = Union[SQLTable, Directory]
@@ -1051,7 +1052,12 @@ class Source:
             self.definition = self.definition.query
         elif type(self.definition) == PrimaryData:
             if isinstance(self.definition.location, Directory):
-                self.definition = self.definition.path()
+                self.definition = json.dumps(
+                    {
+                        "path": self.definition.location.path,
+                        "continue_on_error": self.definition.location.continue_on_invalid_file,
+                    }
+                )
                 self.is_transformation = SourceType.DIRECTORY.value
             elif isinstance(self.definition.location, SQLTable):
                 self.definition = self.definition.name()


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allows option to ignore or error when an invalid file is read when reading a directory

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
