### PR TITLE
Materialization Copy Performance Improvement

### DIFF
--- a/runner/copy.go
+++ b/runner/copy.go
@@ -75,13 +75,14 @@ func (m *MaterializedChunkRunner) Run() (types.CompletionWatcher, error) {
 			jobWatcher.EndWatch(fmt.Errorf("failed to create iterator: %w", err))
 			return
 		}
-		// Buffer the records channel to ensure readers won't block on the writer loop below
-		ch := make(chan provider.ResourceRecord, 100_000)
+		// Buffer the records channel to ensure readers won't block the writer loop below
+		ch := make(chan provider.ResourceRecord, 1_000_000)
 		var wg sync.WaitGroup
-		wg.Add(100)
+		waitGroupSize := 1000
+		wg.Add(waitGroupSize)
 		// Create a "pool" of 100 goroutines to write to the table to better utilize CPU resources
 		// and speed up the write operations to the inference table.
-		for idx := 0; idx < 100; idx++ {
+		for idx := 0; idx < waitGroupSize; idx++ {
 			go func() {
 				defer wg.Done()
 				for record := range ch {

--- a/runner/copy.go
+++ b/runner/copy.go
@@ -17,8 +17,15 @@ import (
 	"go.uber.org/zap"
 )
 
+// We buffer the channel responsible for passing records to the goroutines that will write
+// to the inference store avoid blocking the writer loop below; after some initial testing,
+// 1M records seems to be a good buffer size
 const resourceRecordBufferSize = 1_000_000
-const waitGroupSize = 1000
+
+// We create a pool of goroutines per materialization chunk runner to make Set requests to
+// the inference store asynchronously; after some initial testing, 1000 workers appears to
+// offer the best results
+const workerPoolSize = 1000
 
 type IndexRunner interface {
 	types.Runner
@@ -78,17 +85,29 @@ func (m *MaterializedChunkRunner) Run() (types.CompletionWatcher, error) {
 			jobWatcher.EndWatch(fmt.Errorf("failed to create iterator: %w", err))
 			return
 		}
-		// Buffer the records channel to ensure readers won't block the writer loop below
+		// The logic for the below code (i.e. the channel, goroutines, wait group and iteration loop)
+		// is as follows:
+		// 1. create a record channel and an error channel; the record channel will be written to by
+		// the iterator loop; the error channel will be written to by one or more of the goroutines
+		// if they happen to encounter an error while trying to set a value to the inference store
+		// 2. create a wait group that will be used to wait for the goroutines to finish processing
+		// all of the records in the channel before continuing execution of the Run method
+		// 3. create a set/pool of goroutines that can process records from the channel asynchronously
+		// to avoid unnecessary waiting/blocking; creating the workers prior to writing to the channel
+		// means that as messages are sent to the channel, the workers will be ready to process them,
+		// which means we don't have to wait for the iterator to be consumed before the work of persisting
+		// records in the inference store begins
+		// 4. create an iteration loop that will completely consume the iterator and write all records
+		// to the channel
 		ch := make(chan provider.ResourceRecord, resourceRecordBufferSize)
 		// Using a buffered error channel to capture any errors that may occur while trying to
 		// set values; buffering the error channel prevents the goroutines from blocking when
 		// trying to write to the channel.
 		errCh := make(chan error, 1)
 		var wg sync.WaitGroup
-		wg.Add(waitGroupSize)
-		// Create a "pool" of 100 goroutines to write to the table to better utilize CPU resources
-		// and speed up the write operations to the inference table.
-		for idx := 0; idx < waitGroupSize; idx++ {
+		wg.Add(workerPoolSize)
+		// Create a set goroutines that can wait for the inference store to response asynchronously
+		for idx := 0; idx < workerPoolSize; idx++ {
 			go func() {
 				defer wg.Done()
 				for record := range ch {
@@ -101,26 +120,21 @@ func (m *MaterializedChunkRunner) Run() (types.CompletionWatcher, error) {
 				}
 			}()
 		}
-	iterationLoop:
-		for {
+		var chanErr error
+		for it.Next() {
 			select {
-			case <-errCh:
-				// If an error occurs while trying to set a value, we want to stop the iteration
-				// and return the error.
-				break iterationLoop
-			default:
-				// Completely consume the iterator and write all records to the channel
-				if it.Next() {
-					ch <- it.Value()
-				} else {
-					break iterationLoop
-				}
+			case chanErr = <-errCh:
+			case ch <- it.Value():
+			}
+			if chanErr != nil {
+				break
 			}
 		}
 		close(ch)
 		wg.Wait()
-		if err, ok := <-errCh; ok {
-			jobWatcher.EndWatch(err)
+		close(errCh)
+		if chanErr != nil {
+			jobWatcher.EndWatch(fmt.Errorf("error encountered by inference store writer goroutine: %w", chanErr))
 			return
 		}
 		if err = it.Err(); err != nil {


### PR DESCRIPTION
# Description

Based on profiling conducted using `pprof`, we determined that the materialization's copy operation spent far too much time waiting on calls to `Table.Set`; introducing concurrency resulted in a ~72% decrease in the time required to copy ~1M records to the inference store.

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance enhancement

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
