### PR TITLE
Change Provider Init Errors/Postgres failed output

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -599,7 +599,7 @@ func (c *Coordinator) runRegisterSourceJob(resID metadata.ResourceID, schedule s
 	}
 	p, err := provider.Get(pt.Type(sourceProvider.Type()), sourceProvider.SerializedConfig())
 	if err != nil {
-		return fmt.Errorf("get source's dependent provider in offline store: %v", err)
+		return fmt.Errorf("failed to initialize provider: %v", err)
 	}
 	sourceStore, err := p.AsOfflineStore()
 	if err != nil {

--- a/provider/postgres.go
+++ b/provider/postgres.go
@@ -25,7 +25,7 @@ const (
 func postgresOfflineStoreFactory(config pc.SerializedConfig) (Provider, error) {
 	sc := pc.PostgresConfig{}
 	if err := sc.Deserialize(config); err != nil {
-		return nil, fmt.Errorf("invalid postgres config: %v", config)
+		return nil, fmt.Errorf("invalid postgres config: %s", err.Error())
 	}
 
 	// We are doing this to support older versions of


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Changed this:
```
get source's dependent provider in offline store: invalid postgres config: [123 34 72 111 115 116 34 58 32 34 108
                                                                                            111 99 97 108 104 111 115 116 34 44 32 34 80 111 114 116 34 58 32 53 52 51 50 44 32 34 85 115 101 114 110 97 109
                                                                                            101 34 58 32 34 112 111 115 116 103 114 101 115 34 44 32 34 80 97 115 115 119 111 114 100 34 58 32 34 112 111 115
                                                                                            116 103 114 101 115 34 44 32 34 68 97 116 97 98 97 115 101 34 58 32 34 112 111 115 116 103 114 101 115 34 44 32 34
                                                                                            83 83 76 77 111 100 101 34 58 32 34 100 105 115 97 98 108 101 34 125]
```

to this

```
failed to initialize provider: invalid postgres config: json: cannot unmarshal number into Go
                                                                                            struct field PostgresConfig.Port of type string
```

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
