### PR TITLE
Bugfix: Fix state error for resource redefined error

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -4182,8 +4182,8 @@ class ResourceClient:
         """
 
         print(f"Applying Run: {get_run()}")
-        resource_state = state()
         try:
+            resource_state = state()
             if self._dry_run:
                 print(resource_state.sorted_list())
                 return

--- a/client/tests/register_test.py
+++ b/client/tests/register_test.py
@@ -4,6 +4,7 @@ import stat
 import sys
 
 import featureform as ff
+from featureform import ResourceRedefinedError
 
 sys.path.insert(0, "client/src/")
 import pytest
@@ -264,3 +265,18 @@ def run_before_and_after_tests(tmpdir):
         shutil.rmtree(".featureform", onerror=del_rw)
     except:
         print("File Already Removed")
+
+
+def test_state_not_clearing_after_resource_not_defined():
+    ff.local.register_file(name="a", path="a.csv")
+
+    ff.local.register_file(name="a", path="b.csv")
+
+    client = ff.Client(local=True)
+
+    with pytest.raises(ResourceRedefinedError):
+        client.apply()  # should clear state after
+
+    ff.local.register_file(name="a", path="a.csv")
+
+    client.apply()  # should throw no error, previously this was a bug

--- a/client/tests/test_resource_registration.py
+++ b/client/tests/test_resource_registration.py
@@ -1,33 +1,6 @@
 import time
 import featureform as ff
 import pytest
-from featureform import ResourceRedefinedError
-
-
-def test_state_not_clearing_after_resource_not_defined():
-    ff.local.register_file(
-        name="a",
-        path="a.csv"
-    )
-
-    ff.local.register_file(
-        name="a",
-        path="b.csv"
-    )
-
-    client = ff.Client(local=True)
-
-    with pytest.raises(ResourceRedefinedError):
-        client.apply()  # should clear state
-
-    ff.local.register_file(
-        name="a",
-        path="a.csv"
-    )
-
-    client.apply()  # should throw no error, previously this was a bug
-
-
 
 
 @pytest.mark.parametrize(

--- a/client/tests/test_resource_registration.py
+++ b/client/tests/test_resource_registration.py
@@ -1,6 +1,33 @@
 import time
 import featureform as ff
 import pytest
+from featureform import ResourceRedefinedError
+
+
+def test_state_not_clearing_after_resource_not_defined():
+    ff.local.register_file(
+        name="a",
+        path="a.csv"
+    )
+
+    ff.local.register_file(
+        name="a",
+        path="b.csv"
+    )
+
+    client = ff.Client(local=True)
+
+    with pytest.raises(ResourceRedefinedError):
+        client.apply()  # should clear state
+
+    ff.local.register_file(
+        name="a",
+        path="a.csv"
+    )
+
+    client.apply()  # should throw no error, previously this was a bug
+
+
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This was how to recreate the problem:

- register file
- register file again with different name
- apply (you get a failure)
- reregister file and re apply and it fails

# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
