### PR TITLE
Hide Source Preview in Error State

### DIFF
--- a/dashboard/src/components/entitypage/EntityPageView.js
+++ b/dashboard/src/components/entitypage/EntityPageView.js
@@ -541,13 +541,20 @@ const EntityPageView = ({ api, entity, setVariant, activeVariants }) => {
                             );
                           }
                         })()}
-                        {!metadata['error'] && (
-                          <SourceDialog
-                            api={api}
-                            sourceName={name}
-                            sourceVariant={variant}
-                          />
-                        )}
+                        {(() => {
+                          if (
+                            !metadata['error'] &&
+                            metadata['status']?.toUpperCase() !== 'PENDING'
+                          ) {
+                            return (
+                              <SourceDialog
+                                api={api}
+                                sourceName={name}
+                                sourceVariant={variant}
+                              />
+                            );
+                          }
+                        })()}
                       </div>
                     )}
 

--- a/dashboard/src/components/entitypage/EntityPageView.js
+++ b/dashboard/src/components/entitypage/EntityPageView.js
@@ -543,7 +543,7 @@ const EntityPageView = ({ api, entity, setVariant, activeVariants }) => {
                         })()}
                         {(() => {
                           if (
-                            !metadata['error'] &&
+                            metadata['status']?.toUpperCase() !== 'FAILED' &&
                             metadata['status']?.toUpperCase() !== 'PENDING'
                           ) {
                             return (

--- a/dashboard/src/components/entitypage/EntityPageView.js
+++ b/dashboard/src/components/entitypage/EntityPageView.js
@@ -541,11 +541,13 @@ const EntityPageView = ({ api, entity, setVariant, activeVariants }) => {
                             );
                           }
                         })()}
-                        <SourceDialog
-                          api={api}
-                          sourceName={name}
-                          sourceVariant={variant}
-                        />
+                        {!metadata['error'] && (
+                          <SourceDialog
+                            api={api}
+                            sourceName={name}
+                            sourceVariant={variant}
+                          />
+                        )}
                       </div>
                     )}
 


### PR DESCRIPTION
# Description

This PR will hide the `Preview Result` table source table when a variant is in an error state, and is not in pending state. 

<img width="1072" alt="Screenshot 2023-10-01 at 4 40 49 PM" src="https://github.com/featureform/featureform/assets/34227093/822ac08b-0250-4647-89ee-1380f1ca592e">



<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
