### PR TITLE
Bugfix: Same variants being added to parent resource, no deduping

### DIFF
--- a/metadata/dashboard/dashboard_metadata.go
+++ b/metadata/dashboard/dashboard_metadata.go
@@ -1,5 +1,4 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
-// This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 

--- a/metadata/dashboard/dashboard_metadata.go
+++ b/metadata/dashboard/dashboard_metadata.go
@@ -1,4 +1,5 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
+// This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
@@ -1366,12 +1367,12 @@ func main() {
 		},
 	}
 
-	metadata_server, err := NewMetadataServer(logger, client, &storageProvider)
+	metadataServer, err := NewMetadataServer(logger, client, &storageProvider)
 	if err != nil {
 		logger.Panicw("Failed to create server", "error", err)
 	}
 	metadataHTTPPort := help.GetEnv("METADATA_HTTP_PORT", "3001")
 	metadataServingPort := fmt.Sprintf(":%s", metadataHTTPPort)
 	logger.Infof("Serving HTTP Metadata on port: %s\n", metadataServingPort)
-	metadata_server.Start(metadataServingPort)
+	metadataServer.Start(metadataServingPort)
 }

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	slices "golang.org/x/exp/slices"
+
 	pb "github.com/featureform/metadata/proto"
 	"github.com/featureform/metadata/search"
 	pc "github.com/featureform/provider/provider_config"
@@ -378,6 +380,9 @@ func (this *SourceResource) Notify(lookup ResourceLookup, op operation, that Res
 	if !isVariant {
 		return nil
 	}
+	if slices.Contains(this.serialized.Variants, otherId.Variant) {
+		return nil
+	}
 	this.serialized.Variants = append(this.serialized.Variants, otherId.Variant)
 	return nil
 }
@@ -503,6 +508,9 @@ func (this *featureResource) Notify(lookup ResourceLookup, op operation, that Re
 	otherId := that.ID()
 	isVariant := otherId.Type == FEATURE_VARIANT && otherId.Name == this.serialized.Name
 	if !isVariant {
+		return nil
+	}
+	if slices.Contains(this.serialized.Variants, otherId.Variant) {
 		return nil
 	}
 	this.serialized.Variants = append(this.serialized.Variants, otherId.Variant)
@@ -641,6 +649,9 @@ func (this *labelResource) Notify(lookup ResourceLookup, op operation, that Reso
 	if !isVariant {
 		return nil
 	}
+	if slices.Contains(this.serialized.Variants, otherId.Variant) {
+		return nil
+	}
 	this.serialized.Variants = append(this.serialized.Variants, otherId.Variant)
 	return nil
 }
@@ -768,6 +779,9 @@ func (this *trainingSetResource) Notify(lookup ResourceLookup, op operation, tha
 	otherId := that.ID()
 	isVariant := otherId.Type == TRAINING_SET_VARIANT && otherId.Name == this.serialized.Name
 	if !isVariant {
+		return nil
+	}
+	if slices.Contains(this.serialized.Variants, otherId.Variant) {
 		return nil
 	}
 	this.serialized.Variants = append(this.serialized.Variants, otherId.Variant)
@@ -1533,11 +1547,15 @@ func (serv *MetadataServer) genericCreate(ctx context.Context, res Resource, ini
 	}
 	parentId, hasParent := id.Parent()
 	if hasParent {
-		if parentExists, err := serv.lookup.Has(parentId); err != nil {
+		parentExists, err := serv.lookup.Has(parentId)
+		if err != nil {
 			return nil, err
-		} else if !parentExists {
+		}
+
+		if !parentExists {
 			parent := init(id.Name, id.Variant)
-			if err := serv.lookup.Set(parentId, parent); err != nil {
+			err = serv.lookup.Set(parentId, parent)
+			if err != nil {
 				return nil, err
 			}
 		}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -381,6 +381,7 @@ func (this *SourceResource) Notify(lookup ResourceLookup, op operation, that Res
 		return nil
 	}
 	if slices.Contains(this.serialized.Variants, otherId.Variant) {
+		fmt.Printf("source %s already has variant %s\n", this.serialized.Name, otherId.Variant)
 		return nil
 	}
 	this.serialized.Variants = append(this.serialized.Variants, otherId.Variant)
@@ -511,6 +512,7 @@ func (this *featureResource) Notify(lookup ResourceLookup, op operation, that Re
 		return nil
 	}
 	if slices.Contains(this.serialized.Variants, otherId.Variant) {
+		fmt.Printf("source %s already has variant %s\n", this.serialized.Name, otherId.Variant)
 		return nil
 	}
 	this.serialized.Variants = append(this.serialized.Variants, otherId.Variant)
@@ -650,6 +652,7 @@ func (this *labelResource) Notify(lookup ResourceLookup, op operation, that Reso
 		return nil
 	}
 	if slices.Contains(this.serialized.Variants, otherId.Variant) {
+		fmt.Printf("source %s already has variant %s\n", this.serialized.Name, otherId.Variant)
 		return nil
 	}
 	this.serialized.Variants = append(this.serialized.Variants, otherId.Variant)
@@ -782,6 +785,7 @@ func (this *trainingSetResource) Notify(lookup ResourceLookup, op operation, tha
 		return nil
 	}
 	if slices.Contains(this.serialized.Variants, otherId.Variant) {
+		fmt.Printf("source %s already has variant %s\n", this.serialized.Name, otherId.Variant)
 		return nil
 	}
 	this.serialized.Variants = append(this.serialized.Variants, otherId.Variant)


### PR DESCRIPTION
# Description
https://github.com/featureform/featureform-enterprise/issues/221

Issue has to do with how we update. When you apply a resource twice it attempts to update it, after the update (which only updates tags and properties btw) it goes to propagate the change and part of the propagate goes to update the parent resource (a sourcevariant resource goes to update the source resource) and part of the propagation has a notify that adds the source variant to the source's variant list. Since the variant list is a list (and not a set) it allows the same variant to be added twice. All I've added is a check to ensure it doesn't exist

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
