### PR TITLE
Truncate long form errors

### DIFF
--- a/dashboard/src/components/entitypage/EntityPageView.js
+++ b/dashboard/src/components/entitypage/EntityPageView.js
@@ -30,6 +30,7 @@ import MetricsDropdown from './elements/MetricsDropdown';
 import StatsDropdown from './elements/StatsDropdown';
 import TagBox from './elements/TagBox.js';
 import VariantControl from './elements/VariantControl';
+import ErrorModal from './ErrorModal.js';
 
 SyntaxHighlighter.registerLanguage('python', python);
 SyntaxHighlighter.registerLanguage('sql', sql);
@@ -507,15 +508,20 @@ const EntityPageView = ({
                         <b>Team:</b> {metadata['team']}
                       </Typography>
                     )}
-                    {metadata['status'] && metadata['status'] !== 'NO_STATUS' && (
-                      <Typography variant='body1'>
-                        <b>Status:</b> {metadata['status']}
-                      </Typography>
-                    )}
+                    {metadata['status'] &&
+                      metadata['status'] !== 'NO_STATUS' && (
+                        <Typography variant='body1'>
+                          <b>Status:</b> {metadata['status']}
+                        </Typography>
+                      )}
                     {metadata['error'] && metadata['error'] !== '' && (
-                      <Typography variant='body1'>
-                        <b>Error Message:</b> {metadata['error']}
-                      </Typography>
+                      <>
+                        <b>Error Message:</b>
+                        <ErrorModal
+                          buttonTxt='See More'
+                          errorTxt={metadata['error']}
+                        />
+                      </>
                     )}
                     {metadata['source-type'] && (
                       <Typography variant='body1'>

--- a/dashboard/src/components/entitypage/ErrorModal.js
+++ b/dashboard/src/components/entitypage/ErrorModal.js
@@ -8,11 +8,12 @@ import DialogTitle from '@mui/material/DialogTitle';
 import IconButton from '@mui/material/IconButton';
 import * as React from 'react';
 
+export const ERROR_MSG_MAX = 200;
+
 export default function ErrorModal({ errorTxt = '', buttonTxt = '' }) {
-  const MAX = 200;
   const [open, setOpen] = React.useState(false);
-  const [isShowMore] = React.useState(errorTxt.length > MAX);
-  const [truncated] = React.useState(errorTxt.substring(0, MAX));
+  const [isShowMore] = React.useState(errorTxt.length > ERROR_MSG_MAX);
+  const [truncated] = React.useState(errorTxt.substring(0, ERROR_MSG_MAX));
   const [openSnack, setOpenSnack] = React.useState(false);
 
   const closeSnackBar = (_, reason) => {
@@ -52,7 +53,7 @@ export default function ErrorModal({ errorTxt = '', buttonTxt = '' }) {
           <Typography>Copied to clipboard!</Typography>
         </Alert>
       </Snackbar>
-      <Typography variant='body1'>
+      <Typography data-testid='errorMessageId' variant='body1'>
         {truncated}
         {isShowMore && (
           <Button
@@ -94,7 +95,9 @@ export default function ErrorModal({ errorTxt = '', buttonTxt = '' }) {
           </IconButton>
         </DialogTitle>
         <DialogContent>
-          <Typography variant='body1'>{errorTxt}</Typography>
+          <Typography variant='body1' data-testid='fullTextContent'>
+            {errorTxt}
+          </Typography>
         </DialogContent>
       </Dialog>
     </div>

--- a/dashboard/src/components/entitypage/ErrorModal.js
+++ b/dashboard/src/components/entitypage/ErrorModal.js
@@ -1,0 +1,102 @@
+import CloseIcon from '@mui/icons-material/Close';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { Alert, Slide, Snackbar, Tooltip, Typography } from '@mui/material';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import IconButton from '@mui/material/IconButton';
+import * as React from 'react';
+
+export default function ErrorModal({ errorTxt = '', buttonTxt = '' }) {
+  const MAX = 200;
+  const [open, setOpen] = React.useState(false);
+  const [isShowMore] = React.useState(errorTxt.length > MAX);
+  const [truncated] = React.useState(errorTxt.substring(0, MAX));
+  const [openSnack, setOpenSnack] = React.useState(false);
+
+  const closeSnackBar = (_, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setOpenSnack(false);
+  };
+
+  const copyToClipBoard = (error = '') => {
+    if (error) {
+      navigator.clipboard.writeText(error);
+      setOpenSnack(true);
+    }
+  };
+
+  function transition(props) {
+    return <Slide {...props} direction='right' />;
+  }
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <Snackbar
+        open={openSnack}
+        autoHideDuration={1250}
+        onClose={closeSnackBar}
+        TransitionComponent={transition}
+      >
+        <Alert severity='success' onClose={closeSnackBar}>
+          <Typography>Copied to clipboard!</Typography>
+        </Alert>
+      </Snackbar>
+      <Typography variant='body1'>
+        {truncated}
+        {isShowMore && (
+          <Button
+            data-testid='openErrorModalId'
+            variant='text'
+            onClick={handleClickOpen}
+            sx={{ paddingLeft: 0, fontSize: 15 }}
+          >
+            {`...${buttonTxt}`}
+          </Button>
+        )}
+      </Typography>
+
+      <Dialog
+        fullWidth={true}
+        maxWidth={'xl'}
+        open={open}
+        onClose={handleClose}
+        aria-labelledby='dialog-title'
+        aria-describedby='dialog-description'
+      >
+        <DialogTitle id='dialog-title' data-testid={'errorModalTitleId'}>
+          Error Message
+          <Tooltip title='Copy to Clipboard'>
+            <Button
+              role='none'
+              onClick={() => copyToClipBoard(errorTxt)}
+              fontSize={11.5}
+            >
+              <ContentCopyIcon />
+            </Button>
+          </Tooltip>
+          <IconButton
+            data-testid={'errorModalCloseId'}
+            sx={{ float: 'right' }}
+            onClick={handleClose}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant='body1'>{errorTxt}</Typography>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/dashboard/src/components/entitypage/ErrorModal.js
+++ b/dashboard/src/components/entitypage/ErrorModal.js
@@ -54,18 +54,18 @@ export default function ErrorModal({ errorTxt = '', buttonTxt = '' }) {
         </Alert>
       </Snackbar>
       <Typography data-testid='errorMessageId' variant='body1'>
-        {truncated}
-        {isShowMore && (
-          <Button
-            data-testid='openErrorModalId'
-            variant='text'
-            onClick={handleClickOpen}
-            sx={{ paddingLeft: 0, fontSize: 15 }}
-          >
-            {`...${buttonTxt}`}
-          </Button>
-        )}
+        {`${truncated + (isShowMore ? '...' : '')}`}
       </Typography>
+      {isShowMore && (
+        <Button
+          data-testid='openErrorModalId'
+          variant='text'
+          onClick={handleClickOpen}
+          sx={{ paddingLeft: 0, fontSize: 15 }}
+        >
+          {buttonTxt}
+        </Button>
+      )}
 
       <Dialog
         fullWidth={true}

--- a/dashboard/src/components/entitypage/ErrorModal.test.js
+++ b/dashboard/src/components/entitypage/ErrorModal.test.js
@@ -1,0 +1,103 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
+import 'jest-canvas-mock';
+import React from 'react';
+import ErrorModal, { ERROR_MSG_MAX } from './ErrorModal';
+
+describe('Error modal tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  const P_NODE = 'P';
+  const BTN_NODE = 'BUTTON';
+  const OPEN_BTN_ID = 'openErrorModalId';
+  const CLOSE_BTN_ID = 'errorModalCloseId';
+  const ERROR_MSG_ID = 'errorMessageId';
+  const TITLE_ID = 'errorModalTitleId';
+  const FULL_TXT_ID = 'fullTextContent';
+
+  const getTestBody = (errorTxt = '', buttonTxt = 'Show More') => {
+    const testBody = (
+      <>
+        <ErrorModal errorTxt={errorTxt} buttonTxt={buttonTxt} />
+      </>
+    );
+    return { testBody };
+  };
+
+  test('An error message shorter than MAX renders OK, without a show more button.', async () => {
+    //given:
+    const errorMsg = 'Something went wrong';
+    const { testBody } = getTestBody(errorMsg);
+    const helper = render(testBody);
+
+    //when:
+    const foundError = helper.getByTestId(ERROR_MSG_ID);
+    const foundButton = helper.queryByTestId(OPEN_BTN_ID);
+
+    //then:
+    expect(foundError.nodeName).toBe(P_NODE);
+    expect(foundError.textContent).toBe(errorMsg);
+    expect(foundButton).toBeNull();
+  });
+
+  test('An error message greater than the MAX, will render the show more button.', () => {
+    //given:
+    const errorMsg = '#'.repeat(ERROR_MSG_MAX + 1);
+    const { testBody } = getTestBody(errorMsg);
+    const helper = render(testBody);
+
+    //when:
+    const foundError = helper.getByText(errorMsg.substring(0, ERROR_MSG_MAX));
+    const foundButton = helper.getByTestId(OPEN_BTN_ID);
+
+    //then:
+    expect(foundError.nodeName).toBe(P_NODE);
+    expect(foundButton.nodeName).toBe(BTN_NODE);
+  });
+
+  test('The show more button displays the full error message', async () => {
+    //given:
+    const errorMsg = '#'.repeat(ERROR_MSG_MAX + ERROR_MSG_MAX);
+    const { testBody } = getTestBody(errorMsg);
+    const helper = render(testBody);
+
+    //and: show more displays, the user clicks open
+    fireEvent.click(helper.getByTestId(OPEN_BTN_ID));
+    await helper.findByTestId(TITLE_ID);
+
+    //when:
+    const foundFullError = helper.getByTestId(FULL_TXT_ID);
+
+    //then: the full error is found
+    expect(foundFullError.textContent).toBe(errorMsg);
+  });
+
+  test('The full error dialog closes on user click', async () => {
+    //given:
+    const errorMsg = '#'.repeat(ERROR_MSG_MAX + ERROR_MSG_MAX);
+    const { testBody } = getTestBody(errorMsg);
+    const helper = render(testBody);
+
+    //and: show more displays, the user clicks open
+    fireEvent.click(helper.getByTestId(OPEN_BTN_ID));
+    await helper.findByTestId(TITLE_ID);
+
+    //when:
+    fireEvent.click(helper.getByTestId(CLOSE_BTN_ID));
+    let titleQuery = helper.queryByTestId(TITLE_ID);
+    await waitForElementToBeRemoved(() => helper.queryByTestId(TITLE_ID));
+
+    //then:
+    expect(titleQuery).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/entitypage/ErrorModal.test.js
+++ b/dashboard/src/components/entitypage/ErrorModal.test.js
@@ -57,7 +57,9 @@ describe('Error modal tests', () => {
     const helper = render(testBody);
 
     //when:
-    const foundError = helper.getByText(errorMsg.substring(0, ERROR_MSG_MAX));
+    const foundError = helper.getByText(errorMsg.substring(0, ERROR_MSG_MAX), {
+      exact: false,
+    });
     const foundButton = helper.getByTestId(OPEN_BTN_ID);
 
     //then:


### PR DESCRIPTION
# Description

This PR will truncate long form errors in the entity page view, and include the option to view and copy the full content in a modal.

closes [#454-ent](https://github.com/featureform/featureform-enterprise/issues/454)

`example`
<img width="1500" alt="Screenshot 2023-12-07 at 4 26 05 PM" src="https://github.com/featureform/featureform/assets/34227093/f52b1439-b5be-4d67-a75c-d159a2072878">


`tests`

<img width="781" alt="Screenshot 2023-12-07 at 3 15 40 PM" src="https://github.com/featureform/featureform/assets/34227093/267a27b0-d551-4d2a-8fa6-3899f97a7d34">


<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
