### PR TITLE
Bugfix localmode for created time field and python formatting

### DIFF
--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -1125,7 +1125,7 @@ class SourceVariant:
     def _create_local(self, db) -> None:
         should_insert_text = False
         source_text = ""
-        source_type = "Source"
+        self.source_type = "Source"
         if type(self.definition) == DFTransformation:
             should_insert_text = True
             self.is_transformation = SourceType.DF_TRANSFORMATION.value

--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -1125,6 +1125,7 @@ class SourceVariant:
     def _create_local(self, db) -> None:
         should_insert_text = False
         source_text = ""
+        source_type = "Source"
         if type(self.definition) == DFTransformation:
             should_insert_text = True
             self.is_transformation = SourceType.DF_TRANSFORMATION.value
@@ -1132,6 +1133,7 @@ class SourceVariant:
             self.inputs = self.definition.inputs
             self.definition = self.definition.query
             self.source_text = source_text
+            self.source_type = "Dataframe Transformation"
         elif type(self.definition) == SQLTransformation:
             self.is_transformation = SourceType.SQL_TRANSFORMATION.value
             self.definition = self.definition.query
@@ -1151,7 +1153,7 @@ class SourceVariant:
             str(time.time()),
             self.description,
             self.name,
-            "Source",
+            self.source_type,
             self.owner,
             self.provider,
             self.variant,

--- a/client/tests/local_dash_test.py
+++ b/client/tests/local_dash_test.py
@@ -236,7 +236,7 @@ sources = [
             "quickstart": {
                 "description": "the average transaction amount for a user",
                 "name": "average_user_transaction",
-                "source-type": "Source",
+                "source-type": "Dataframe Transformation",
                 "owner": "default_user",
                 "provider": "local-mode",
                 "variant": "quickstart",
@@ -744,7 +744,7 @@ users = [
                 {
                     "description": "the average transaction amount for a user",
                     "name": "average_user_transaction",
-                    "source-type": "Source",
+                    "source-type": "Dataframe Transformation",
                     "owner": "default_user",
                     "provider": "local-mode",
                     "variant": "quickstart",
@@ -955,7 +955,7 @@ providers = [
                 {
                     "description": "the average transaction amount for a user",
                     "name": "average_user_transaction",
-                    "source-type": "Source",
+                    "source-type": "Dataframe Transformation",
                     "owner": "default_user",
                     "provider": "local-mode",
                     "variant": "quickstart",
@@ -1313,7 +1313,7 @@ default_user = {
             {
                 "description": "the average transaction amount for a user",
                 "name": "average_user_transaction",
-                "source-type": "Source",
+                "source-type": "Dataframe Transformation",
                 "owner": "default_user",
                 "provider": "local-mode",
                 "variant": "quickstart",
@@ -1521,7 +1521,7 @@ localmode = {
             {
                 "description": "the average transaction amount for a user",
                 "name": "average_user_transaction",
-                "source-type": "Source",
+                "source-type": "Dataframe Transformation",
                 "owner": "default_user",
                 "provider": "local-mode",
                 "variant": "quickstart",
@@ -1633,7 +1633,7 @@ average_user_transaction = {
         "quickstart": {
             "description": "the average transaction amount for a user",
             "name": "average_user_transaction",
-            "source-type": "Source",
+            "source-type": "Dataframe Transformation",
             "owner": "default_user",
             "provider": "local-mode",
             "variant": "quickstart",
@@ -2144,7 +2144,6 @@ def test_sourcedata_args_not_found(client: FlaskClient):
     )
     json_data = json.loads(response.data.decode())
 
-    print(json_data)
     assert response.status == "500 INTERNAL SERVER ERROR"
     assert json_data == "Error 500: Unable to retrieve source_data columns."
 

--- a/dashboard/__tests__/entityPage.test.js
+++ b/dashboard/__tests__/entityPage.test.js
@@ -180,10 +180,11 @@ describe('Entity Page Tests', () => {
     expect(attemptedFormatSql).toBe(originalInvalidSQL);
   });
 
+  // number string since epoch in seconds
   test.each`
     CreatedInputParam                  | ResultParam
-    ${'1695751185.068369'}             | ${'1/20/1970'}
-    ${'1695751185'}                    | ${'1/20/1970'}
+    ${'1695751185.068369'}             | ${'9/26/2023'}
+    ${'1695751185'}                    | ${'9/26/2023'}
     ${'2023-09-23T12:10:33.61933372Z'} | ${'9/23/2023'}
     ${'2023-12-16T12:00:00'}           | ${'12/16/2023'}
     ${'Not a number or a date string'} | ${'Invalid Date'}

--- a/dashboard/src/components/entitypage/EntityPageView.js
+++ b/dashboard/src/components/entitypage/EntityPageView.js
@@ -221,7 +221,9 @@ export const convertInputToDate = (timestamp_string_or_mil = '') => {
   if (isNaN(input)) {
     return generateDate(input);
   } else {
-    return generateDate(parseFloat(input));
+    const createdTimeInSeconds = parseFloat(input); //resources.py returns seconds, not milliseconds
+    const createdTimeMilliSeconds = Math.round(createdTimeInSeconds * 1000);
+    return generateDate(createdTimeMilliSeconds);
   }
 
   function generateDate(str) {
@@ -431,8 +433,7 @@ const EntityPageView = ({ api, entity, setVariant, activeVariants }) => {
                     )}
                     {metadata['joined'] && (
                       <Typography variant='body1'>
-                        <b>Joined:</b>{' '}
-                        {convertInputToDate(metadata['joined'])}
+                        <b>Joined:</b> {convertInputToDate(metadata['joined'])}
                       </Typography>
                     )}
                     {metadata['software'] && (


### PR DESCRIPTION
# Description

This PR fixes a sync issue with python's and js's time values for the `created` field. 
`resources.py` returns epoch time in seconds, and the dash was interpreting it as milliseconds.
Resulting in created times always rendering 1/1/1970.

`entityPage.test.js`
<img width="828" alt="Screenshot 2023-09-29 at 11 35 26 AM" src="https://github.com/featureform/featureform/assets/34227093/a696980c-e5cb-4269-ba2d-dd793f45f56d">

The PR also fixes an issue where `localmode` is returning 'Source' as the `source-type` for DFT transformations.
This enables the python formatter to correctly pick up the source type and format the code accordingly. 

`local_dash_test.py`
<img width="1138" alt="Screenshot 2023-09-29 at 3 08 30 PM" src="https://github.com/featureform/featureform/assets/34227093/97c3fba6-1ee7-4d7a-9c75-2f4fb9a41ac1">




![Screenshot 2023-09-29 at 11 38 04 AM](https://github.com/featureform/featureform/assets/34227093/d665d51e-3ba5-4bff-9a21-3a525b6bce6c)



<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
