### PR TITLE
Write Spark Submit Params to File Store to Avoid Databricks API 10K-byte Limit

### DIFF
--- a/client/src/featureform/tls.py
+++ b/client/src/featureform/tls.py
@@ -8,10 +8,14 @@ secure_protocol = "https://"
 
 
 def insecure_channel(host):
+    keep_alive_ms = int(os.getenv("FEATUREFORM_KEEPALIVE_TIME_MS", "60_000"))
+    keep_alive_timeout_ms = int(
+        os.getenv("FEATUREFORM_KEEPALIVE_TIMEOUT_MS", "300_000")
+    )
     channel_options = [
         ("grpc.enable_http_proxy", 0),
-        ("grpc.keepalive_time_ms", 25000),
-        ("grpc.keepalive_timeout_ms", 55000),
+        ("grpc.keepalive_time_ms", keep_alive_ms),
+        ("grpc.keepalive_timeout_ms", keep_alive_timeout_ms),
         ("grpc.http2.max_pings_without_data", 100),
         ("grpc.keepalive_permit_without_calls", 1),
     ]
@@ -19,9 +23,13 @@ def insecure_channel(host):
 
 
 def secure_channel(host, cert_path):
+    keep_alive_ms = int(os.getenv("FEATUREFORM_KEEPALIVE_TIME_MS", "60_000"))
+    keep_alive_timeout_ms = int(
+        os.getenv("FEATUREFORM_KEEPALIVE_TIMEOUT_MS", "300_000")
+    )
     channel_options = [
-        ("grpc.keepalive_time_ms", 25000),
-        ("grpc.keepalive_timeout_ms", 55000),
+        ("grpc.keepalive_time_ms", keep_alive_ms),
+        ("grpc.keepalive_timeout_ms", keep_alive_timeout_ms),
         ("grpc.http2.max_pings_without_data", 100),
         ("grpc.keepalive_permit_without_calls", 1),
     ]

--- a/provider/scripts/spark/offline_store_spark_runner.py
+++ b/provider/scripts/spark/offline_store_spark_runner.py
@@ -315,12 +315,7 @@ def execute_sql_query(
         spark = SparkSession.builder.appName("Execute SQL Query").getOrCreate()
         set_spark_configs(spark, spark_configs)
 
-        if (
-            job_type == JobType.TRANSFORMATION
-            or job_type == JobType.MATERIALIZATION
-            or job_type == JobType.TRAINING_SET
-            or job_type == JobType.BATCH_FEATURES
-        ):
+        if job_type in list(JobType):
             for i, source in enumerate(source_list):
                 file_extension = Path(source).suffix
                 is_directory = file_extension == ""
@@ -563,7 +558,7 @@ def get_s3_object(file_path, credentials):
     bucket_name = credentials.get("aws_bucket_name")
     if not (aws_region and aws_access_key_id and aws_secret_access_key and bucket_name):
         raise Exception(
-            "the values for 'aws_region', 'aws_access_key_id', 'aws_secret_access_key', 'aws_bucket_name' need to be set as credential"
+            "Missing credential values for 'aws_region', 'aws_access_key_id', 'aws_secret_access_key', 'aws_bucket_name'"
         )
 
     session = boto3.Session(
@@ -687,12 +682,7 @@ def parse_args(args=None):
     sql_parser = subparser.add_parser("sql")
     sql_parser.add_argument(
         "--job_type",
-        choices=[
-            JobType.TRANSFORMATION,
-            JobType.MATERIALIZATION,
-            JobType.TRAINING_SET,
-            JobType.BATCH_FEATURES,
-        ],
+        choices=list(JobType),
         help="type of job being run on spark",
     )
     sql_parser.add_argument(

--- a/provider/scripts/spark/tests/conftest.py
+++ b/provider/scripts/spark/tests/conftest.py
@@ -38,6 +38,7 @@ def sql_all_arguments():
         store_type=None,
         output_format="parquet",
         headers="include",
+        submit_params_uri=None,
     )
     return (input_args, expected_args)
 
@@ -55,6 +56,7 @@ def sql_local_all_arguments():
         credential={},
         output_format="parquet",
         headers="include",
+        submit_params_uri=None,
     )
     return expected_args
 
@@ -79,6 +81,7 @@ def sql_partial_arguments():
         store_type=None,
         output_format="parquet",
         headers="include",
+        submit_params_uri=None,
     )
     return (input_args, expected_args)
 
@@ -97,6 +100,7 @@ def sql_invaild_arguments():
         store_type=None,
         output_format="parquet",
         headers="include",
+        submit_params_uri=None,
     )
     return (input_args, expected_args)
 
@@ -112,6 +116,7 @@ def sql_invalid_local_arguments():
         store_type=None,
         output_format="parquet",
         headers="include",
+        submit_params_uri=None,
     )
     return expected_args
 
@@ -200,6 +205,7 @@ def sql_databricks_all_arguments():
         credential={"key": "value"},
         output_format="parquet",
         headers="include",
+        submit_params_uri=None,
     )
     return input_args, expected_args
 

--- a/tests/end_to_end/features/serving.feature
+++ b/tests/end_to_end/features/serving.feature
@@ -19,3 +19,13 @@ Feature: Batch Serving
     And I define a SparkUser and register features
     Then I serve batch features for spark
     And I can get a list containing the entity name and a tuple with all the features
+
+  Scenario: Serving Batch Features (Spark with Submit Params Exceeding 10K Bytes)
+    Given Featureform is installed
+    When I create a "hosted" "insecure" client for "localhost:7878"
+    And I register "s3" filestore with bucket "featureform-spark-testing" and root path "behave"
+    And I register databricks
+    And I register the files from the database
+    And I define a SparkUser and register features
+    Then I serve batch features for spark with submit params that exceed the 10K-byte API limit
+    And I can get a list containing the correct number of features

--- a/tests/end_to_end/features/steps/serving.py
+++ b/tests/end_to_end/features/steps/serving.py
@@ -178,6 +178,20 @@ def step_impl(context):
     )
 
 
+@then(
+    "I serve batch features for spark with submit params that exceed the 10K-byte API limit"
+)
+def step_impl(context):
+    context.expected = 30
+    context.iter = context.client.batch_features(
+        [
+            *([("transaction_feature", ff.get_run())] * 10),
+            *([("balance_feature", ff.get_run())] * 10),
+            *([("perc_feature", ff.get_run())] * 10),
+        ]
+    )
+
+
 @then("I can get a list containing the entity name and a tuple with all the features")
 def step_impl(context):
     i = 0
@@ -187,6 +201,17 @@ def step_impl(context):
         print(entity, features)
         assert entity == context.expected[i][0]
         assert Counter(features) == Counter(context.expected[i][1])
+        i += 1
+
+
+@then("I can get a list containing the correct number of features")
+def step_impl(context):
+    i = 0
+    for entity, features in context.iter:
+        if i >= len(context.expected):
+            break
+        print(entity, features)
+        assert len(features) == context.expected
         i += 1
 
 

--- a/tests/end_to_end/features/steps/serving.py
+++ b/tests/end_to_end/features/steps/serving.py
@@ -208,7 +208,7 @@ def step_impl(context):
 def step_impl(context):
     i = 0
     for entity, features in context.iter:
-        if i >= len(context.expected):
+        if i >= context.expected:
             break
         print(entity, features)
         assert len(features) == context.expected


### PR DESCRIPTION
# Description

Databricks's API has a 10K-byte limit on spark job submit params. Given batch features can overrun this limit due to numerous source paths and larger queries, an alternative is needed in cases where the payload is too large. This PR introduces writing a JSON file containing the query and the source list to the file store and reading this file from the PySpark script to side step the 10K-byte constraint.

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
