### PR TITLE
Refresh and Loading fix

### DIFF
--- a/dashboard/src/components/entitypage/EntityPage.js
+++ b/dashboard/src/components/entitypage/EntityPage.js
@@ -59,14 +59,14 @@ const EntityPage = ({
     }
   }, [type, entity]);
 
-  return (
-    <div>
-      {entityPage.loading ? (
-        <LoadingDots />
-      ) : entityPage.failed ||
-        (!entityPage.loading && fetchNotFound(entityPage)) ? (
-        <NotFoundPage />
-      ) : (
+  let body = <></>;
+  if (entityPage.loading === true) {
+    body = <LoadingDots />;
+  } else if (entityPage.loading === false) {
+    if (entityPage.failed === true || fetchNotFound(entityPage)) {
+      body = <NotFoundPage />;
+    } else {
+      body = (
         <EntityPageView
           api={api}
           entity={entityPage}
@@ -75,9 +75,10 @@ const EntityPage = ({
           typePath={type}
           resourceType={resourceType}
         />
-      )}
-    </div>
-  );
+      );
+    }
+  }
+  return body;
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(EntityPage);

--- a/dashboard/src/components/notfoundpage/NotFoundPage.js
+++ b/dashboard/src/components/notfoundpage/NotFoundPage.js
@@ -3,7 +3,7 @@ import React from 'react';
 const NotFoundPage = () => {
   return (
     <div data-testid='notFoundId'>
-      <h1>404 Not Found :(</h1>
+      <h1>404 Not Found</h1>
     </div>
   );
 };


### PR DESCRIPTION
# Description

This PR fixes an issue that causes a "404" message to display when hard refreshing the page. Now the loading dots correctly display until the resources is fully loaded. 

`example slowed to 'Fast 3g'`

https://github.com/featureform/featureform/assets/34227093/2eba8434-64bc-423e-8f5e-414448bdafbd


<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
