### PR TITLE
Bugfix: postgres backend default disable ssl

### DIFF
--- a/docs/deployment/quickstart-docker.md
+++ b/docs/deployment/quickstart-docker.md
@@ -227,7 +227,7 @@ training set and returns 25 rows of the training set.
 from featureform import ServingClient
 
 client = ServingClient(insecure=True)
-dataset = client.training_set("fraud_training")
+dataset = client.training_set("fraud_training", "default")
 
 for i, batch in enumerate(dataset):
     print(batch)

--- a/docs/quickstart_scripts/training.py
+++ b/docs/quickstart_scripts/training.py
@@ -1,7 +1,7 @@
 from featureform import Client
 
 client = Client(insecure=True)
-dataset = client.training_set("fraud_training")
+dataset = client.training_set("fraud_training", "default")
 
 for i, batch in enumerate(dataset):
     print(batch)

--- a/provider/postgres.go
+++ b/provider/postgres.go
@@ -27,11 +27,20 @@ func postgresOfflineStoreFactory(config pc.SerializedConfig) (Provider, error) {
 	if err := sc.Deserialize(config); err != nil {
 		return nil, fmt.Errorf("invalid postgres config: %v", config)
 	}
+
+	// We are doing this to support older versions of
+	// featureform that did not have the sslmode field
+	// on the client side.
+	sslMode := sc.SSLMode
+	if sslMode == "" {
+		sslMode = "disable"
+	}
+
 	queries := postgresSQLQueries{}
 	queries.setVariableBinding(PostgresBindingStyle)
 	sgConfig := SQLOfflineStoreConfig{
 		Config:        config,
-		ConnectionURL: fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", sc.Username, sc.Password, sc.Host, sc.Port, sc.Database, sc.SSLMode),
+		ConnectionURL: fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", sc.Username, sc.Password, sc.Host, sc.Port, sc.Database, sslMode),
 		Driver:        "postgres",
 		ProviderType:  pt.PostgresOffline,
 		QueryImpl:     &queries,


### PR DESCRIPTION
# Description
Defaulting the postgres backend to `"disable"` for empty strings. This allows for backwards compatibility with older versions of featureform. 

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
