### PR TITLE
Bugfix: Skip null timestamp columns stats

### DIFF
--- a/dashboard/src/components/dialog/SourceDialog.js
+++ b/dashboard/src/components/dialog/SourceDialog.js
@@ -21,6 +21,7 @@ export default function SourceDialog({
   const [stats, setStats] = React.useState([]);
   const [error, setError] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(true);
+  const [skipIndexList, setSkipIndexList] = React.useState([]);
 
   React.useEffect(async () => {
     if (sourceName && sourceVariant && open && api) {
@@ -33,6 +34,21 @@ export default function SourceDialog({
         response = await api.fetchFeatureFileStats(sourceName, sourceVariant);
       }
       if (response?.columns && response?.rows) {
+        if (type === 'Feature') {
+          let skipList = [];
+          response.columns?.map((col, index) => {
+            if (
+              col === 'ts' &&
+              response.stats?.[index]?.string_categories?.[0] === 'unique' &&
+              response.stats?.[index]?.categoryCounts?.[0] === 1
+            ) {
+              skipList.push(index);
+              return false;
+            }
+            return true;
+          });
+          setSkipIndexList(skipList);
+        }
         setColumns(response.columns);
         setRowList(response.rows);
         setStats(response.stats);
@@ -46,7 +62,6 @@ export default function SourceDialog({
   const handleClickOpen = () => {
     setOpen(true);
   };
-
   const handleClose = () => {
     setOpen(false);
   };
@@ -88,6 +103,7 @@ export default function SourceDialog({
               stats={stats}
               columns={columns}
               rowList={rowList}
+              skipIndexList={skipIndexList}
             />
           ) : (
             <div data-testid='errorMessageId'>{error}</div>

--- a/dashboard/src/components/dialog/SourceDialogTable.js
+++ b/dashboard/src/components/dialog/SourceDialogTable.js
@@ -66,7 +66,7 @@ export default function SourceDialogTable({
           <TableHead>
             <TableRow>
               {columns?.map((col, i) => (
-                <>
+                <React.Fragment key={i}>
                   {!skipIndexList.includes(i) && (
                     <TableCell
                       key={col + i}
@@ -76,14 +76,14 @@ export default function SourceDialogTable({
                       {`${col}`}
                     </TableCell>
                   )}
-                </>
+                </React.Fragment>
               ))}
             </TableRow>
             {stats?.length ? (
-              <>
+              <React.Fragment>
                 <TableRow>
                   {stats?.map((statObj, index) => (
-                    <>
+                    <React.Fragment key={index}>
                       {!skipIndexList.includes(index) && (
                         <TableCell
                           key={index}
@@ -104,10 +104,10 @@ export default function SourceDialogTable({
                           )}
                         </TableCell>
                       )}
-                    </>
+                    </React.Fragment>
                   ))}
                 </TableRow>
-              </>
+              </React.Fragment>
             ) : null}
           </TableHead>
           <TableBody>
@@ -118,7 +118,7 @@ export default function SourceDialogTable({
                 sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
               >
                 {currentRow?.map((row, index) => (
-                  <>
+                  <React.Fragment key={index}>
                     {!skipIndexList.includes(index) && (
                       <TableCell
                         key={row + index}
@@ -136,7 +136,7 @@ export default function SourceDialogTable({
                         </Tooltip>
                       </TableCell>
                     )}
-                  </>
+                  </React.Fragment>
                 ))}
               </TableRow>
             ))}

--- a/dashboard/src/components/dialog/SourceDialogTable.js
+++ b/dashboard/src/components/dialog/SourceDialogTable.js
@@ -20,6 +20,7 @@ export default function SourceDialogTable({
   stats = [],
   columns = [],
   rowList = [],
+  skipIndexList = [],
 }) {
   const textEllipsis = {
     whiteSpace: 'nowrap',
@@ -65,35 +66,48 @@ export default function SourceDialogTable({
           <TableHead>
             <TableRow>
               {columns?.map((col, i) => (
-                <TableCell
-                  key={col + i}
-                  data-testid={col + i}
-                  align={i === 0 ? 'left' : 'right'}
-                >
-                  {`${col}`}
-                </TableCell>
+                <>
+                  {!skipIndexList.includes(i) && (
+                    <TableCell
+                      key={col + i}
+                      data-testid={col + i}
+                      align={i === 0 ? 'left' : 'right'}
+                    >
+                      {`${col}`}
+                    </TableCell>
+                  )}
+                </>
               ))}
             </TableRow>
             {stats?.length ? (
-              <TableRow>
-                {stats?.map((statObj, index) => (
-                  <TableCell key={index} align={index === 0 ? 'left' : 'right'}>
-                    {['numeric', 'boolean'].includes(statObj.type) ? (
-                      <Barchart
-                        categories={
-                          statObj.type === 'boolean'
-                            ? statObj.string_categories
-                            : statObj.numeric_categories
-                        }
-                        categoryCounts={statObj.categoryCounts}
-                        type={statObj.type}
-                      />
-                    ) : (
-                      <UniqueValues count={statObj?.categoryCounts[0]} />
-                    )}
-                  </TableCell>
-                ))}
-              </TableRow>
+              <>
+                <TableRow>
+                  {stats?.map((statObj, index) => (
+                    <>
+                      {!skipIndexList.includes(index) && (
+                        <TableCell
+                          key={index}
+                          align={index === 0 ? 'left' : 'right'}
+                        >
+                          {['numeric', 'boolean'].includes(statObj.type) ? (
+                            <Barchart
+                              categories={
+                                statObj.type === 'boolean'
+                                  ? statObj.string_categories
+                                  : statObj.numeric_categories
+                              }
+                              categoryCounts={statObj.categoryCounts}
+                              type={statObj.type}
+                            />
+                          ) : (
+                            <UniqueValues count={statObj?.categoryCounts[0]} />
+                          )}
+                        </TableCell>
+                      )}
+                    </>
+                  ))}
+                </TableRow>
+              </>
             ) : null}
           </TableHead>
           <TableBody>
@@ -104,21 +118,25 @@ export default function SourceDialogTable({
                 sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
               >
                 {currentRow?.map((row, index) => (
-                  <TableCell
-                    key={row + index}
-                    align={index === 0 ? 'left' : 'right'}
-                    sx={{ maxHeight: '50px' }}
-                  >
-                    <Tooltip title='Copy to Clipboard'>
-                      <Typography
-                        onClick={copyToClipBoard}
-                        fontSize={11.5}
-                        style={textEllipsis}
+                  <>
+                    {!skipIndexList.includes(index) && (
+                      <TableCell
+                        key={row + index}
+                        align={index === 0 ? 'left' : 'right'}
+                        sx={{ maxHeight: '50px' }}
                       >
-                        {`${row}`}
-                      </Typography>
-                    </Tooltip>
-                  </TableCell>
+                        <Tooltip title='Copy to Clipboard'>
+                          <Typography
+                            onClick={copyToClipBoard}
+                            fontSize={11.5}
+                            style={textEllipsis}
+                          >
+                            {`${row}`}
+                          </Typography>
+                        </Tooltip>
+                      </TableCell>
+                    )}
+                  </>
                 ))}
               </TableRow>
             ))}

--- a/dashboard/src/components/dialog/faultyTimestamp.test.json
+++ b/dashboard/src/components/dialog/faultyTimestamp.test.json
@@ -1,0 +1,49 @@
+{
+  "columns": ["entity", "ts", "value"],
+  "rows": [
+    [
+      "entity-value",
+      "java.util.GregorianCalendar[time=?,areFieldsSet=false,areAllFieldsSet=false,lenient=true,zone=sun.util.calendar.ZoneInfo[id=\"Etc/UTC\",offset=0,dstSavings=0,useDaylight=false,transitions=0,lastRule=null],firstDayOfWeek=1,minimalDaysInFirstWeek=1,ERA=?,YEAR=1970,MONTH=0,WEEK_OF_YEAR=?,WEEK_OF_MONTH=?,DAY_OF_MONTH=1,DAY_OF_YEAR=?,DAY_OF_WEEK=?,DAY_OF_WEEK_IN_MONTH=?,AM_PM=0,HOUR=0,HOUR_OF_DAY=0,MINUTE=0,SECOND=0,MILLISECOND=0,ZONE_OFFSET=?,DST_OFFSET=?]",
+      "-0.9724802301485045"
+    ],
+    [
+      "ACH-000783",
+      "java.util.GregorianCalendar[time=?,areFieldsSet=false,areAllFieldsSet=false,lenient=true,zone=sun.util.calendar.ZoneInfo[id=\"Etc/UTC\",offset=0,dstSavings=0,useDaylight=false,transitions=0,lastRule=null],firstDayOfWeek=1,minimalDaysInFirstWeek=1,ERA=?,YEAR=1970,MONTH=0,WEEK_OF_YEAR=?,WEEK_OF_MONTH=?,DAY_OF_MONTH=1,DAY_OF_YEAR=?,DAY_OF_WEEK=?,DAY_OF_WEEK_IN_MONTH=?,AM_PM=0,HOUR=0,HOUR_OF_DAY=0,MINUTE=0,SECOND=0,MILLISECOND=0,ZONE_OFFSET=?,DST_OFFSET=?]",
+      "2.748565292845975"
+    ]
+  ],
+  "stats": [
+    {
+      "name": "entity",
+      "type": "string",
+      "string_categories": ["unique"],
+      "numeric_categories": [],
+      "categoryCounts": [1095]
+    },
+    {
+      "name": "ts",
+      "type": "string",
+      "string_categories": ["unique"],
+      "numeric_categories": [],
+      "categoryCounts": [1]
+    },
+    {
+      "name": "value",
+      "type": "numeric",
+      "string_categories": [],
+      "numeric_categories": [
+        [-9, -8],
+        [-8, -6],
+        [-6, -4],
+        [-4, -3],
+        [-3, -1],
+        [-1, 0],
+        [0, 1],
+        [1, 3],
+        [3, 5],
+        [5, 6]
+      ],
+      "categoryCounts": [7, 15, 16, 49, 129, 303, 403, 147, 21, 5]
+    }
+  ]
+}


### PR DESCRIPTION
# Description

This PR mitigates an issue where missing time stamp stat column(s) are still rendered in the stats dialog window. 

It creates a skip list if it detects a null `ts` column, and skips that column's render. 

`example (with faulty but skipped TS column)`

<img width="652" alt="Screenshot 2023-12-05 at 5 29 28 PM" src="https://github.com/featureform/featureform/assets/34227093/43ddbf9f-b016-428e-958a-fbbfa188a09b">



`sourceDialog tests`
<img width="690" alt="Screenshot 2023-12-05 at 7 28 04 PM" src="https://github.com/featureform/featureform/assets/34227093/53f8bbd7-157a-4b9c-8448-ca65150815fc">


<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
