### PR TITLE
MD5 Hash of `offline_store_spark_runner.py`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,14 @@ COPY provider/scripts/spark/requirements.txt $SPARK_REQUIREMENTS
 COPY provider/queries/materialize_no_ts.sql $MATERIALIZE_NO_TIMESTAMP_QUERY_PATH
 COPY provider/queries/materialize_ts.sql $MATERIALIZE_TIMESTAMP_QUERY_PATH
 
-ENV SPARK_LOCAL_SCRIPT_PATH=$SPARK_FILEPATH
+# Take the MD5 hash of the Spark runner script and store it in a file for use by the config package
+# when determining the remove filepath in cloud object storage (e.g. S3). By adding the hash as a suffix
+# to the file, we ensure that different versions of the script are uploaded to cloud object storage
+# without overwriting previous or future versions.
+RUN cat /app/provider/scripts/spark/offline_store_spark_runner.py | md5sum \
+    | awk '{print $1}' \
+    | xargs echo -n > /app/provider/scripts/spark/offline_store_spark_runner_md5.txt
+
 ENV PYTHON_LOCAL_INIT_PATH=$SPARK_PYTHON_PACKAGES
 
 # Setup Nginx

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -46,6 +46,15 @@ ENV PYTHON_INIT_PATH="/app/provider/scripts/spark/python_packages.sh"
 ENV MATERIALIZE_NO_TIMESTAMP_QUERY_PATH="/app/provider/queries/materialize_no_ts.sql"
 ENV MATERIALIZE_TIMESTAMP_QUERY_PATH="/app/provider/queries/materialize_ts.sql"
 
+COPY provider/scripts/spark/offline_store_spark_runner.py $SPARK_FILEPATH
+
+# Take the MD5 hash of the Spark runner script and store it in a file for use by the config package
+# when determining the remove filepath in cloud object storage (e.g. S3). By adding the hash as a suffix
+# to the file, we ensure that different versions of the script are uploaded to cloud object storage
+# without overwriting previous or future versions.
+RUN cat $SPARK_SCRIPT_PATH | md5sum \
+    | awk '{print $1}' \
+    | xargs echo -n > /app/provider/scripts/spark/offline_store_spark_runner_md5.txt
 
 EXPOSE 8080
 ENTRYPOINT ["./main"]

--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -85,6 +85,14 @@ ENV PYTHON_INIT_PATH="/app/provider/scripts/spark/python_packages.sh"
 ENV MATERIALIZE_NO_TIMESTAMP_QUERY_PATH="/app/provider/queries/materialize_no_ts.sql"
 ENV MATERIALIZE_TIMESTAMP_QUERY_PATH="/app/provider/queries/materialize_ts.sql"
 
+# Take the MD5 hash of the Spark runner script and store it in a file for use by the config package
+# when determining the remove filepath in cloud object storage (e.g. S3). By adding the hash as a suffix
+# to the file, we ensure that different versions of the script are uploaded to cloud object storage
+# without overwriting previous or future versions.
+RUN cat $SPARK_SCRIPT_PATH | md5sum \
+  | awk '{print $1}' \
+  | xargs echo -n > /app/provider/scripts/spark/offline_store_spark_runner_md5.txt
+
 ## Download Shaded Jar
 RUN wget https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop2-2.2.11/gcs-connector-hadoop2-2.2.11-shaded.jar -P /app/provider/scripts/spark/jars/
 

--- a/metadata/dashboard/Dockerfile
+++ b/metadata/dashboard/Dockerfile
@@ -47,7 +47,14 @@ COPY provider/scripts/spark/requirements.txt $SPARK_REQUIREMENTS
 COPY provider/queries/materialize_no_ts.sql $MATERIALIZE_NO_TIMESTAMP_QUERY_PATH
 COPY provider/queries/materialize_ts.sql $MATERIALIZE_TIMESTAMP_QUERY_PATH
 
-ENV SPARK_SCRIPT_PATH="/app/provider/scripts/spark/offline_store_spark_runner.py"
+# Take the MD5 hash of the Spark runner script and store it in a file for use by the config package
+# when determining the remove filepath in cloud object storage (e.g. S3). By adding the hash as a suffix
+# to the file, we ensure that different versions of the script are uploaded to cloud object storage
+# without overwriting previous or future versions.
+RUN cat $SPARK_FILEPATH | md5sum \
+    | awk '{print $1}' \
+    | xargs echo -n > /app/provider/scripts/spark/offline_store_spark_runner_md5.txt
+
 ENV PYTHON_INIT_PATH="/app/provider/scripts/spark/python_packages.sh"
 ENV MATERIALIZE_NO_TIMESTAMP_QUERY_PATH="/app/provider/queries/materialize_no_ts.sql"
 ENV MATERIALIZE_TIMESTAMP_QUERY_PATH="/app/provider/queries/materialize_ts.sql"

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -90,6 +90,14 @@ ENV PYTHON_INIT_PATH="/app/provider/scripts/spark/python_packages.sh"
 ENV MATERIALIZE_NO_TIMESTAMP_QUERY_PATH="/app/provider/queries/materialize_no_ts.sql"
 ENV MATERIALIZE_TIMESTAMP_QUERY_PATH="/app/provider/queries/materialize_ts.sql"
 
+# Take the MD5 hash of the Spark runner script and store it in a file for use by the config package
+# when determining the remove filepath in cloud object storage (e.g. S3). By adding the hash as a suffix
+# to the file, we ensure that different versions of the script are uploaded to cloud object storage
+# without overwriting previous or future versions.
+RUN cat $SPARK_SCRIPT_PATH | md5sum \
+  | awk '{print $1}' \
+  | xargs echo -n > /app/provider/scripts/spark/offline_store_spark_runner_md5.txt
+
 # Download Shaded Jar
 RUN wget https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop2-2.2.11/gcs-connector-hadoop2-2.2.11-shaded.jar -P /app/provider/scripts/spark/jars/
 

--- a/runner/Dockerfile.debug
+++ b/runner/Dockerfile.debug
@@ -12,6 +12,7 @@ COPY go.mod ./
 COPY go.sum ./
 #RUN go mod download
 
+COPY filestore/ ./filestore/
 COPY ./metadata/proto/metadata.proto ./metadata/proto/metadata.proto
 RUN apk update && apk add protobuf-dev && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest && go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 ENV PATH /go/bin:$PATH
@@ -88,6 +89,14 @@ ENV SPARK_SCRIPT_PATH="/app/provider/scripts/spark/offline_store_spark_runner.py
 ENV PYTHON_INIT_PATH="/app/provider/scripts/spark/python_packages.sh"
 ENV MATERIALIZE_NO_TIMESTAMP_QUERY_PATH="/app/provider/queries/materialize_no_ts.sql"
 ENV MATERIALIZE_TIMESTAMP_QUERY_PATH="/app/provider/queries/materialize_ts.sql"
+
+# Take the MD5 hash of the Spark runner script and store it in a file for use by the config package
+# when determining the remove filepath in cloud object storage (e.g. S3). By adding the hash as a suffix
+# to the file, we ensure that different versions of the script are uploaded to cloud object storage
+# without overwriting previous or future versions.
+RUN cat $SPARK_SCRIPT_PATH | md5sum \
+  | awk '{print $1}' \
+  | xargs echo -n > /app/provider/scripts/spark/offline_store_spark_runner_md5.txt
 
 # Download Shaded Jar
 RUN curl https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop2-2.2.11/gcs-connector-hadoop2-2.2.11-shaded.jar -P /app/provider/scripts/spark/jars/

--- a/serving/Dockerfile
+++ b/serving/Dockerfile
@@ -43,6 +43,14 @@ ENV PYTHON_INIT_PATH="/app/provider/scripts/spark/python_packages.sh"
 ENV MATERIALIZE_NO_TIMESTAMP_QUERY_PATH="/app/provider/queries/materialize_no_ts.sql"
 ENV MATERIALIZE_TIMESTAMP_QUERY_PATH="/app/provider/queries/materialize_ts.sql"
 
+# Take the MD5 hash of the Spark runner script and store it in a file for use by the config package
+# when determining the remove filepath in cloud object storage (e.g. S3). By adding the hash as a suffix
+# to the file, we ensure that different versions of the script are uploaded to cloud object storage
+# without overwriting previous or future versions.
+RUN cat $SPARK_SCRIPT_PATH | md5sum \
+    | awk '{print $1}' \
+    | xargs echo -n > /app/provider/scripts/spark/offline_store_spark_runner_md5.txt
+
 ENV SERVING_PORT "8080"
 EXPOSE 8080
 ENTRYPOINT ["./main"]


### PR DESCRIPTION
# Description

This PR ensures that newer/different versions of `offline_store_spark_runner.py` are uploaded to cloud object storage by writing the MD5 hash of the file in the container and adding this as a suffix to the filename that's uploaded.

## Type of change

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
