### PR TITLE
Client-side gRC Configuration for Long-running jobs

### DIFF
--- a/client/src/featureform/tls.py
+++ b/client/src/featureform/tls.py
@@ -10,9 +10,9 @@ secure_protocol = "https://"
 def insecure_channel(host):
     channel_options = [
         ("grpc.enable_http_proxy", 0),
-        ("grpc.keepalive_time_ms", 20000),
-        ("grpc.keepalive_timeout_ms", 5000),
-        ("grpc.http2.max_pings_without_data", 5),
+        ("grpc.keepalive_time_ms", 25000),
+        ("grpc.keepalive_timeout_ms", 55000),
+        ("grpc.http2.max_pings_without_data", 100),
         ("grpc.keepalive_permit_without_calls", 1),
     ]
     return grpc.insecure_channel(host, options=channel_options)
@@ -20,9 +20,9 @@ def insecure_channel(host):
 
 def secure_channel(host, cert_path):
     channel_options = [
-        ("grpc.keepalive_time_ms", 20000),
-        ("grpc.keepalive_timeout_ms", 5000),
-        ("grpc.http2.max_pings_without_data", 5),
+        ("grpc.keepalive_time_ms", 25000),
+        ("grpc.keepalive_timeout_ms", 55000),
+        ("grpc.http2.max_pings_without_data", 100),
         ("grpc.keepalive_permit_without_calls", 1),
     ]
     cert_path = cert_path or os.getenv("FEATUREFORM_CERT")


### PR DESCRIPTION
# Description

`batch_features` is a long-running operations, which means it can and does sometimes exceed the client-side gRPC timeouts waiting for data. This PR increases the timeout values to account for this.

## Type of change

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
