### PR TITLE
Splits execution error into 2 constructors to avoid empty args

### DIFF
--- a/fferr/data.go
+++ b/fferr/data.go
@@ -11,8 +11,8 @@ func NewDatasetNotFoundError(resourceName, resourceVariant string, err error) *D
 		err = fmt.Errorf("initial dataset not found error")
 	}
 	baseError := newBaseGRPCError(err, DATASET_NOT_FOUND, codes.NotFound)
-	baseError.AddDetail("Resource Name", resourceName)
-	baseError.AddDetail("Resource Variant", resourceVariant)
+	baseError.AddDetail("resource_name", resourceName)
+	baseError.AddDetail("resource_variant", resourceVariant)
 
 	return &DatasetNotFoundError{
 		baseError,
@@ -25,11 +25,11 @@ type DatasetNotFoundError struct {
 
 func NewDatasetAlreadyExistsError(resourceName, resourceVariant string, err error) *DatasetAlreadyExistsError {
 	if err == nil {
-		err = fmt.Errorf("initial dataset not found error")
+		err = fmt.Errorf("initial dataset already exists error")
 	}
 	baseError := newBaseGRPCError(err, DATASET_ALREADY_EXISTS, codes.AlreadyExists)
-	baseError.AddDetail("Resource Name", resourceName)
-	baseError.AddDetail("Resource Variant", resourceVariant)
+	baseError.AddDetail("resource_name", resourceName)
+	baseError.AddDetail("resource_variant", resourceVariant)
 
 	return &DatasetAlreadyExistsError{
 		baseError,
@@ -42,10 +42,10 @@ type DatasetAlreadyExistsError struct {
 
 func NewDataTypeNotFoundError(valueType string, err error) *DataTypeNotFoundError {
 	if err == nil {
-		err = fmt.Errorf("initial datatype already exists error")
+		err = fmt.Errorf("initial datatype not found error")
 	}
 	baseError := newBaseGRPCError(err, DATATYPE_NOT_FOUND, codes.NotFound)
-	baseError.AddDetail("Value Type", valueType)
+	baseError.AddDetail("value_type", valueType)
 
 	return &DataTypeNotFoundError{
 		baseError,
@@ -61,8 +61,8 @@ func NewTransformationNotFoundError(resourceName, resourceVariant string, err er
 		err = fmt.Errorf("initial transformation not found error")
 	}
 	baseError := newBaseGRPCError(err, TRANSFORMATION_NOT_FOUND, codes.NotFound)
-	baseError.AddDetail("Resource Name", resourceName)
-	baseError.AddDetail("Resource Variant", resourceVariant)
+	baseError.AddDetail("resource_name", resourceName)
+	baseError.AddDetail("resource_variant", resourceVariant)
 
 	return &TransformationNotFoundError{
 		baseError,
@@ -113,8 +113,8 @@ func NewTrainingSetNotFoundError(resourceName, resourceVariant string, err error
 		err = fmt.Errorf("initial training set not found error")
 	}
 	baseError := newBaseGRPCError(err, TRAINING_SET_NOT_FOUND, codes.NotFound)
-	baseError.AddDetail("Resource Name", resourceName)
-	baseError.AddDetail("Resource Variant", resourceVariant)
+	baseError.AddDetail("resource_name", resourceName)
+	baseError.AddDetail("resource_variant", resourceVariant)
 
 	return &TrainingSetNotFoundError{
 		baseError,
@@ -127,11 +127,11 @@ type TrainingSetNotFoundError struct {
 
 func NewInvalidResourceTypeError(resourceName, resourceVariant, resourceType string, err error) *InvalidResourceTypeError {
 	if err == nil {
-		err = fmt.Errorf("initial invalid resource type not found error")
+		err = fmt.Errorf("initial invalid resource type error")
 	}
 	baseError := newBaseGRPCError(err, INVALID_RESOURCE_TYPE, codes.InvalidArgument)
-	baseError.AddDetail("Resource Name", resourceName)
-	baseError.AddDetail("Resource Variant", resourceVariant)
+	baseError.AddDetail("resource_name", resourceName)
+	baseError.AddDetail("resource_variant", resourceVariant)
 	baseError.AddDetail("Resource Type", resourceType)
 
 	return &InvalidResourceTypeError{
@@ -145,11 +145,11 @@ type InvalidResourceTypeError struct {
 
 func NewInvalidResourceVariantNameError(resourceName, resourceVariant, resourceType string, err error) *InvalidResourceTypeError {
 	if err == nil {
-		err = fmt.Errorf("initial invalid resource variant name")
+		err = fmt.Errorf("initial invalid resource variant name error")
 	}
 	baseError := newBaseGRPCError(err, INVALID_RESOURCE_TYPE, codes.InvalidArgument)
-	baseError.AddDetail("Resource Name", resourceName)
-	baseError.AddDetail("Resource Variant", resourceVariant)
+	baseError.AddDetail("resource_name", resourceName)
+	baseError.AddDetail("resource_variant", resourceVariant)
 	baseError.AddDetail("Resource Type", resourceType)
 
 	return &InvalidResourceTypeError{
@@ -163,7 +163,7 @@ type InvalidResourceNameVariantError struct {
 
 func NewInvalidFileTypeError(extension string, err error) *InvalidFileTypeError {
 	if err == nil {
-		err = fmt.Errorf("initial invalid filetype name")
+		err = fmt.Errorf("initial invalid filetype name error")
 	}
 	baseError := newBaseGRPCError(err, INVALID_FILE_TYPE, codes.InvalidArgument)
 	baseError.AddDetail("Extension", extension)

--- a/fferr/errors.go
+++ b/fferr/errors.go
@@ -7,6 +7,8 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+type ResourceType string
+
 const (
 	// PROVIDERS:
 	EXECUTION_ERROR  = "Execution Error"
@@ -31,6 +33,20 @@ const (
 	RESOURCE_ALREADY_FAILED   = "Resource Already Failed"
 	RESOURCE_NOT_READY        = "Resource Not Ready"
 	RESOURCE_FAILED           = "Resource Failed"
+
+	// RESOURCE TYPES:
+	FEATURE              ResourceType = "FEATURE"
+	LABEL                ResourceType = "LABEL"
+	TRAINING_SET         ResourceType = "TRAINING_SET"
+	SOURCE               ResourceType = "SOURCE"
+	FEATURE_VARIANT      ResourceType = "FEATURE_VARIANT"
+	LABEL_VARIANT        ResourceType = "LABEL_VARIANT"
+	TRAINING_SET_VARIANT ResourceType = "TRAINING_SET_VARIANT"
+	SOURCE_VARIANT       ResourceType = "SOURCE_VARIANT"
+	PROVIDER             ResourceType = "PROVIDER"
+	ENTITY               ResourceType = "ENTITY"
+	MODEL                ResourceType = "MODEL"
+	USER                 ResourceType = "USER"
 )
 
 type JSONStackTrace map[string]interface{}

--- a/fferr/generic.go
+++ b/fferr/generic.go
@@ -2,6 +2,7 @@ package fferr
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rotisserie/eris"
 )
@@ -43,5 +44,7 @@ func (e *GenericError) Details() map[string]string {
 }
 
 func (e *GenericError) AddDetail(key, value string) {
+	key = strings.ReplaceAll(key, " ", "_")
+	key = strings.ToLower(key)
 	e.details[key] = value
 }

--- a/fferr/jobs.go
+++ b/fferr/jobs.go
@@ -11,7 +11,7 @@ func NewJobDoesNotExistError(key string, err error) *JobDoesNotExistError {
 		err = fmt.Errorf("initial job does not exist error")
 	}
 	baseError := newBaseGRPCError(err, JOB_DOES_NOT_EXIST, codes.NotFound)
-	baseError.AddDetail("Key", key)
+	baseError.AddDetail("key", key)
 
 	return &JobDoesNotExistError{
 		baseError,
@@ -27,9 +27,9 @@ func NewResourceAlreadyCompleteError(resourceName, resourceVariant, resourceType
 		err = fmt.Errorf("initial resource already complete error")
 	}
 	baseError := newBaseGRPCError(err, RESOURCE_ALREADY_COMPLETE, codes.Internal)
-	baseError.AddDetail("Resource Name", resourceName)
-	baseError.AddDetail("Resource Variant", resourceVariant)
-	baseError.AddDetail("Resource Type", resourceType)
+	baseError.AddDetail("resource_name", resourceName)
+	baseError.AddDetail("resource_variant", resourceVariant)
+	baseError.AddDetail("resource_type", resourceType)
 
 	return &ResourceAlreadyCompleteError{
 		baseError,
@@ -45,9 +45,9 @@ func NewResourceAlreadyFailedError(resourceName, resourceVariant, resourceType s
 		err = fmt.Errorf("initial resource already failed error")
 	}
 	baseError := newBaseGRPCError(err, RESOURCE_ALREADY_FAILED, codes.Internal)
-	baseError.AddDetail("Resource Name", resourceName)
-	baseError.AddDetail("Resource Variant", resourceVariant)
-	baseError.AddDetail("Resource Type", resourceType)
+	baseError.AddDetail("resource_name", resourceName)
+	baseError.AddDetail("resource_variant", resourceVariant)
+	baseError.AddDetail("resource_type", resourceType)
 
 	return &ResourceAlreadyFailedError{
 		baseError,
@@ -63,9 +63,9 @@ func NewResourceNotReadyError(resourceName, resourceVariant, resourceType string
 		err = fmt.Errorf("initial resource not ready error")
 	}
 	baseError := newBaseGRPCError(err, RESOURCE_NOT_READY, codes.Internal)
-	baseError.AddDetail("Resource Name", resourceName)
-	baseError.AddDetail("Resource Variant", resourceVariant)
-	baseError.AddDetail("Resource Type", resourceType)
+	baseError.AddDetail("resource_name", resourceName)
+	baseError.AddDetail("resource_variant", resourceVariant)
+	baseError.AddDetail("resource_type", resourceType)
 
 	return &ResourceNotReadyError{
 		baseError,
@@ -81,9 +81,9 @@ func NewResourceFailedError(resourceName, resourceVariant, resourceType string, 
 		err = fmt.Errorf("initial resource failed error")
 	}
 	baseError := newBaseGRPCError(err, RESOURCE_FAILED, codes.Internal)
-	baseError.AddDetail("Resource Name", resourceName)
-	baseError.AddDetail("Resource Variant", resourceVariant)
-	baseError.AddDetail("Resource Type", resourceType)
+	baseError.AddDetail("resource_name", resourceName)
+	baseError.AddDetail("resource_variant", resourceVariant)
+	baseError.AddDetail("resource_type", resourceType)
 
 	return &ResourceFailedError{
 		baseError,

--- a/fferr/providers.go
+++ b/fferr/providers.go
@@ -11,7 +11,7 @@ func NewConnectionError(providerName string, err error) *ConnectionError {
 		err = fmt.Errorf("initial connection error")
 	}
 	baseError := newBaseGRPCError(err, CONNECTION_ERROR, codes.Internal)
-	baseError.AddDetail("Provider", providerName)
+	baseError.AddDetail("provider", providerName)
 
 	return &ConnectionError{
 		baseError,
@@ -22,14 +22,27 @@ type ConnectionError struct {
 	baseGRPCError
 }
 
-func NewExecutionError(providerName, resourceName, resourceVariant, resourceType string, err error) *ExecutionError {
+func NewExecutionError(providerName string, err error) *ExecutionError {
 	if err == nil {
 		err = fmt.Errorf("initial execution error")
 	}
 	baseError := newBaseGRPCError(err, EXECUTION_ERROR, codes.Internal)
-	baseError.AddDetail("Provider", providerName)
-	baseError.AddDetail("Resource Name", resourceName)
-	baseError.AddDetail("Resource Variant", resourceVariant)
+	baseError.AddDetail("provider", providerName)
+
+	return &ExecutionError{
+		baseError,
+	}
+}
+
+func NewResourceExecutionError(providerName, resourceName, resourceVariant string, resourceType ResourceType, err error) *ExecutionError {
+	if err == nil {
+		err = fmt.Errorf("initial execution error")
+	}
+	baseError := newBaseGRPCError(err, EXECUTION_ERROR, codes.Internal)
+	baseError.AddDetail("provider", providerName)
+	baseError.AddDetail("resource_name", resourceName)
+	baseError.AddDetail("resource_variant", resourceVariant)
+	baseError.AddDetail("resource_type", string(resourceType))
 
 	return &ExecutionError{
 		baseError,
@@ -45,7 +58,7 @@ func NewProviderConfigError(providerName string, err error) *ProviderConfigError
 		err = fmt.Errorf("initial provider error")
 	}
 	baseError := newBaseGRPCError(err, EXECUTION_ERROR, codes.Internal)
-	baseError.AddDetail("Provider", providerName)
+	baseError.AddDetail("provider", providerName)
 
 	return &ProviderConfigError{
 		baseError,

--- a/provider/mysql.go
+++ b/provider/mysql.go
@@ -32,7 +32,7 @@ func mySqlOfflineStoreFactory(config pc.SerializedConfig) (Provider, error) {
 	queries.setVariableBinding(MySQLBindingStyle)
 	sgConfig := SQLOfflineStoreConfig{
 		Config:       config,
-		Driver:       "mysql",
+		Driver:       pt.MySqlOffline.String(),
 		ProviderType: pt.MySqlOffline,
 		QueryImpl:    &queries,
 	}
@@ -71,8 +71,13 @@ func (q mySQLQueries) registerResources(db *sql.DB, tableName string, schema Res
 		return fferr.NewInternalError(err)
 	}
 	defer query.Close()
-	_, err = query.Exec(tableName, schema.Entity, schema.Value, schema.TS, schema.SourceTable)
-	return fferr.NewExecutionError("mysql", tableName, "", "entity", err)
+	if _, err = query.Exec(tableName, schema.Entity, schema.Value, schema.TS, schema.SourceTable); err != nil {
+		wrapped := fferr.NewExecutionError(pt.MySqlOffline.String(), err)
+		wrapped.AddDetail("table_name", tableName)
+		wrapped.AddDetail("entity", schema.Entity)
+		return wrapped
+	}
+	return nil
 }
 
 func (q mySQLQueries) primaryTableRegister(tableName string, sourceName string) string {
@@ -87,8 +92,13 @@ func (q mySQLQueries) materializationCreate(tableName string, sourceName string)
 
 func (q mySQLQueries) materializationUpdate(db *sql.DB, tableName string, sourceName string) error {
 	query := `DROP VIEW IF EXISTS ?;` + q.primaryTableCreate(tableName, sourceName)
-	_, err := db.Exec(query, tableName)
-	return fferr.NewExecutionError("mysql", tableName, "", "materialization", err)
+	if _, err := db.Exec(query, tableName); err != nil {
+		wrapped := fferr.NewExecutionError(pt.MySqlOffline.String(), err)
+		wrapped.AddDetail("table_name", tableName)
+		wrapped.AddDetail("source_name", sourceName)
+		return wrapped
+	}
+	return nil
 }
 
 func (q mySQLQueries) materializationExists() string {
@@ -167,7 +177,11 @@ func (q mySQLQueries) trainingSetQuery(store *sqlOfflineStore, def TrainingSetDe
 	} else {
 		fullQuery := fmt.Sprintf("CREATE TABLE %s AS (SELECT %s, l.value as label FROM %s ", sanitize(tableName), columnStr, query)
 		if _, err := store.db.Exec(fullQuery); err != nil {
-			return err
+			wrapped := fferr.NewExecutionError(pt.MySqlOffline.String(), err)
+			wrapped.AddDetail("table_name", tableName)
+			wrapped.AddDetail("training_set_name", def.ID.Name)
+			wrapped.AddDetail("training_set_variant", def.ID.Variant)
+			return wrapped
 		}
 	}
 	return nil
@@ -214,7 +228,11 @@ func (q mySQLQueries) getValueColumnType(t *sql.ColumnType) interface{} {
 }
 
 func (q mySQLQueries) numRows(n interface{}) (int64, error) {
-	return n.(int64), nil
+	num, ok := n.(int64)
+	if !ok {
+		return 0, fferr.NewInternalError(fmt.Errorf("could not convert %T to int64", n))
+	}
+	return num, nil
 }
 
 func (q mySQLQueries) transformationCreate(name string, query string) []string {
@@ -236,14 +254,18 @@ func (q mySQLQueries) transformationExists() string {
 func (q mySQLQueries) getColumns(db *sql.DB, tableName string) ([]TableColumn, error) {
 	rows, err := db.Query("SELECT column_name FROM information_schema.columns WHERE table_name = ?", tableName)
 	if err != nil {
-		return nil, err
+		wrapped := fferr.NewExecutionError(pt.MySqlOffline.String(), err)
+		wrapped.AddDetail("table_name", tableName)
+		return nil, wrapped
 	}
 	defer rows.Close()
 	columnNames := make([]TableColumn, 0)
 	for rows.Next() {
 		var column string
 		if err := rows.Scan(&column); err != nil {
-			return nil, err
+			wrapped := fferr.NewExecutionError(pt.MySqlOffline.String(), err)
+			wrapped.AddDetail("table_name", tableName)
+			return nil, wrapped
 		}
 		columnNames = append(columnNames, TableColumn{Name: column})
 	}

--- a/provider/spark.go
+++ b/provider/spark.go
@@ -510,7 +510,12 @@ func (db *DatabricksExecutor) RunSparkJob(args []string, store SparkFileStore) e
 		},
 	})
 	if err != nil {
-		return fferr.NewExecutionError("Databricks", "", "", "", err)
+		wrapped := fferr.NewExecutionError(pt.SparkOffline.String(), err)
+		wrapped.AddDetail("job_name", fmt.Sprintf("featureform-job-%s", id))
+		wrapped.AddDetail("job_id", fmt.Sprint(jobToRun.JobId))
+		wrapped.AddDetail("executor_type", "Databricks")
+		wrapped.AddDetail("store_type", store.Type())
+		return wrapped
 	}
 
 	// Making the timeout a week because we don't want to timeout on long-running jobs
@@ -526,8 +531,12 @@ func (db *DatabricksExecutor) RunSparkJob(args []string, store SparkFileStore) e
 				fmt.Printf("the '%v' job failed, could not get error message: %v\n", jobToRun.JobId, err)
 			}
 		}
-
-		return fferr.NewExecutionError("Databricks", "", "", "", fmt.Errorf("the '%v' job failed: %v", jobToRun.JobId, errorMessage))
+		wrapped := fferr.NewExecutionError(pt.SparkOffline.String(), fmt.Errorf("job failed: %v", errorMessage))
+		wrapped.AddDetail("job_name", fmt.Sprintf("featureform-job-%s", id))
+		wrapped.AddDetail("job_id", fmt.Sprint(jobToRun.JobId))
+		wrapped.AddDetail("executor_type", "Databricks")
+		wrapped.AddDetail("store_type", store.Type())
+		return wrapped
 	}
 
 	return nil
@@ -542,11 +551,17 @@ func (db *DatabricksExecutor) getErrorMessage(jobId int64) (error, error) {
 
 	runs, err := db.client.Jobs.ListRunsAll(ctx, runRequest)
 	if err != nil {
-		return nil, fferr.NewExecutionError(string(pt.SparkOffline), "", "", "", fmt.Errorf("could not get runs for Databricks job ID %v: %v", jobId, err))
+		wrapped := fferr.NewExecutionError(pt.SparkOffline.String(), fmt.Errorf("could not get runs for job: %v", err))
+		wrapped.AddDetail("job_id", fmt.Sprint(jobId))
+		wrapped.AddDetail("executor_type", "Databricks")
+		return nil, wrapped
 	}
 
 	if len(runs) == 0 {
-		return nil, fferr.NewInternalError(fmt.Errorf("no runs found for Databricks job ID: %v", jobId))
+		wrapped := fferr.NewInternalError(fmt.Errorf("no runs found for job"))
+		wrapped.AddDetail("job_id", fmt.Sprint(jobId))
+		wrapped.AddDetail("executor_type", "Databricks")
+		return nil, wrapped
 	}
 	runID := runs[0].RunId
 	request := jobs.GetRunRequest{
@@ -563,7 +578,10 @@ func (db *DatabricksExecutor) getErrorMessage(jobId int64) (error, error) {
 	path := "/api/2.0/jobs/runs/get-output"
 	err = db.errorMessageClient.Do(ctx, http.MethodGet, path, request, &runOutput)
 	if err != nil {
-		return nil, fferr.NewExecutionError(string(pt.SparkOffline), "", "", "", fmt.Errorf("could not get run output for Databricks job ID %v: %v", jobId, err))
+		wrapped := fferr.NewExecutionError(pt.SparkOffline.String(), fmt.Errorf("could not get run output for job: %v", err))
+		wrapped.AddDetail("job_id", fmt.Sprint(jobId))
+		wrapped.AddDetail("executor_type", "Databricks")
+		return nil, wrapped
 	}
 
 	return fmt.Errorf("%s", runOutput.Error), nil
@@ -1017,12 +1035,20 @@ func (s *SparkGenericExecutor) RunSparkJob(args []string, store SparkFileStore) 
 
 	err := cmd.Start()
 	if err != nil {
-		return fferr.NewExecutionError("Spark", "", "", "", fmt.Errorf("could not run spark job: %v", err))
+		wrapped := fferr.NewExecutionError(pt.SparkOffline.String(), fmt.Errorf("could not run spark job: %v", err))
+		wrapped.AddDetail("executor_type", "Spark Generic")
+		wrapped.AddDetail("store_type", store.Type())
+		return wrapped
 	}
 
 	err = cmd.Wait()
 	if err != nil {
-		return fferr.NewExecutionError("Spark", "", "", "", fmt.Errorf("spark job failed: %v : stdout %s : stderr %s", err, outb.String(), errb.String()))
+		wrapped := fferr.NewExecutionError(pt.SparkOffline.String(), fmt.Errorf("spark job failed: %v", err))
+		wrapped.AddDetail("executor_type", "Spark Generic")
+		wrapped.AddDetail("store_type", store.Type())
+		wrapped.AddDetail("stdout", outb.String())
+		wrapped.AddDetail("stderr", errb.String())
+		return wrapped
 	}
 
 	return nil
@@ -1212,18 +1238,24 @@ func (e *EMRExecutor) RunSparkJob(args []string, store SparkFileStore) error {
 			e.logger.Infof("could not get error message for EMR step '%s': %s", stepId, getErr)
 		}
 		if errorMessage != "" {
-			return fferr.NewExecutionError("EMR", "", "", "", fmt.Errorf("the EMR step '%s' failed: %s", stepId, errorMessage))
+			wrapped := fferr.NewExecutionError(pt.SparkOffline.String(), fmt.Errorf("step failed: %s", errorMessage))
+			wrapped.AddDetail("executor_type", "EMR")
+			wrapped.AddDetail("store_type", store.Type())
+			return wrapped
 		}
 
 		e.logger.Errorf("Failure waiting for completion of EMR cluster: %s", err)
-		return fferr.NewExecutionError("EMR", "", "", "", fmt.Errorf("failure waiting for completion of EMR cluster: %s", err))
+		wrapped := fferr.NewExecutionError(pt.SparkOffline.String(), fmt.Errorf("failure waiting for completion of cluster: %w", err))
+		wrapped.AddDetail("executor_type", "EMR")
+		wrapped.AddDetail("store_type", store.Type())
+		return wrapped
 	}
 	return nil
 }
 
 func (e *EMRExecutor) getStepErrorMessage(clusterId string, stepId string) (string, error) {
 	if e.logFileStore == nil {
-		return "", fmt.Errorf("cannot get error message for EMR step '%s' because the log file store is not set", stepId)
+		return "", fferr.NewInternalError(fmt.Errorf("cannot get error message for EMR step '%s' because the log file store is not set", stepId))
 	}
 
 	stepResults, err := e.client.DescribeStep(context.TODO(), &emr.DescribeStepInput{
@@ -1231,7 +1263,11 @@ func (e *EMRExecutor) getStepErrorMessage(clusterId string, stepId string) (stri
 		StepId:    aws.String(stepId),
 	})
 	if err != nil {
-		return "", fferr.NewExecutionError("EMR", "", "", "", fmt.Errorf("could not get information on EMR step '%s'", stepId))
+		wrapped := fferr.NewExecutionError(pt.SparkOffline.String(), fmt.Errorf("could not get information on step: %w", err))
+		wrapped.AddDetail("executor_type", "EMR")
+		wrapped.AddDetail("cluster_id", clusterId)
+		wrapped.AddDetail("step_id", stepId)
+		return "", wrapped
 	}
 
 	if stepResults.Step.Status.State == "FAILED" {
@@ -1250,7 +1286,12 @@ func (e *EMRExecutor) getStepErrorMessage(clusterId string, stepId string) (stri
 
 			errorMessage, err := e.getLogFileMessage(logFile)
 			if err != nil {
-				return "", fferr.NewExecutionError("EMR", "", "", "", fmt.Errorf("could not get error message from log file '%s': %v", logFile, err))
+				wrapped := fferr.NewExecutionError(pt.SparkOffline.String(), fmt.Errorf("could not get error message from log file: %v", err))
+				wrapped.AddDetail("executor_type", "EMR")
+				wrapped.AddDetail("cluster_id", clusterId)
+				wrapped.AddDetail("step_id", stepId)
+				wrapped.AddDetail("log_file", logFile)
+				return "", wrapped
 			}
 
 			return errorMessage, nil


### PR DESCRIPTION
# Description

Splits execution error into 2 constructors to avoid empty args.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
