### PR TITLE
Bugfix: Removing scheme in container_name and checking it is a container_name for Azure Blob Store

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -2455,6 +2455,13 @@ class Registrar:
         """
 
         tags, properties = set_tags_properties(tags, properties)
+
+        container_name = container_name.replace("abfss://", "")
+        if "/" in container_name:
+            raise ValueError(
+                "container_name cannot contain '/'. container_name should be the name of the Azure Blobstore container only."
+            )
+
         azure_config = AzureFileStoreConfig(
             account_name=account_name,
             account_key=account_key,

--- a/client/tests/register_test.py
+++ b/client/tests/register_test.py
@@ -374,3 +374,37 @@ def test_register_s3(bucket_name, expected_error, ff_registrar, aws_credentials)
         assert str(ve) == str(expected_error)
     except Exception as e:
         raise e
+
+
+@pytest.mark.parametrize(
+    "container_name, expected_error",
+    [
+        ("abfss://container_name", None),
+        ("container_name", None),
+        (
+            "container_name/",
+            ValueError(
+                "container_name cannot contain '/'. container_name should be the name of the Azure Blobstore container only."
+            ),
+        ),
+        (
+            "abfss://bucket_name/",
+            ValueError(
+                "container_name cannot contain '/'. container_name should be the name of the Azure Blobstore container only."
+            ),
+        ),
+    ],
+)
+def test_register_blob_store(container_name, expected_error, ff_registrar):
+    try:
+        _ = ff_registrar.register_blob_store(
+            name="blob_store_container",
+            container_name=container_name,
+            root_path="custom/path/in/container",
+            account_name="account_name",
+            account_key="azure_account_key",
+        )
+    except ValueError as ve:
+        assert str(ve) == str(expected_error)
+    except Exception as e:
+        raise e

--- a/provider/filestore.go
+++ b/provider/filestore.go
@@ -207,6 +207,12 @@ func NewAzureFileStore(config Config) (FileStore, error) {
 	if err := os.Setenv("AZURE_STORAGE_KEY", azureStoreConfig.AccountKey); err != nil {
 		return nil, fmt.Errorf("could not set storage key env: %w", err)
 	}
+
+	azureStoreConfig.ContainerName = strings.TrimPrefix(azureStoreConfig.ContainerName, "abfss://")
+	if strings.Contains(azureStoreConfig.ContainerName, "/") {
+		return nil, fmt.Errorf("container_name cannot contain '/'. container_name should be the name of the Azure Blobstore container only")
+	}
+
 	serviceURL := azureblob.ServiceURL(fmt.Sprintf("https://%s.blob.core.windows.net", azureStoreConfig.AccountName))
 	client, err := azureblob.NewDefaultServiceClient(serviceURL)
 	if err != nil {


### PR DESCRIPTION
# Description
Adding similar https://github.com/featureform/featureform/pull/1040 for Azure Blob Store. Removes the abyss:// prefix from the container name if provided.

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
