### PR TITLE
Fix table row sizing

### DIFF
--- a/dashboard/src/components/resource-list/ResourceListView.js
+++ b/dashboard/src/components/resource-list/ResourceListView.js
@@ -297,6 +297,8 @@ export const ResourceListView = ({
             ),
           }}
           options={{
+            pageSize: 10,
+            emptyRowsWhenPaging: true,
             loadingType: 'overlay',
             search: true,
             draggable: false,
@@ -408,8 +410,9 @@ export const VariantTable = ({ name, setVariant, type, row }) => {
           ]}
           data={myVariants}
           options={{
+            pageSize: 10,
+            emptyRowsWhenPaging: false,
             search: true,
-            pageSize: row.variants.length,
             maxHeight: `${MAX_ROW_SHOW * ROW_HEIGHT}em`,
             toolbar: false,
             draggable: false,


### PR DESCRIPTION
# Description
This PR sets a default `pageSize` for the main resource tables to 10, and also decouples the variant length from the sub tables. 

`primary table`
Defaults to 10 records. 
![Screenshot 2023-07-27 at 2 23 37 PM](https://github.com/featureform/featureform/assets/34227093/13abc41a-39ed-4348-bf19-f05e3918c5d3)

`sub variant table`
Dynamically grows to a max of 10 records before paging.
![Screenshot 2023-07-27 at 2 23 46 PM](https://github.com/featureform/featureform/assets/34227093/a5567165-20c8-4390-9941-afb1df442f2b)


<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
