### PR TITLE
feat: add mysql offline store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -167,6 +167,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
+	github.com/go-sql-driver/mysql v1.7.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang-jwt/jwt v3.2.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -708,6 +708,8 @@ github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QX
 github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
+github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=

--- a/metadata/provider.go
+++ b/metadata/provider.go
@@ -82,6 +82,22 @@ func isValidMongoConfigUpdate(sa, sb pc.SerializedConfig) (bool, error) {
 	return a.MutableFields().Contains(diff), nil
 }
 
+func isValidMySqlConfigUpdate(sa, sb pc.SerializedConfig) (bool, error) {
+	a := pc.MySqlConfig{}
+	b := pc.MySqlConfig{}
+	if err := a.Deserialize(sa); err != nil {
+		return false, err
+	}
+	if err := b.Deserialize(sb); err != nil {
+		return false, err
+	}
+	diff, err := a.DifferingFields(b)
+	if err != nil {
+		return false, err
+	}
+	return a.MutableFields().Contains(diff), nil
+}
+
 func isValidPostgresConfigUpdate(sa, sb pc.SerializedConfig) (bool, error) {
 	a := pc.PostgresConfig{}
 	b := pc.PostgresConfig{}

--- a/metadata/provider_test.go
+++ b/metadata/provider_test.go
@@ -71,6 +71,16 @@ func TestProviderConfigUpdates(t *testing.T) {
 			providerType: pt.MongoDBOnline,
 		},
 		{
+			name:         "Valid mySQL Configuration Update",
+			valid:        true,
+			providerType: pt.MySqlOffline,
+		},
+		{
+			name:         "Invalid mySQL Configuration Update",
+			valid:        false,
+			providerType: pt.MySqlOffline,
+		},
+		{
 			name:         "Valid PostgreSQL Configuration Update",
 			valid:        true,
 			providerType: pt.PostgresOffline,
@@ -144,6 +154,8 @@ func TestProviderConfigUpdates(t *testing.T) {
 				testFirestoreConfigUpdates(t, c.providerType, c.valid)
 			case pt.MongoDBOnline:
 				testMongoConfigUpdates(t, c.providerType, c.valid)
+			case pt.MySqlOffline:
+				testMySqlConfigUpdates(t, c.providerType, c.valid)
 			case pt.PostgresOffline:
 				testPostgresConfigUpdates(t, c.providerType, c.valid)
 			case pt.RedisOnline:
@@ -340,6 +352,44 @@ func testMongoConfigUpdates(t *testing.T, providerType pt.Type, valid bool) {
 	b := configB.Serialized()
 
 	actual, err := isValidMongoConfigUpdate(a, b)
+	assertConfigUpdateResult(t, valid, actual, err, providerType)
+}
+
+func testMySqlConfigUpdates(t *testing.T, providerType pt.Type, valid bool) {
+	host := "0.0.0.0"
+	port := "3306"
+	username := "mysql"
+	password := "password"
+	database := "mysql"
+
+	configA := pc.PostgresConfig{
+		Host:     host,
+		Port:     port,
+		Username: username,
+		Password: password,
+		Database: database,
+	}
+	a := configA.Serialize()
+
+	if valid {
+		username += updateSuffix
+		password += updateSuffix
+		port = "3307"
+	} else {
+		host = "127.0.0.1"
+		database += updateSuffix
+	}
+
+	configB := pc.PostgresConfig{
+		Host:     host,
+		Port:     port,
+		Username: username,
+		Password: password,
+		Database: database,
+	}
+	b := configB.Serialize()
+
+	actual, err := isValidPostgresConfigUpdate(a, b)
 	assertConfigUpdateResult(t, valid, actual, err, providerType)
 }
 

--- a/provider/connection/connection_configs.json
+++ b/provider/connection/connection_configs.json
@@ -1,17 +1,27 @@
 {
-  "RedisConfig": { "Addr": "host:1", "Password": "password", "DB": 1 },
+  "RedisConfig": {
+    "Addr": "host:1",
+    "Password": "password",
+    "DB": 1
+  },
   "PineconeConfig": {
     "ProjectID": "1",
     "Environment": "local",
     "ApiKey": "api_key"
   },
-  "WeaviateConfig": { "URL": "url", "ApiKey": "api_key" },
+  "WeaviateConfig": {
+    "URL": "url",
+    "ApiKey": "api_key"
+  },
   "GCSFileStoreConfig": {
     "BucketName": "bucket_name",
     "BucketPath": "bucket_path",
     "Credentials": {
       "ProjectId": "id",
-      "JSON": { "username": "username", "password:": "password" }
+      "JSON": {
+        "username": "username",
+        "password:": "password"
+      }
     }
   },
   "AzureFileStoreConfig": {
@@ -21,7 +31,10 @@
     "Path": "/path"
   },
   "S3StoreConfig": {
-    "Credentials": { "AWSAccessKeyId": "id", "AWSSecretKey": "key" },
+    "Credentials": {
+      "AWSAccessKeyId": "id",
+      "AWSSecretKey": "key"
+    },
     "BucketRegion": "bucket_region",
     "BucketPath": "bucket_path",
     "Path": ""
@@ -81,6 +94,13 @@
     "Warehouse": "warehouse",
     "Role": "role"
   },
+  "MysqlConfig": {
+    "Host": "host",
+    "Port": "port",
+    "User": "user",
+    "Password": "password",
+    "Database": "database"
+  },
   "PostgresConfig": {
     "Host": "host",
     "Port": "port",
@@ -112,7 +132,9 @@
   },
   "K8sConfig": {
     "ExecutorType": "K8S",
-    "ExecutorConfig": { "docker_image": "docker_image" },
+    "ExecutorConfig": {
+      "docker_image": "docker_image"
+    },
     "StoreType": "store_type",
     "StoreConfig": {}
   },

--- a/provider/mysql.go
+++ b/provider/mysql.go
@@ -1,0 +1,249 @@
+package provider
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	pc "github.com/featureform/provider/provider_config"
+	pt "github.com/featureform/provider/provider_type"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+type mySqlColumnType string
+
+const (
+	mySqlInt       mySqlColumnType = "integer"
+	mySqlBigInt                    = "bigint"
+	mySqlFloat                     = "float"
+	mySqlString                    = "varchar"
+	mySqlBool                      = "boolean"
+	mySqlTimestamp                 = "timestamp"
+)
+
+func mySqlOfflineStoreFactory(config pc.SerializedConfig) (Provider, error) {
+	sc := pc.MySqlConfig{}
+	if err := sc.Deserialize(config); err != nil {
+		return nil, fmt.Errorf("invalid postgres config: %v", config)
+	}
+	queries := mySQLQueries{}
+	queries.setVariableBinding(MySQLBindingStyle)
+	sgConfig := SQLOfflineStoreConfig{
+		Config:       config,
+		Driver:       "mysql",
+		ProviderType: pt.MySqlOffline,
+		QueryImpl:    &queries,
+	}
+	if sc.Host != "" && sc.Host != "" {
+		sgConfig.ConnectionURL = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", sc.Username, sc.Password, sc.Host, sc.Port, sc.Database)
+	} else {
+		sgConfig.ConnectionURL = fmt.Sprintf("%s:%s@/%s", sc.Username, sc.Password, sc.Database)
+	}
+	store, err := NewSQLOfflineStore(sgConfig)
+	if err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+type mySQLQueries struct {
+	defaultOfflineSQLQueries
+}
+
+func (q mySQLQueries) tableExists() string {
+	return "SELECT COUNT(*) FROM pg_tables WHERE  table_name  = $1"
+}
+
+func (q mySQLQueries) viewExists() string {
+	return "SELECT COUNT(*) FROM information_schema.views WHERE table_name = ?"
+}
+
+func (q mySQLQueries) registerResources(db *sql.DB, tableName string, schema ResourceSchema, timestamp bool) error {
+	var query *sql.Stmt
+	var err error
+	if !timestamp {
+		schema.TS = time.Now().UTC().Format("2006-01-02 15:04:05")
+	}
+	query, err = db.Prepare("CREATE VIEW ? AS SELECT ? as entity, ? as value, ? as ts FROM ?")
+	if err != nil {
+		return fmt.Errorf("error registering view: %w", err)
+	}
+	defer query.Close()
+	fmt.Printf("Resource creation query: %s", query)
+	_, err = query.Exec(tableName, schema.Entity, schema.Value, schema.TS, schema.SourceTable)
+	return err
+}
+
+func (q mySQLQueries) primaryTableRegister(tableName string, sourceName string) string {
+	return fmt.Sprintf("CREATE VIEW %s AS SELECT * FROM %s", sanitize(tableName), sanitize(sourceName))
+}
+
+// materializationCreate satisfies the OfflineTableQueries interface.
+// mySQL doesn't have materialized views.
+func (q mySQLQueries) materializationCreate(tableName string, sourceName string) string {
+	return q.primaryTableRegister(tableName, sourceName)
+}
+
+func (q mySQLQueries) materializationUpdate(db *sql.DB, tableName string, sourceName string) error {
+	query := `DROP VIEW IF EXISTS ?;` + q.primaryTableCreate(tableName, sourceName)
+	_, err := db.Exec(query, tableName)
+	return err
+}
+
+func (q mySQLQueries) materializationExists() string {
+	return "SELECT * FROM information_schema.tables	WHERE table_name = ? AND table_type = 'VIEW'"
+}
+
+func (q mySQLQueries) determineColumnType(valueType ValueType) (string, error) {
+	switch valueType {
+	case Int, Int32, Int64:
+		return "INT", nil
+	case Float32, Float64:
+		return "FLOAT8", nil
+	case String:
+		return "VARCHAR", nil
+	case Bool:
+		return "BOOLEAN", nil
+	case Timestamp:
+		return "TIMESTAMP", nil
+	case NilType:
+		return "VARCHAR", nil
+	default:
+		return "", fmt.Errorf("cannot find column type for value type: %s", valueType)
+	}
+}
+
+func (q mySQLQueries) newSQLOfflineTable(name string, columnType string) string {
+	return fmt.Sprintf(
+		"CREATE TABLE %s (entity VARCHAR(255), value %s, ts TIMESTAMP, UNIQUE KEY(entity, ts))",
+		name, columnType,
+	)
+}
+
+func (q mySQLQueries) createValuePlaceholderString(columns []TableColumn) string {
+	placeholders := make([]string, 0)
+	for i := range columns {
+		placeholders = append(placeholders, fmt.Sprintf("$%d", i+1))
+	}
+	return strings.Join(placeholders, ", ")
+}
+
+func (q mySQLQueries) trainingSetCreate(store *sqlOfflineStore, def TrainingSetDef, tableName string, labelName string) error {
+	return q.trainingSetQuery(store, def, tableName, labelName, false)
+}
+
+func (q mySQLQueries) trainingSetUpdate(store *sqlOfflineStore, def TrainingSetDef, tableName string, labelName string) error {
+	return q.trainingSetQuery(store, def, tableName, labelName, true)
+}
+
+func (q mySQLQueries) trainingSetQuery(store *sqlOfflineStore, def TrainingSetDef, tableName string, labelName string, isUpdate bool) error {
+	columns := make([]string, 0)
+	query := fmt.Sprintf("(SELECT entity, value , ts from %s ) l", sanitize(labelName))
+	for i, feature := range def.Features {
+		tableName, err := store.getResourceTableName(feature)
+		if err != nil {
+			return err
+		}
+		santizedName := sanitize(tableName)
+		tableJoinAlias := fmt.Sprintf("t%d", i)
+		columns = append(columns, santizedName)
+		query = fmt.Sprintf("%s LEFT JOIN (SELECT entity, value AS %s, ts FROM %s "+
+			"WHERE entity=l.entity AND ts <= l.ts ORDER BY ts DESC LIMIT 1) AS %s ON %s.entity=l.entity",
+			query, santizedName, santizedName, tableJoinAlias, tableJoinAlias)
+		if i == len(def.Features)-1 {
+			query = fmt.Sprintf("%s )", query)
+		}
+	}
+	columnStr := strings.Join(columns, ", ")
+
+	if isUpdate {
+		tempName := sanitize(fmt.Sprintf("tmp_%s", tableName))
+		fullQuery := fmt.Sprintf("CREATE TABLE %s AS (SELECT %s, l.value as label FROM %s ", tempName, columnStr, query)
+		err := q.atomicUpdate(store.db, tableName, tempName, fullQuery)
+		if err != nil {
+			return err
+		}
+	} else {
+		fullQuery := fmt.Sprintf("CREATE TABLE %s AS (SELECT %s, l.value as label FROM %s ", sanitize(tableName), columnStr, query)
+		if _, err := store.db.Exec(fullQuery); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (q mySQLQueries) castTableItemType(v interface{}, t interface{}) interface{} {
+	if v == nil {
+		return v
+	}
+	switch t {
+	case mySqlInt:
+		return int32(v.(int64))
+	case mySqlBigInt:
+		return int(v.(int64))
+	case mySqlFloat:
+		return v.(float64)
+	case mySqlString:
+		return v.(string)
+	case mySqlBool:
+		return v.(bool)
+	case mySqlTimestamp:
+		return v.(time.Time).UTC()
+	default:
+		return v
+	}
+}
+
+func (q mySQLQueries) getValueColumnType(t *sql.ColumnType) interface{} {
+	switch t.ScanType().String() {
+	case "string":
+		return mySqlString
+	case "int32":
+		return mySqlInt
+	case "int64":
+		return mySqlBigInt
+	case "float32", "float64", "interface {}":
+		return mySqlFloat
+	case "bool":
+		return mySqlBool
+	case "time.Time":
+		return mySqlTimestamp
+	}
+	return mySqlString
+}
+
+func (q mySQLQueries) numRows(n interface{}) (int64, error) {
+	return n.(int64), nil
+}
+
+func (q mySQLQueries) transformationCreate(name string, query string) string {
+	return fmt.Sprintf("CREATE TABLE  %s AS %s", sanitize(name), query)
+}
+
+func (q mySQLQueries) transformationUpdate(db *sql.DB, tableName string, query string) error {
+	tempName := sanitize(fmt.Sprintf("tmp_%s", tableName))
+	fullQuery := fmt.Sprintf("CREATE TABLE %s AS %s", tempName, query)
+	return q.atomicUpdate(db, tableName, tempName, fullQuery)
+}
+
+func (q mySQLQueries) transformationExists() string {
+	return "SELECT * FROM information_schema.tables	WHERE table_name = ? AND table_type = 'VIEW'"
+}
+
+func (q mySQLQueries) getColumns(db *sql.DB, tableName string) ([]TableColumn, error) {
+	rows, err := db.Query("SELECT column_name FROM information_schema.columns WHERE table_name = ?", tableName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	columnNames := make([]TableColumn, 0)
+	for rows.Next() {
+		var column string
+		if err := rows.Scan(&column); err != nil {
+			return nil, err
+		}
+		columnNames = append(columnNames, TableColumn{Name: column})
+	}
+	return columnNames, nil
+}

--- a/provider/offline_test.go
+++ b/provider/offline_test.go
@@ -75,6 +75,20 @@ func TestOfflineStores(t *testing.T) {
 		return postgresConfig.Serialize()
 	}
 
+	mySqlInit := func() pc.SerializedConfig {
+		db := checkEnv("MYSQL_DB")
+		user := checkEnv("MYSQL_USER")
+		password := checkEnv("MYSQL_PASSWORD")
+		var mySqlConfig = pc.MySqlConfig{
+			Host:     "localhost",
+			Port:     "3306",
+			Username: user,
+			Password: password,
+			Database: db,
+		}
+		return mySqlConfig.Serialize()
+	}
+
 	snowflakeInit := func() (pc.SerializedConfig, pc.SnowflakeConfig) {
 		snowFlakeDatabase := strings.ToUpper(uuid.NewString())
 		t.Log("Snowflake Database: ", snowFlakeDatabase)
@@ -245,6 +259,9 @@ func TestOfflineStores(t *testing.T) {
 	}
 	if *provider == "postgres" || *provider == "" {
 		testList = append(testList, testMember{pt.PostgresOffline, postgresInit(), true})
+	}
+	if *provider == "mysql" || *provider == "" {
+		testList = append(testList, testMember{pt.MySqlOffline, mySqlInit(), true})
 	}
 	if *provider == "snowflake" || *provider == "" {
 		serialSFConfig, snowflakeConfig := snowflakeInit()
@@ -3728,7 +3745,7 @@ func modifyTransformationConfig(t *testing.T, testName, tableName string, provid
 		// In contrast to the SQL provider, that only needed change is the table name to perform the required transformation configuration,
 		// The Spark implementation needs to update the source mappings to ensure the source file is used in the transformation query.
 		config.SourceMapping[0].Source = tableName
-	case pt.MemoryOffline, pt.BigQueryOffline, pt.PostgresOffline, pt.SnowflakeOffline, pt.RedshiftOffline:
+	case pt.MemoryOffline, pt.BigQueryOffline, pt.PostgresOffline, pt.MySqlOffline, pt.SnowflakeOffline, pt.RedshiftOffline:
 		tableName := getTableName(testName, tableName)
 		config.Query = strings.Replace(config.Query, "tb", tableName, 1)
 	default:

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -20,6 +20,7 @@ func init() {
 		pt.DynamoDBOnline:   dynamodbOnlineStoreFactory,
 		pt.PineconeOnline:   pineconeOnlineStoreFactory,
 		pt.MemoryOffline:    memoryOfflineStoreFactory,
+		pt.MySqlOffline:     memoryOfflineStoreFactory,
 		pt.PostgresOffline:  postgresOfflineStoreFactory,
 		pt.SnowflakeOffline: snowflakeOfflineStoreFactory,
 		pt.RedshiftOffline:  redshiftOfflineStoreFactory,

--- a/provider/provider_config/mysql_config.go
+++ b/provider/provider_config/mysql_config.go
@@ -1,0 +1,45 @@
+package provider_config
+
+import (
+	"encoding/json"
+
+	ss "github.com/featureform/helpers/string_set"
+)
+
+type MySqlConfig struct {
+	Host     string `json:"Host"`
+	Port     string `json:"Port"`
+	Username string `json:"Username"`
+	Password string `json:"Password"`
+	Database string `json:"Database"`
+}
+
+func (my *MySqlConfig) Deserialize(config SerializedConfig) error {
+	err := json.Unmarshal(config, my)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (my *MySqlConfig) Serialize() []byte {
+	conf, err := json.Marshal(my)
+	if err != nil {
+		panic(err)
+	}
+	return conf
+}
+
+func (my MySqlConfig) MutableFields() ss.StringSet {
+	return ss.StringSet{
+		"Username": true,
+		"Password": true,
+		"Host":     true,
+		"Port":     true,
+		"Database": true,
+	}
+}
+
+func (a MySqlConfig) DifferingFields(b MySqlConfig) (ss.StringSet, error) {
+	return differingFields(a, b)
+}

--- a/provider/provider_type/provider_type.go
+++ b/provider/provider_type/provider_type.go
@@ -19,6 +19,7 @@ const (
 
 	// Offline
 	MemoryOffline    Type = "MEMORY_OFFLINE"
+	MySqlOffline     Type = "MYSQL_OFFLINE"
 	PostgresOffline  Type = "POSTGRES_OFFLINE"
 	SnowflakeOffline Type = "SNOWFLAKE_OFFLINE"
 	RedshiftOffline  Type = "REDSHIFT_OFFLINE"
@@ -41,6 +42,7 @@ var AllProviderTypes = []Type{
 	BlobOnline,
 	MongoDBOnline,
 	MemoryOffline,
+	MySqlOffline,
 	PineconeOnline,
 	PostgresOffline,
 	SnowflakeOffline,


### PR DESCRIPTION
# Description
Adds mySQL as offline store

There are some aspects of mySQL that differ from postgresql. For example mySQL doesn't have materialized views. But the offlinestore interface has several methods centered around materialized views. I incorporated simiarl/close to functionality with mySQL views - but it just not exactly the same. Where possible got close approximations of the behavior of the interface methods and did implement all methods to satisfy the interface definition.

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change
Feature: Include mySQL and the go mySQL driver as option for offline store
### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->
Closes: https://github.com/featureform/featureform/issues/1069
### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
