### PR TITLE
Feature (Timestamp variants): defer fetching of name and variant until create

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -3981,10 +3981,8 @@ class Registrar:
         feature_nv_list = []
         feature_lags = []
         for feature in features:
-            # if isinstance(feature, FeatureColumnResource):
-            #     feature_nv_list.append(feature)
             if isinstance(feature, str):
-                feature_nv_list.append((feature, run))  # git rid of this´
+                feature_nv_list.append((feature, run))
             elif isinstance(feature, dict):
                 lag = feature.get("lag")
                 if "variant" not in feature:
@@ -4097,9 +4095,6 @@ class Registrar:
             # Elif: If label was updated to store resource_label it will not check the following elif
             elif resource_label != ():
                 raise ValueError("A training set can only have one label")
-
-        # if isinstance(label, LabelColumnResource):
-        #     label = label.name_variant()
 
         features, feature_lags = self.__get_feature_nv(features, self.__run)
         if label == ():


### PR DESCRIPTION
# Description

For part of the timestamp variant work we want to defer the retrieval of the name variant of a dependency until at create in case the variant changes.

Let's say you register

tf1 
tf2
tf3

If, while registering tf2, we find an equivalent tf1 and use it's variant. We should use that new variant to tf2

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
