### PR TITLE
bug: fixed mySqlOfflineStoreFactory Issue

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -20,7 +20,7 @@ func init() {
 		pt.DynamoDBOnline:   dynamodbOnlineStoreFactory,
 		pt.PineconeOnline:   pineconeOnlineStoreFactory,
 		pt.MemoryOffline:    memoryOfflineStoreFactory,
-		pt.MySqlOffline:     memoryOfflineStoreFactory,
+		pt.MySqlOffline:     mySqlOfflineStoreFactory,
 		pt.PostgresOffline:  postgresOfflineStoreFactory,
 		pt.SnowflakeOffline: snowflakeOfflineStoreFactory,
 		pt.RedshiftOffline:  redshiftOfflineStoreFactory,


### PR DESCRIPTION
# Description
 This PR addresses a typo issue in the code. The incorrect usage of `memoryOfflineStoreFactory` has been corrected to `mySqlOfflineStoreFactory`.
 
![image (1)](https://github.com/featureform/featureform/assets/43810146/ff729ca7-b932-46fb-8a51-fa0eb443a62b)
<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
