### PR TITLE
Bugfix: Returning meaningful error message when Dill doesn't work

### DIFF
--- a/provider/scripts/k8s/tests/conftest.py
+++ b/provider/scripts/k8s/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import dill
 import pytest
@@ -208,3 +209,16 @@ def container_client():
         os.getenv("AZURE_CONTAINER_NAME")
     )
     return container_client
+
+
+@pytest.fixture(scope="module")
+def dill_python_version_error():
+    version = sys.version_info
+    python_version = f"{version.major}.{version.minor}.{version.micro}"
+    error_message = f"""This error is most likely caused by different Python versions between the client and k8s provider. Check to see if you are running Python version '{python_version}' on the client."""
+    return Exception(error_message)
+
+
+@pytest.fixture(scope="module")
+def generic_error():
+    return Exception("generic error")

--- a/provider/scripts/k8s/tests/test_offline_store_pandas_runner.py
+++ b/provider/scripts/k8s/tests/test_offline_store_pandas_runner.py
@@ -17,6 +17,7 @@ from offline_store_pandas_runner import (
     execute_df_job,
     execute_sql_job,
     get_blob_credentials,
+    check_dill_exception,
 )
 
 real_path = os.path.realpath(__file__)
@@ -235,3 +236,19 @@ def load_env_file():
     )
     env_file = os.path.join(env_directory, ".env")
     load_dotenv(env_file)
+
+
+@pytest.mark.parametrize(
+    "exception_message, error",
+    [
+        (
+            Exception("TypeError: code() takes at most 16 arguments (19 given)"),
+            "dill_python_version_error",
+        ),
+        (Exception("generic error"), "generic_error"),
+    ],
+)
+def test_check_dill_exception(exception_message, error, request):
+    expected_error = request.getfixturevalue(error)
+    error = check_dill_exception(exception_message)
+    assert str(error) == str(expected_error)

--- a/provider/scripts/spark/offline_store_spark_runner.py
+++ b/provider/scripts/spark/offline_store_spark_runner.py
@@ -1,5 +1,6 @@
 import io
 import os
+import sys
 import json
 import uuid
 import types
@@ -360,6 +361,15 @@ def delete_file(file_path):
         os.remove(file_path)
     else:
         print(f"{file_path} does not exist.")
+
+
+def dill_exception(exception):
+    if "TypeError: code() takes at most" in str(exception):
+        version = sys.version_info
+        python_version = f"{version.major}.{version.minor}.{version.micro}"
+        error_message = f"""DF Transformations require the same Python versions for both the client and provider. Please use Python '{python_version}' to run this job."""
+        return Exception(error_message)
+    return exception
 
 
 def split_key_value(values):

--- a/provider/scripts/spark/tests/conftest.py
+++ b/provider/scripts/spark/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from argparse import Namespace
 
 import dill
@@ -256,3 +257,16 @@ def container_client():
         os.getenv("AZURE_CONTAINER_NAME")
     )
     return container_client
+
+
+@pytest.fixture(scope="module")
+def dill_python_version_error():
+    version = sys.version_info
+    python_version = f"{version.major}.{version.minor}.{version.micro}"
+    error_message = f"""DF Transformations require the same Python versions for both the client and provider. Please use Python '{python_version}' to run this job."""
+    return Exception(error_message)
+
+
+@pytest.fixture(scope="module")
+def generic_error():
+    return Exception("generic error")

--- a/provider/scripts/spark/tests/conftest.py
+++ b/provider/scripts/spark/tests/conftest.py
@@ -263,7 +263,7 @@ def container_client():
 def dill_python_version_error():
     version = sys.version_info
     python_version = f"{version.major}.{version.minor}.{version.micro}"
-    error_message = f"""DF Transformations require the same Python versions for both the client and provider. Please use Python '{python_version}' to run this job."""
+    error_message = f"""This error is most likely caused by different Python versions between the client and Spark provider. Check to see if you are running Python version '{python_version}' on the client."""
     return Exception(error_message)
 
 

--- a/provider/scripts/spark/tests/test_offline_store_spark_runner.py
+++ b/provider/scripts/spark/tests/test_offline_store_spark_runner.py
@@ -15,6 +15,7 @@ from offline_store_spark_runner import (
     split_key_value,
     get_credentials_dict,
     delete_file,
+    dill_exception,
 )
 
 
@@ -160,3 +161,16 @@ def test_split_key_value():
 
     output = split_key_value(key_values)
     assert output == expected_output
+
+
+@pytest.mark.parametrize(
+    "exception_message, error",
+    [
+        (Exception("TypeError: code() takes at most 16 arguments (19 given)"), "dill_python_version_error"),
+        (Exception("generic error"), "generic_error"),
+    ],
+)
+def test_dill_exception(exception_message, error, request):
+    expected_error = request.getfixturevalue(error)
+    error = dill_exception(exception_message)
+    assert str(error) == str(expected_error)

--- a/provider/scripts/spark/tests/test_offline_store_spark_runner.py
+++ b/provider/scripts/spark/tests/test_offline_store_spark_runner.py
@@ -15,7 +15,7 @@ from offline_store_spark_runner import (
     split_key_value,
     get_credentials_dict,
     delete_file,
-    dill_exception,
+    check_dill_exception,
 )
 
 
@@ -173,7 +173,7 @@ def test_split_key_value():
         (Exception("generic error"), "generic_error"),
     ],
 )
-def test_dill_exception(exception_message, error, request):
+def test_check_dill_exception(exception_message, error, request):
     expected_error = request.getfixturevalue(error)
-    error = dill_exception(exception_message)
+    error = check_dill_exception(exception_message)
     assert str(error) == str(expected_error)

--- a/provider/scripts/spark/tests/test_offline_store_spark_runner.py
+++ b/provider/scripts/spark/tests/test_offline_store_spark_runner.py
@@ -166,7 +166,10 @@ def test_split_key_value():
 @pytest.mark.parametrize(
     "exception_message, error",
     [
-        (Exception("TypeError: code() takes at most 16 arguments (19 given)"), "dill_python_version_error"),
+        (
+            Exception("TypeError: code() takes at most 16 arguments (19 given)"),
+            "dill_python_version_error",
+        ),
         (Exception("generic error"), "generic_error"),
     ],
 )


### PR DESCRIPTION
Adding a check to make sure that we return a more meaningful error message when the dill throws:
```
TypeError: code() takes at most 16 arguments (19 given)
```

I was also reading through more about it and came across this Issue on [dill's GitHub repo](https://github.com/uqfoundation/dill/issues/254). This [comment](https://github.com/uqfoundation/dill/issues/254#issuecomment-363625245) on the issue can potentially be really useful for us. Basically, they mention that **marshal** might be an alternative option that would avoid these issues. 

# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
