### PR TITLE
Bugfix: Removing scheme in bucket_name and checking it is a bucket_name

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -75,3 +75,4 @@ With steps 1-5 successfully completed, you should have the `featureform` CLI com
 ```
 
 To further verify that your setup is complete and correct, you may optionally walk through the [Quickstart](https://docs.featureform.com/quickstart-local) tutorial. You may put the `definitions.py` file at the root of the project, which won’t be ignored by Git, or use a URL to a file (e.g. hosted on GitHub).
+

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2495,6 +2495,14 @@ class Registrar:
         if bucket_name == "":
             raise ValueError("bucket_name required")
 
+        # TODO: add verification into S3StoreConfig
+        bucket_name = bucket_name.replace("s3://", "").replace("s3a://", "")
+
+        if "/" in bucket_name:
+            raise ValueError(
+                "bucket_name cannot contain '/'. bucket_name should be the name of the AWS S3 bucket only."
+            )
+
         s3_config = S3StoreConfig(
             bucket_path=bucket_name,
             bucket_region=bucket_region,

--- a/client/tests/redefined_test.py
+++ b/client/tests/redefined_test.py
@@ -193,8 +193,7 @@ class TestResourcesRedefined:
                 },
             ],
         )
-        with pytest.raises(ResourceRedefinedError):
-            client.apply()
+        client.apply()
 
         ff.register_training_set(
             "fraud_training",

--- a/client/tests/register_test.py
+++ b/client/tests/register_test.py
@@ -280,3 +280,43 @@ def test_state_not_clearing_after_resource_not_defined():
     ff.local.register_file(name="a", path="a.csv")
 
     client.apply()  # should throw no error, previously this was a bug
+
+
+@pytest.mark.parametrize(
+    "bucket_name, expected_error",
+    [
+        ("s3://bucket_name", None),
+        ("bucket_name", None),
+        ("s3a://bucket_name", None),
+        (
+            "bucket_name/",
+            ValueError(
+                "bucket_name cannot contain '/'. bucket_name should be the name of the AWS S3 bucket only."
+            ),
+        ),
+        (
+            "s3://bucket_name/",
+            ValueError(
+                "bucket_name cannot contain '/'. bucket_name should be the name of the AWS S3 bucket only."
+            ),
+        ),
+        (
+            "s3a://bucket_name/",
+            ValueError(
+                "bucket_name cannot contain '/'. bucket_name should be the name of the AWS S3 bucket only."
+            ),
+        ),
+    ],
+)
+def test_register_s3(bucket_name, expected_error, ff_registrar, aws_credentials):
+    try:
+        _ = ff_registrar.register_s3(
+            name="s3_bucket",
+            credentials=aws_credentials,
+            bucket_region="us-east-1",
+            bucket_name=bucket_name,
+        )
+    except ValueError as ve:
+        assert str(ve) == str(expected_error)
+    except Exception as e:
+        raise e

--- a/provider/filestore.go
+++ b/provider/filestore.go
@@ -243,6 +243,13 @@ func NewS3FileStore(config Config) (FileStore, error) {
 	if err := s3StoreConfig.Deserialize(pc.SerializedConfig(config)); err != nil {
 		return nil, fmt.Errorf("could not deserialize s3 store config: %v", err)
 	}
+
+	s3StoreConfig.BucketPath = strings.TrimPrefix("s3://", strings.TrimPrefix(s3StoreConfig.BucketPath, "s3a://"))
+
+	if strings.Contains(s3StoreConfig.BucketPath, "/") {
+		return nil, fmt.Errorf("bucket_name cannot contain '/'. bucket_name should be the name of the AWS S3 bucket only")
+	}
+
 	cfg, err := awsv2cfg.LoadDefaultConfig(context.TODO(),
 		awsv2cfg.WithCredentialsProvider(credentials.StaticCredentialsProvider{
 			Value: aws.Credentials{


### PR DESCRIPTION
# Description
Verifying that `bucket_name` doesn't contain `s3://` and doesn't contain `/`. 

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
