### PR TITLE
doesnt print resource metadata table

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -4214,7 +4214,6 @@ class ResourceClient:
 
             if not asynchronous and self._stub:
                 resources = resource_state.sorted_list()
-                display_statuses(self._stub, resources)
 
         finally:
             clear_state()

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -4214,6 +4214,7 @@ class ResourceClient:
 
             if not asynchronous and self._stub:
                 resources = resource_state.sorted_list()
+                display_statuses(self._stub, resources)
 
         finally:
             clear_state()

--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -886,7 +886,7 @@ class User:
 
     @staticmethod
     def operation_type() -> OperationType:
-        return OperationType.CREATE
+        return None #OperationType.CREATE
 
     def type(self) -> str:
         return "user"
@@ -2162,7 +2162,7 @@ class ResourceState:
             if resource.operation_type() is OperationType.GET:
                 print("Getting", resource.type(), resource.name, resource_variant)
                 resource._get_local(db)
-            if resource.operation_type() is OperationType.CREATE:
+            if resource.operation_type() is OperationType.CREATE and resource.name != "default_user":
                 print("Creating", resource.type(), resource.name, resource_variant)
                 resource._create_local(db)
         db.close()

--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -2162,11 +2162,9 @@ class ResourceState:
                 print("Getting", resource.type(), resource.name, resource_variant)
                 resource._get_local(db)
 
-            if (
-                resource.operation_type() is OperationType.CREATE
-                and resource.name != "default_user"
-            ):
-                print("Creating", resource.type(), resource.name, resource_variant)
+            if resource.operation_type() is OperationType.CREATE:
+                if resource.name != "default_user":
+                    print("Creating", resource.type(), resource.name, resource_variant)
                 resource._create_local(db)
         db.close()
 
@@ -2198,13 +2196,11 @@ class ResourceState:
                         f"Getting {resource.type()} {resource.name}{resource_variant}"
                     )
                     resource._get(stub)
-                if (
-                    resource.operation_type() is OperationType.CREATE
-                    and resource.name != "default_user"
-                ):
-                    print(
-                        f"Creating {resource.type()} {resource.name}{resource_variant}"
-                    )
+                if resource.operation_type() is OperationType.CREATE:
+                    if resource.name != "default_user":
+                        print(
+                            f"Creating {resource.type()} {resource.name}{resource_variant}"
+                        )
                     resource._create(stub)
             except grpc.RpcError as e:
                 if e.code() == grpc.StatusCode.ALREADY_EXISTS:

--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -886,7 +886,7 @@ class User:
 
     @staticmethod
     def operation_type() -> OperationType:
-        return None #OperationType.CREATE
+        return OperationType.CREATE
 
     def type(self) -> str:
         return "user"
@@ -2161,10 +2161,15 @@ class ResourceState:
             if resource.operation_type() is OperationType.GET:
                 print("Getting", resource.type(), resource.name, resource_variant)
                 resource._get_local(db)
-            if resource.operation_type() is OperationType.CREATE and resource.name != "default_user":
+
+            if (
+                resource.operation_type() is OperationType.CREATE
+                and resource.name != "default_user"
+            ):
                 print("Creating", resource.type(), resource.name, resource_variant)
                 resource._create_local(db)
         db.close()
+
         from .serving import LocalClientImpl
 
         client = LocalClientImpl()
@@ -2193,7 +2198,10 @@ class ResourceState:
                         f"Getting {resource.type()} {resource.name}{resource_variant}"
                     )
                     resource._get(stub)
-                if resource.operation_type() is OperationType.CREATE:
+                if (
+                    resource.operation_type() is OperationType.CREATE
+                    and resource.name != "default_user"
+                ):
                     print(
                         f"Creating {resource.type()} {resource.name}{resource_variant}"
                     )

--- a/client/src/featureform/status_display.py
+++ b/client/src/featureform/status_display.py
@@ -125,27 +125,38 @@ class StatusDisplayer:
                     header_style="bold",
                     box=None,
                 )
-                table.add_column("Resource Type", width=25)
-                table.add_column("Name (Variant)", width=50, no_wrap=True)
-                table.add_column("Status", width=10)
-                table.add_column("Error", style="red")
 
-                for _, status in self.resource_to_status_list:
-                    error = f" {status.error}" if status.error else ""
-                    resource_type = status.resource_type.__name__
-                    name = status.name
-                    status_text = (
-                        status.status
-                        if status.resource_type is not Provider
-                        else "CREATED"
-                    )
+                no_table = False
+                if len(self.resource_to_status_list) == 1:
+                    status = self.resource_to_status_list[0][1]
+                    if status.name == "local-mode":
+                        no_table = True
 
-                    table.add_row(
-                        Text(resource_type),
-                        Text(f"{name} ({status.variant})"),
-                        Text(status_text, style=self.STATUS_TO_COLOR[status_text]),
-                        Text(error, style="red"),
-                    )
+                if not no_table:
+                    table.add_column("Resource Type", width=25)
+                    table.add_column("Name (Variant)", width=50, no_wrap=True)
+                    table.add_column("Status", width=10)
+                    table.add_column("Error", style="red")
+
+
+                    for _, status in self.resource_to_status_list:
+                        error = f" {status.error}" if status.error else ""
+                        if status.name == "local-mode":
+                            continue
+                        resource_type = status.resource_type.__name__
+                        name = status.name
+                        status_text = (
+                            status.status
+                            if status.resource_type is not Provider
+                            else "CREATED"
+                        )
+
+                        table.add_row(
+                            Text(resource_type),
+                            Text(f"{name} ({status.variant})"),
+                            Text(status_text, style=self.STATUS_TO_COLOR[status_text]),
+                            Text(error, style="red"),
+                        )
 
                 live.update(table)
                 live.refresh()


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

removed the Resource Type, Name (metadata) table when running client.dataframe(). 

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
