### PR TITLE
Fix banner reload issue

### DIFF
--- a/dashboard/src/components/topbar/TopBar.js
+++ b/dashboard/src/components/topbar/TopBar.js
@@ -91,7 +91,11 @@ export default function TopBar({ api }) {
 
   return (
     <div className={classes.root}>
-      <AppBar position='absolute' className={classes.appbar}>
+      <AppBar
+        position='absolute'
+        className={classes.appbar}
+        style={{ backgroundColor: '#FC195C' }}
+      >
         <Toolbar className={classes.toolbar}>
           <div className={classes.title}>
             <Box


### PR DESCRIPTION
# Description

Directly sets the styling on the top bar banner. `makeStyles` seems to load slower than the component's original styling, so setting directly to fix for now. 

closes #1299 

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
