### PR TITLE
Handle missing default variant issue on dash

### DIFF
--- a/dashboard/__tests__/ResourceListView.test.js
+++ b/dashboard/__tests__/ResourceListView.test.js
@@ -4,7 +4,10 @@ import { configure } from 'enzyme';
 import produce from 'immer';
 import 'jest-canvas-mock';
 import React from 'react';
-import { ResourceListView } from '../src/components/resource-list/ResourceListView';
+import {
+  filterMissingDefaults,
+  ResourceListView,
+} from '../src/components/resource-list/ResourceListView';
 import { deepCopy } from '../src/helper';
 
 configure({ adapter: new Adapter() });
@@ -124,7 +127,7 @@ describe('ResourceListView tests', () => {
     expect(foundProgressBar.firstChild.nodeName).toBe(SVG_NODE);
   });
 
-  test('Warn the user if the default variant is missing from the all-variants list', async () => {
+  test('Filter out resources that are missing their default variant in their all-variants list.', async () => {
     console.warn = jest.fn();
     const missingDefault = 'MISSING DEFAULT!!!';
     const variantList = ['eloquent_goldstine', 'sleepy_volhard'];
@@ -150,19 +153,66 @@ describe('ResourceListView tests', () => {
 
     const helper = render(
       <ResourceListView
-        title='test'
+        title='Source'
         loading={false}
         failed={false}
         type='Source'
         resources={badJsonResponse}
       />
     );
+
     const foundTitle = await helper.findByText('Sources');
+    const foundNoDataContainer = await helper.findByTestId('noDataContainerId');
 
     expect(foundTitle.nodeName).toBeDefined();
+    expect(foundNoDataContainer.nodeName).toBeDefined();
     expect(console.warn).toHaveBeenCalledWith(
       `The current default rowVariant (${missingDefault}) is not present in the variants list:`,
       variantList
     );
+  });
+
+  test('removeResourcesWithMissingDefaults() removes resources whose default names are not present in the "all-variants"', async () => {
+    console.warn = jest.fn();
+    //the second record, is missing it's default variant from the all-variants list
+    const jsonResponse = [
+      {
+        'all-variants': ['presentVariant', 'secondVariant'],
+        type: 'Source',
+        'default-variant': ['presentVariant'],
+        name: 'good record',
+        variants: {
+          presentVariant: {
+            name: 'transactions',
+            variant: 'presentVariant',
+          },
+          secondVariant: {
+            name: 'transactions',
+            variant: 'secondVariant',
+          },
+        },
+      },
+      {
+        'all-variants': ['eloquent_goldstine', 'sleepy_volhard'],
+        type: 'Source',
+        'default-variant': 'MISSING VARIANT!',
+        name: 'faulty record',
+        variants: {
+          eloquent_goldstine: {
+            name: 'transactions',
+            variant: 'eloquent_goldstine',
+          },
+          sleepy_volhard: {
+            name: 'transactions',
+            variant: 'sleepy_volhard',
+          },
+        },
+      },
+    ];
+
+    const result = jsonResponse.filter(filterMissingDefaults);
+
+    expect(result.length).toBe(1);
+    expect(result[0].name).toBe('good record');
   });
 });

--- a/dashboard/__tests__/ResourceListView.test.js
+++ b/dashboard/__tests__/ResourceListView.test.js
@@ -127,7 +127,7 @@ describe('ResourceListView tests', () => {
     expect(foundProgressBar.firstChild.nodeName).toBe(SVG_NODE);
   });
 
-  test('Filter out resources that are missing their default variant in their all-variants list.', async () => {
+  test('Issue-204: Filter out resources that are missing their default variant in their all-variants list.', async () => {
     console.warn = jest.fn();
     const missingDefault = 'MISSING DEFAULT!!!';
     const variantList = ['eloquent_goldstine', 'sleepy_volhard'];
@@ -172,7 +172,7 @@ describe('ResourceListView tests', () => {
     );
   });
 
-  test('removeResourcesWithMissingDefaults() removes resources whose default names are not present in the "all-variants"', async () => {
+  test('Issue-204: removeResourcesWithMissingDefaults() removes resources whose default names are not present in the "all-variants"', async () => {
     console.warn = jest.fn();
     //the second record, is missing it's default variant from the all-variants list
     const jsonResponse = [

--- a/dashboard/src/components/resource-list/ResourceListView.js
+++ b/dashboard/src/components/resource-list/ResourceListView.js
@@ -86,6 +86,22 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+export function filterMissingDefaults(row = {}) {
+  const defaultVariant = row['default-variant'];
+  if (row?.variants) {
+    if (defaultVariant in row.variants) {
+      return true;
+    } else {
+      console.warn(
+        `The current default rowVariant (${defaultVariant}) is not present in the variants list:`,
+        row.variants ? Object.keys(row.variants) : 'row.variants is undefined.'
+      );
+      return false;
+    }
+  }
+  return true;
+}
+
 export const ResourceListView = ({
   title,
   resources,
@@ -199,9 +215,11 @@ export const ResourceListView = ({
   const initialLoad = resources == null && !loading;
   const initRes = resources || [];
   const noVariants = !Resource[type].hasVariants;
+
   // MaterialTable can't handle immutable object, we have to make a copy
   // https://github.com/mbrn/material-table/issues/666
-  const mutableRes = deepCopy(initRes);
+  let mutableRes = deepCopy(initRes);
+  mutableRes = mutableRes.filter(filterMissingDefaults);
 
   function detailRedirect(e, data) {
     e.stopPropagation();
@@ -267,13 +285,6 @@ export const ResourceListView = ({
               )) {
                 rowData[key] = data;
               }
-            } else {
-              console.warn(
-                `The current default rowVariant (${rowVariant}) is not present in the variants list:`,
-                row.variants
-                  ? Object.keys(row.variants)
-                  : 'row.variants is undefined.'
-              );
             }
             let variantList = [];
             Object.values(row.variants).forEach((variantValue) => {
@@ -325,7 +336,7 @@ export const ResourceListView = ({
             ? {
                 localization: {
                   body: {
-                    emptyDataSourceMessage: <NoDataMessage type={title} />,
+                    emptyDataSourceMessage: <NoDataMessage type={type} />,
                   },
                 },
               }
@@ -498,7 +509,7 @@ const NoDataMessage = ({ type }) => {
       'https://docs.featureform.com/getting-started/overview';
   }
   return (
-    <Container>
+    <Container data-testid='noDataContainerId'>
       <div className={classes.noDataPage}>
         <Typography variant='h4'>
           No {Resource[type].typePlural} Registered


### PR DESCRIPTION
# Description

This PR mitigates an issue where a resource with variants, does not contain its `default-variant` in its `all-variants` list. 
This causes an "empty" record to display on the dashboard that leads to a 404 when clicked. 

The current mitigation is to remove the offending table record from the resources table, but warn the user of the issue. 

`faulty example`

<img width="1342" alt="Screenshot 2023-09-25 at 3 56 53 PM" src="https://github.com/featureform/featureform/assets/34227093/877f894c-b7c9-4ae5-a6ac-251d97aef066">






`unit tests`

<img width="1033" alt="Screenshot 2023-09-26 at 5 12 42 PM" src="https://github.com/featureform/featureform/assets/34227093/385aa06b-eec4-4f67-8cfa-130bc576f1eb">



<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
