### PR TITLE
Batch Feature Directory Path Validation

### DIFF
--- a/filestore/filepath.go
+++ b/filestore/filepath.go
@@ -514,9 +514,11 @@ func groupByDateTimeDirectory(files []Filepath) (FilePathGroup, error) {
 		pathParts := strings.Split(file.Key(), "/")
 		// The path to a file follows the format:
 		// <OPTIONAL PATH>/featureform/<TYPE>/<NAME DIR>/<VARIANT DIR>/<DATETIME DIR>/<FILENAME>
-		// so there should be at least 6 path components.
-		if len(pathParts) < 6 {
-			return FilePathGroup{}, fmt.Errorf("expected 5 path components: %s", file.Key())
+		// or in the case of batch features:
+		// <OPTIONAL PATH>/featureform/BatchFeatures/<UUID 5>/<DATETIME DIR>/<FILENAME>
+		// so there should be at least 5 path components.
+		if len(pathParts) < 5 {
+			return FilePathGroup{}, fmt.Errorf("expected at least 5 path components, but found: %s", file.Key())
 		}
 		// The datetime directory is the second to last path component and follows the format:
 		// <YEAR>-<MONTH>-<DAY>-<HOUR>-<MINUTE>-<SECOND>-<FRACTIONAL SECONDS>


### PR DESCRIPTION
# Description

Previously, file store buckets registered with an additional/optional `path` cleared the validation for datetime directories because they contained 6 parts (i.e. `featureform/<TYPE>/<NAME>/<VARIANT>/<DATETIME DIR>/file`); however, batch features use a UUID v5 for the name-variant list, which means their paths were failing validation without the additional/optional `path` config on the bucket. This PR lowers the threshold to 5 path components to account for this.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
