### PR TITLE
Reduce ETCD Spam

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -389,6 +389,7 @@ func (c *Coordinator) verifyCompletionOfSources(sources []metadata.NameVariant) 
 			}
 		}
 		allReady = total == totalReady
+		time.Sleep(1 * time.Second)
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently when doing status checks interally, there is no sleep and it spams ETCD contantly. Added a sleep so it only checks once a second.

Original:
<img width="861" alt="Screenshot 2023-09-30 at 11 54 11 PM" src="https://github.com/featureform/featureform/assets/15040917/7688d811-e66b-4029-af72-cd95bf40b1b5">

After:
<img width="1457" alt="Screenshot 2023-10-01 at 12 05 42 AM" src="https://github.com/featureform/featureform/assets/15040917/e39b6089-2586-431d-8549-3e8a2b2a2593">


## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
