### PR TITLE
Helm Install-Upgrade ETCD fix. 

### DIFF
--- a/charts/featureform/templates/etcd-upgrade-configmap.yaml
+++ b/charts/featureform/templates/etcd-upgrade-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etcd-upgrade-configmap
+data:
+  DYNAMIC_IS_INSTALL:  {{ .Release.IsInstall | quote }}
+  DYNAMIC_IS_UPGRADE:  {{ .Release.IsUpgrade | quote }}
+  DYNAMIC_ETCD_INITIAL_CLUSTER_STATE:  {{ ternary "new" "existing" .Release.IsInstall | quote }}
+  ETCD_INITIAL_CLUSTER_STATE: {{ ternary "new" "existing" .Release.IsInstall | quote }} 

--- a/charts/featureform/templates/etcd-upgrade-configmap.yaml
+++ b/charts/featureform/templates/etcd-upgrade-configmap.yaml
@@ -3,7 +3,4 @@ kind: ConfigMap
 metadata:
   name: etcd-upgrade-configmap
 data:
-  DYNAMIC_IS_INSTALL:  {{ .Release.IsInstall | quote }}
-  DYNAMIC_IS_UPGRADE:  {{ .Release.IsUpgrade | quote }}
-  DYNAMIC_ETCD_INITIAL_CLUSTER_STATE:  {{ ternary "new" "existing" .Release.IsInstall | quote }}
   ETCD_INITIAL_CLUSTER_STATE: {{ ternary "new" "existing" .Release.IsInstall | quote }} 

--- a/charts/featureform/values.yaml
+++ b/charts/featureform/values.yaml
@@ -116,6 +116,9 @@ etcd:
     token:
       ttl: 100h
   replicaCount: 3
+  extraEnvVarsCM: etcd-upgrade-configmap
+  removeMemberOnContainerTermination: false
+
 
 meilisearch:
   fullnameOverride: featureform-search

--- a/dashboard/src/components/entitypage/elements/MetricsDropdown.js
+++ b/dashboard/src/components/entitypage/elements/MetricsDropdown.js
@@ -87,7 +87,7 @@ const queryFormats = {
       type: 'count',
     },
   },
-  'Training Set': {
+  TrainingSet: {
     Throughput: {
       query: function (name, variant, step) {
         return `rate(test_counter{feature="${name}",key="${variant}",status="training_row_serve"}[${step}])`;


### PR DESCRIPTION
# Description

This PR creates a configmap that dynamically sets the `ETCD_INITIAL_CLUSTER_STATE` env variable that is read by the ETCD statefulset This means we can skip needing to pass the value during helm upgrades.  

⚠️ **Important Note** ⚠️

When upgrading a cluster, we may want to keep the currently installed release values, while **_also including_** any new chart values/props that may have changed. 

First save the existing release values to a `.yaml` file. Then use the [-f flag](https://helm.sh/docs/helm/helm_upgrade/#helm-upgrade) with the filename in the upgrade command to port them to the new release. 

* helm get values featureform  -o yaml > ff.yaml 
* helm upgrade -f ff.yaml featureform ./charts/featureform --version x.y.z


closes [#526-ent](https://github.com/featureform/featureform-enterprise/issues/526)

`install / upgrade`
<img width="1306" alt="Screenshot 2023-12-14 at 4 19 44 PM" src="https://github.com/featureform/featureform/assets/34227093/ee7a3763-edc3-4d29-b26c-1c4da57be898">


`env check`
<img width="1187" alt="Screenshot 2023-12-13 at 8 56 58 PM" src="https://github.com/featureform/featureform/assets/34227093/949dab46-e205-409c-9113-67882b4943fb">


<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
