### PR TITLE
Error message cleanup for fetching

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -120,7 +120,7 @@ func (c *Coordinator) AwaitPendingSource(sourceNameVariant metadata.NameVariant)
 		}
 		sourceStatus := source.Status()
 		if sourceStatus == metadata.FAILED {
-			return nil, fmt.Errorf("source registration failed: name: %s, variant: %s", sourceNameVariant.Name, sourceNameVariant.Variant)
+			return nil, fmt.Errorf("failed to build resource %s. See source for additional details", sourceNameVariant.ClientString())
 		}
 		if sourceStatus == metadata.READY {
 			return source, nil
@@ -376,6 +376,7 @@ func (c *Coordinator) verifyCompletionOfSources(sources []metadata.NameVariant) 
 	for !allReady {
 		sourceVariants, err := c.Metadata.GetSourceVariants(context.Background(), sources)
 		if err != nil {
+
 			return fmt.Errorf("could not get source variants: %v ", err)
 		}
 		total := len(sourceVariants)
@@ -481,7 +482,7 @@ func (c *Coordinator) runSQLTransformationJob(transformSource *metadata.SourceVa
 
 	err := c.verifyCompletionOfSources(sources)
 	if err != nil {
-		return fmt.Errorf("the sources were not completed: %s", err)
+		return fmt.Errorf("source(s) for the transformation have failed: %s", err)
 	}
 
 	sourceMap, err := c.mapNameVariantsToTables(sources)
@@ -524,7 +525,7 @@ func (c *Coordinator) runDFTransformationJob(transformSource *metadata.SourceVar
 
 	err := c.verifyCompletionOfSources(sources)
 	if err != nil {
-		return fmt.Errorf("the sources were not completed: %s", err)
+		return fmt.Errorf("source(s) for the transformation have failed: %s", err)
 	}
 
 	sourceMap, err := c.mapNameVariantsToTables(sources)
@@ -648,7 +649,7 @@ func (c *Coordinator) runLabelRegisterJob(resID metadata.ResourceID, schedule st
 
 	source, err := c.AwaitPendingSource(sourceNameVariant)
 	if err != nil {
-		return fmt.Errorf("source of could not complete job: %v", err)
+		return fmt.Errorf("source for label has failed: %v", err)
 	}
 	sourceProvider, err := source.FetchProvider(c.Metadata, context.Background())
 	if err != nil {
@@ -737,7 +738,7 @@ func (c *Coordinator) runFeatureMaterializeJob(resID metadata.ResourceID, schedu
 
 	source, err := c.AwaitPendingSource(sourceNameVariant)
 	if err != nil {
-		return fmt.Errorf("source of could not complete job: %v", err)
+		return fmt.Errorf("source for feature has failed: %v", err)
 	}
 	sourceProvider, err := source.FetchProvider(c.Metadata, context.Background())
 	if err != nil {

--- a/metadata/client.go
+++ b/metadata/client.go
@@ -33,7 +33,7 @@ func (variant NameVariant) Serialize() *pb.NameVariant {
 }
 
 func (variant NameVariant) ClientString() string {
-	return fmt.Sprintf("%s.%s", variant.Name, variant.Variant)
+	return fmt.Sprintf("%s (%s)", variant.Name, variant.Variant)
 }
 
 func parseNameVariant(serialized *pb.NameVariant) NameVariant {

--- a/provider/sql.go
+++ b/provider/sql.go
@@ -150,14 +150,14 @@ func (store *sqlOfflineStore) tableExists(id ResourceID) (bool, error) {
 	if n > 0 && err == nil {
 		return true, nil
 	} else if err != nil {
-		return false, fmt.Errorf("table exists check: %v", err)
+		return false, fmt.Errorf("could not check if table exists: %v", err)
 	}
 	query = store.query.viewExists()
 	err = store.db.QueryRow(query, tableName).Scan(&n)
 	if n > 0 && err == nil {
 		return true, nil
 	} else if err != nil {
-		return false, fmt.Errorf("view exists check: %v", err)
+		return false, fmt.Errorf("could not check if view exists: %v", err)
 	}
 	return false, nil
 }
@@ -208,7 +208,7 @@ func (store *sqlOfflineStore) RegisterPrimaryFromSourceTable(id ResourceID, sour
 		return nil, fmt.Errorf("check fail: %w", err)
 	}
 	if exists, err := store.tableExists(id); err != nil {
-		return nil, fmt.Errorf("table exist: %w", err)
+		return nil, err
 	} else if exists {
 		return nil, &TableAlreadyExists{id.Name, id.Variant}
 	}
@@ -340,7 +340,7 @@ func (store *sqlOfflineStore) CreateResourceTable(id ResourceID, schema TableSch
 	}
 
 	if exists, err := store.tableExists(id); err != nil {
-		return nil, fmt.Errorf("could not check if table exists: %v", err)
+		return nil, err
 	} else if exists {
 		return nil, &TableAlreadyExists{id.Name, id.Variant}
 	}


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ORIGINAL
```
COMPLETED
 Resource Type              Name (Variant)                                      Status      Error
 Provider                   local-mode ()                                       CREATED
 Provider                   postgres-quickstart ()                              CREATED
 Provider                   redis-quickstart ()                                 CREATED
 SourceVariant              average_user_transaction (default)                  FAILED       the sources were not completed: could not get source variants: rpc error: code = NotFound desc = resource not
                                                                                            found. SOURCE_VARIANT transactions (default) err: Key Not Found: SOURCE_VARIANT__transactions__default
 SourceVariant              transactions (default)                              FAILED       unable to register primary table from Transactions in POSTGRES_OFFLINE: table exist: table exists check: dial tcp
                                                                                            192.168.65.2:5432: connect: connection refused
 FeatureVariant             avg_transactions (default)                          FAILED       source of could not complete job: source registration failed: name: average_user_transaction, variant: default
 LabelVariant               fraudulent (default)                                FAILED       source of could not complete job: source registration failed: name: transactions, variant: default
 TrainingSetVariant         fraud_training (default)                            FAILED       source of feature could not complete job: source registration failed: name: average_user_transaction, variant:
                                                                                            default
```

NEW
```
COMPLETED
 Resource Type              Name (Variant)                                      Status      Error
 Provider                   local-mode ()                                       CREATED
 Provider                   postgres-quickstart ()                              CREATED
 Provider                   redis-quickstart ()                                 CREATED
 SourceVariant              average_user_transaction (default)                  FAILED       source(s) for the transformation have failed: could not get source variants: rpc error: code = NotFound desc =
                                                                                            resource not found. SOURCE_VARIANT transactions (default)
 SourceVariant              transactions (default)                              FAILED       unable to register primary table from Transactions in POSTGRES_OFFLINE: could not check if table exists: dial tcp
                                                                                            192.168.65.2:5432: connect: connection refused
 FeatureVariant             avg_transactions (default)                          FAILED       source for feature has failed: failed to build resource average_user_transaction (default). See source for
                                                                                            additional details
 LabelVariant               fraudulent (default)                                FAILED       source for label has failed: failed to build resource transactions (default). See source for additional details
 TrainingSetVariant         fraud_training (default)                            FAILED       source of feature could not complete job: failed to build resource average_user_transaction (default). See source
                                                                                            for additional details
```

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
