### PR TITLE
Bugfix: Use sync map for MockOnlineTable to fix concurrent map update

### DIFF
--- a/runner/copy_test.go
+++ b/runner/copy_test.go
@@ -90,16 +90,16 @@ func (m *MaterializedFeaturesIterateRunBroken) IterateSegment(begin int64, end i
 }
 
 type MockOnlineTable struct {
-	DataTable map[string]interface{}
+	DataTable sync.Map
 }
 
 func (m *MockOnlineTable) Set(entity string, value interface{}) error {
-	m.DataTable[entity] = value
+	m.DataTable.Store(entity, value)
 	return nil
 }
 
 func (m *MockOnlineTable) Get(entity string) (interface{}, error) {
-	value, exists := m.DataTable[entity]
+	value, exists := m.DataTable.Load(entity)
 	if !exists {
 		return nil, errors.New("Value does not exist in online table")
 	}
@@ -184,7 +184,7 @@ type ErrorJobTestParams struct {
 
 func testParams(params JobTestParams) error {
 	table := &MockOnlineTable{
-		DataTable: make(map[string]interface{}),
+		DataTable: sync.Map{},
 	}
 	online := NewMockOnlineStore()
 	featureRows := params.Materialized.Rows


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
