### PR TITLE
Source Modal Null Rows Fix

### DIFF
--- a/dashboard/src/components/dialog/SourceDialog.js
+++ b/dashboard/src/components/dialog/SourceDialog.js
@@ -33,8 +33,8 @@ export default function SourceDialog({
       } else if (type === 'Feature') {
         response = await api.fetchFeatureFileStats(sourceName, sourceVariant);
       }
-      if (response?.columns && response?.rows) {
-        if (type === 'Feature') {
+      if (response?.columns) {
+        if (type === 'Feature' && 'rows' in response) {
           let skipList = [];
           response.columns?.map((col, index) => {
             if (
@@ -49,9 +49,9 @@ export default function SourceDialog({
           });
           setSkipIndexList(skipList);
         }
-        setColumns(response.columns);
-        setRowList(response.rows);
-        setStats(response.stats);
+        setColumns(response.columns ?? []);
+        setRowList(response.rows ?? []);
+        setStats(response.stats ?? []);
       } else {
         setError(response);
       }

--- a/dashboard/src/components/dialog/sourceDialog.test.js
+++ b/dashboard/src/components/dialog/sourceDialog.test.js
@@ -54,6 +54,14 @@ describe('Source Table Dialog Tests', () => {
     }),
   };
 
+  const apiNullMock = {
+    fetchFeatureFileStats: jest.fn().mockResolvedValue({
+      columns: ['Column 1', 'Column 2'],
+      rows: null,
+      stats: null,
+    }),
+  };
+
   const apiErrorMock = {
     fetchSourceModalData: jest.fn().mockResolvedValue(ERROR_MSG),
   };
@@ -94,6 +102,36 @@ describe('Source Table Dialog Tests', () => {
       `${DEFAULT_NAME.toUpperCase()} - ${DEFAULT_VARIANT}`
     );
     expect(foundName.nodeName).toBe(H2_NODE);
+  });
+
+  test('Dialog renders OK with null row responses', async () => {
+    //given:
+    const { testBody, apiParam, name } = getTestBody(
+      apiNullMock,
+      DEFAULT_NAME,
+      DEFAULT_VARIANT,
+      'Feature'
+    );
+    const helper = render(testBody);
+
+    //when: the user clicks open
+    fireEvent.click(helper.getByTestId(OPEN_BTN_ID));
+    const foundName = await helper.findByTestId(TITLE_ID);
+    const foundColumn1 = helper.getByText('Column 1');
+    const foundColumn2 = helper.getByText('Column 2');
+
+    //then:
+    expect(apiParam.fetchFeatureFileStats).toHaveBeenCalledTimes(1);
+    expect(apiParam.fetchFeatureFileStats).toHaveBeenCalledWith(
+      name,
+      DEFAULT_VARIANT
+    );
+    expect(foundName.textContent).toBe(
+      `${DEFAULT_NAME.toUpperCase()} - ${DEFAULT_VARIANT}`
+    );
+    expect(foundName.nodeName).toBe(H2_NODE);
+    expect(foundColumn1.nodeName).toBe(TH_NODE);
+    expect(foundColumn2.nodeName).toBe(TH_NODE);
   });
 
   test('The dialog table renders all available columns', async () => {


### PR DESCRIPTION
# Description

This PR fixes an issue where the dashboard crashes if the source modal response `rows` property is `null`

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
