### PR TITLE
`batch_features` accepts list of feature variant tuples

### DIFF
--- a/client/src/featureform/serving.py
+++ b/client/src/featureform/serving.py
@@ -151,17 +151,17 @@ class ServingClient:
         """Closes the connection to the Featureform instance."""
         self.impl.close()
 
-    def batch_features(self, *features):
+    def batch_features(self, features):
         """
         Return an iterator that iterates over each entity and corresponding features in feats.
         **Example:**
         ```py title="definitions.py"
-        for feature_values in client.batch_features("feature1", "feature2", "feature3"):
+        for feature_values in client.batch_features([("feature1", "variant"), ("feature2", "variant"), ("feature3", "variant")]):
             print(feature_values)
         ```
 
         Args:
-            *feats (str): The features to iterate over
+            features (List[NameVariant]): The features to iterate over
 
         Returns:
             iterator: An iterator of entity and feature values

--- a/tests/end_to_end/features/steps/serving.py
+++ b/tests/end_to_end/features/steps/serving.py
@@ -151,9 +151,11 @@ def step_impl(context):
         ("f", ["", 64556, "64556"]),
     ]
     context.iter = context.client.batch_features(
-        ("boolean_feature", ff.get_run()),
-        ("numerical_feature", ff.get_run()),
-        ("string_feature", ff.get_run()),
+        [
+            ("boolean_feature", ff.get_run()),
+            ("numerical_feature", ff.get_run()),
+            ("string_feature", ff.get_run()),
+        ]
     )
 
 
@@ -168,9 +170,11 @@ def step_impl(context):
         ("C1010085", [225.0, "319080.2", 0.0007051518709089439]),
     ]
     context.iter = context.client.batch_features(
-        ("transaction_feature", ff.get_run()),
-        ("balance_feature", ff.get_run()),
-        ("perc_feature", ff.get_run()),
+        [
+            ("transaction_feature", ff.get_run()),
+            ("balance_feature", ff.get_run()),
+            ("perc_feature", ff.get_run()),
+        ]
     )
 
 


### PR DESCRIPTION
# Description

Instead of a variadic method that accepts tuples, this PR change's `batch_features`'s signature to accept a list of feature variant tuples.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
