### PR TITLE
AWS Load Balancer Annotation

### DIFF
--- a/charts/featureform/values.yaml
+++ b/charts/featureform/values.yaml
@@ -135,3 +135,11 @@ loki-stack:
       enabled: false
   grafana:
     enabled: true
+
+# Ensure AWS Load Balancer idle timeout doesn't default to 60 seconds,
+# which cannot support longer running operations
+ingress-nginx:
+  controller:
+    service:
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"


### PR DESCRIPTION
# Description

This PR introduces an annotation that set an AWS load balancer created via EKS/`ingree-nginx` to its maximum idle timeout. Setting the timeout to the maximum ensures long-running operations (e.g. batch feature serving) don't error out due to the LB closing the stream.

## Type of change

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
