### PR TITLE
Databricks Token Validation Pattern (Optional hyphenated suffix)

### DIFF
--- a/client/src/featureform/resources.py
+++ b/client/src/featureform/resources.py
@@ -2338,7 +2338,7 @@ class DatabricksCredentials:
 
         if self.host and not self._validate_token():
             raise ValueError(
-                f"Invalid token: expected token in the format 'dapixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-x' but received '{self.token}'"
+                f"Invalid token: expected token in the format 'dapi' + 32 alphanumeric characters (optionally ending with '-' and 1 alphanumeric character) but received '{self.token}'"
             )
 
     def _validate_cluster_id(self):
@@ -2346,7 +2346,7 @@ class DatabricksCredentials:
         return re.match(cluster_id_regex, self.cluster_id)
 
     def _validate_token(self):
-        token_regex = r"^dapi[a-zA-Z0-9]{32}-[a-zA-Z0-9]"
+        token_regex = r"^dapi[a-zA-Z0-9]{32}(-[a-zA-Z0-9])?$"
         return re.match(token_regex, self.token)
 
     def type(self):

--- a/client/tests/test_executor_resources.py
+++ b/client/tests/test_executor_resources.py
@@ -11,9 +11,10 @@ from featureform.resources import DatabricksCredentials, EMRCredentials
             "",
             "",
             "host_xyz",
-            "dapiabcdefghijklmnopqrstuvwxyz12345-6",
+            "dapiabcdefghijklmnopqrstuvwxyz123456-6",
             "abcd-123def-ghijklmn",
-        ),  # valid token and cluster id
+        ),
+        # valid token and cluster id
         pytest.param(
             "john",
             "abc123",
@@ -21,6 +22,14 @@ from featureform.resources import DatabricksCredentials, EMRCredentials
             "dapiabcdefghijklmnopqrstuvwxyz12345-6",
             "abcd-123def-ghijklmn",
             marks=pytest.mark.xfail,
+        ),
+        # valid token w/o hyphenated suffix and cluster id
+        pytest.param(
+            "",
+            "",
+            "host_xyz",
+            "dapiabcdefghijklmnopqrstuvwxyz123456",
+            "abcd-123def-ghijklmn",
         ),
         # cluster id should always be provided
         ("john", "abc123", "", "", "abcd-123def-ghijklmn"),


### PR DESCRIPTION
# Description

Currently the pattern validation for Datatricks token assumes a hyphenated suffix (e.g. `-3`); however, it seems that tokens generated across different cloud providers (e.g. AWS) don't always contain this suffix.

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Extends existing pattern

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
