### PR TITLE
Fixed error for invalid timestamp type

### DIFF
--- a/provider/k8s.go
+++ b/provider/k8s.go
@@ -1215,11 +1215,11 @@ func (iter *FileStoreFeatureIterator) Next() bool {
 	timestamp := time.UnixMilli(0).UTC()
 	ts, hasTimestamp := nextVal["ts"]
 	if hasTimestamp {
-		if ts, ok := ts.(time.Time); !ok {
-			iter.err = fmt.Errorf("expected timestamp to be of type time.Time, but got %T", ts)
+		if castedTS, err := castToTimestamp(ts); err != nil {
+			iter.err = err
 			return false
 		} else {
-			timestamp = ts
+			timestamp = castedTS
 		}
 	}
 	iter.cur = ResourceRecord{
@@ -1228,6 +1228,14 @@ func (iter *FileStoreFeatureIterator) Next() bool {
 		TS:     timestamp,
 	}
 	return true
+}
+
+func castToTimestamp(timestamp interface{}) (time.Time, error) {
+	if ts, ok := timestamp.(time.Time); !ok {
+		return time.UnixMilli(0).UTC(), fmt.Errorf("expected timestamp to be of type time.Time, but got %T", timestamp)
+	} else {
+		return ts, nil
+	}
 }
 
 // Attempts to parse value in one of the following formats:

--- a/provider/k8s_test.go
+++ b/provider/k8s_test.go
@@ -1052,3 +1052,42 @@ func convertToParquetBytes(schema TableSchema, list []GenericRecord) ([]byte, er
 	}
 	return buf.Bytes(), nil
 }
+
+func Test_castTimestamp(t *testing.T) {
+	timeNow := time.Now()
+	type args struct {
+		timestamp interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    time.Time
+		wantErr bool
+		errMsg  string
+	}{
+		{"With time.Time", args{timeNow}, timeNow, false, ""},
+		{"With string", args{"idk"}, timeNow, true, "expected timestamp to be of type time.Time, but got string"},
+		{"With int", args{0}, timeNow, true, "expected timestamp to be of type time.Time, but got int"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := castToTimestamp(tt.args.timestamp)
+			// Checks if we expect error and are not getting one
+			if (err != nil) != tt.wantErr {
+				t.Errorf("castTimestamp() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			// If we expect error, checks that it is the correct error
+			if (err != nil) && tt.wantErr {
+				if err.Error() != tt.errMsg {
+					t.Errorf("castTimestamp() error = %v, wantMsg %v", err, tt.errMsg)
+				}
+				return
+			}
+			// Checks if value is correct
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("castTimestamp() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`expected timestamp to be of type time.Time, but got time.Time `

Was showing the type of the wrong variable

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
