### PR TITLE
KCF dockerfile image to 3.10 + use consistent dill versioning

### DIFF
--- a/client/setup.cfg
+++ b/client/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     flask==2.2.1
     Flask-Cors==3.0.10
     validators>=0.20.0
-    dill>=0.3.6
+    dill==0.3.7
     pandasql==0.7.3
     sqlalchemy<2.0.0
     requests

--- a/provider/scripts/k8s/Dockerfile
+++ b/provider/scripts/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.10-slim
 
 WORKDIR /usr/app/src
 

--- a/provider/scripts/k8s/offline_store_pandas_runner.py
+++ b/provider/scripts/k8s/offline_store_pandas_runner.py
@@ -1,8 +1,6 @@
-import io
 import os
 import types
 
-from typing import List
 from datetime import datetime
 from argparse import Namespace
 

--- a/provider/scripts/k8s/requirements.txt
+++ b/provider/scripts/k8s/requirements.txt
@@ -1,4 +1,4 @@
-dill>=0.3.6
+dill==0.3.7
 pandas==1.3.5
 pandasql==0.7.3
 pyarrow==9.0.0

--- a/provider/scripts/k8s/requirements.txt
+++ b/provider/scripts/k8s/requirements.txt
@@ -1,4 +1,4 @@
-dill==0.3.5.1
+dill>=0.3.6
 pandas==1.3.5
 pandasql==0.7.3
 pyarrow==9.0.0

--- a/provider/scripts/spark/requirements.txt
+++ b/provider/scripts/spark/requirements.txt
@@ -1,5 +1,5 @@
 boto3
-dill==0.3.5.1
+dill>=0.3.6
 pyspark==3.3.0
 pytest==7.1.2
 pytest-cov==3.0.0

--- a/provider/scripts/spark/requirements.txt
+++ b/provider/scripts/spark/requirements.txt
@@ -1,5 +1,5 @@
 boto3
-dill>=0.3.6
+dill==0.3.7.1
 pyspark==3.3.0
 pytest==7.1.2
 pytest-cov==3.0.0

--- a/provider/scripts/spark/requirements.txt
+++ b/provider/scripts/spark/requirements.txt
@@ -1,5 +1,5 @@
 boto3
-dill==0.3.7.1
+dill==0.3.7
 pyspark==3.3.0
 pytest==7.1.2
 pytest-cov==3.0.0


### PR DESCRIPTION
# Description

Use python 3.10 for KCF base image and use the same dill versioning for both client and k8s/spark

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
