### PR TITLE
Upgrade pandas to >=1.3.5

### DIFF
--- a/client/setup.cfg
+++ b/client/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     typeguard<3.0.0
     grpcio>=1.47.0
     numpy>=1.21.6
-    pandas==1.3.5
+    pandas>=1.3.5
     pandasql>=0.7.3
     typing_extensions>=4.1.1
     dataclasses==0.6

--- a/client/src/featureform/local_utils.py
+++ b/client/src/featureform/local_utils.py
@@ -10,6 +10,11 @@ def get_sql_transformation_sources(query_string):
 
 def merge_feature_into_ts(feature_row, label_row, df, trainingset_df):
     if feature_row["source_timestamp"] != "":
+        # Ensure the entity columns are both the same type from pandas' perspective
+        df[feature_row["source_entity"]] = df[feature_row["source_entity"]].astype(str)
+        trainingset_df[label_row["source_entity"]] = trainingset_df[
+            label_row["source_entity"]
+        ].astype(str)
         trainingset_df = pd.merge_asof(
             trainingset_df.sort_values(label_row["source_timestamp"]),
             df.sort_values(feature_row["source_timestamp"]),

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -1171,7 +1171,7 @@ class Dataset:
         if self._dataframe is not None:
             temp_df = self._dataframe
             for i in range(num):
-                self._dataframe = self._dataframe.append(temp_df)
+                self._dataframe = pd.concat([self._dataframe, temp_df])
         return self
 
     def shuffle(self, buffer_size):

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -274,7 +274,7 @@ class HostedClientImpl:
         id = serving_pb2.SourceID(name=name, version=variant)
         req = serving_pb2.SourceDataRequest(id=id)
         resp = self._stub.SourceColumns(req)
-        return resp.columns
+        return list(resp.columns)
 
     def nearest(self, name, variant, vector, k):
         id = serving_pb2.FeatureID(name=name, version=variant)

--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -274,6 +274,10 @@ class HostedClientImpl:
         id = serving_pb2.SourceID(name=name, version=variant)
         req = serving_pb2.SourceDataRequest(id=id)
         resp = self._stub.SourceColumns(req)
+        # The Python type of resp.columns is <class 'google._upb._message.RepeatedScalarContainer'>
+        # which is not a "recognized" type by pandas internal type check, which resulted in the following error:
+        # `Index(...) must be called with a collection of some kind`
+        # To avoid this issue, we convert the resp.columns to a Python list
         return list(resp.columns)
 
     def nearest(self, name, variant, vector, k):

--- a/provider/scripts/k8s/requirements.txt
+++ b/provider/scripts/k8s/requirements.txt
@@ -1,5 +1,5 @@
 dill==0.3.7
-pandas==1.3.5
+pandas>=1.3.5
 pandasql==0.7.3
 pyarrow==14.0.1
 fastparquet==0.8.3

--- a/tests/end_to_end/requirements.txt
+++ b/tests/end_to_end/requirements.txt
@@ -15,7 +15,7 @@ Flask-Cors==3.0.10
 google-cloud-storage
 grpcio==1.57.0
 numpy==1.24.4
-pandas==1.3.5
+pandas>=1.3.5
 pandasql==0.7.3
 pinecone-client==2.2.2
 protobuf==4.24.2


### PR DESCRIPTION
# Description

This PR upgrades the version of pandas used by the Featureform Python client to `>=1.3.5`.

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency upgrade

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
