### PR TITLE
`get_dynamodb` method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ client/src/featureform/proto/
 .ipynb_checkpoints
 iris.csv
 provider/scripts/spark/tests/test_files/output
-**/grpc_debug.log
 
 # End to End Tests ouput
 tests/end_to_end/feature.txt 

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ client/src/featureform/proto/
 .ipynb_checkpoints
 iris.csv
 provider/scripts/spark/tests/test_files/output
+**/grpc_debug.log
 
 # End to End Tests ouput
 tests/end_to_end/feature.txt 

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -51,7 +51,6 @@ from .resources import (
     SourceVariant,
     PrimaryData,
     SQLTable,
-    Directory,
     SQLTransformation,
     DFTransformation,
     Entity,
@@ -1698,6 +1697,36 @@ class Registrar:
             redis (OnlineProvider): Provider
         """
         mock_config = RedisConfig(host="", port=123, password="", db=123)
+        mock_provider = Provider(
+            name=name, function="ONLINE", description="", team="", config=mock_config
+        )
+        return OnlineProvider(self, mock_provider)
+
+    def get_dynamodb(self, name: str):
+        """Get a DynamoDB provider. The returned object can be used as an inference store in feature registration.
+
+        **Examples**:
+        ``` py
+        dynamodb = ff.get_dynamodb("dynamodb-quickstart")
+
+        @ff.entity
+        class User:
+            avg_transactions = ff.Feature(
+                average_user_transaction[["user_id", "avg_transaction_amt"]],
+                type=ff.Float32,
+                inference_store=dynamodb,
+            )
+        ```
+
+        Args:
+            name (str): Name of DynamoDB provider to be retrieved
+
+        Returns:
+            dynamodb (OnlineProvider): Provider
+        """
+        mock_config = DynamodbConfig(
+            region="", access_key="", secret_key="", should_import_from_s3=False
+        )
         mock_provider = Provider(
             name=name, function="ONLINE", description="", team="", config=mock_config
         )
@@ -5473,6 +5502,7 @@ get_entity = global_registrar.get_entity
 get_source = global_registrar.get_source
 get_redis = global_registrar.get_redis
 get_postgres = global_registrar.get_postgres
+get_dynamodb = global_registrar.get_dynamodb
 get_mongodb = global_registrar.get_mongodb
 get_snowflake = global_registrar.get_snowflake
 get_snowflake_legacy = global_registrar.get_snowflake_legacy

--- a/docs/inference-online-stores/dynamodb.mdx
+++ b/docs/inference-online-stores/dynamodb.mdx
@@ -23,7 +23,8 @@ ff.register_dynamodb(
     name = "dynamodb",
     description = "Example inference store",
     team = "Featureform",
-    credentials = aws_creds
+    credentials = aws_creds,
+    region="us-east-1",
 )
 ```
 
@@ -52,6 +53,7 @@ ff.register_dynamodb(
     description = "Example inference store",
     team = "Featureform",
     credentials = aws_creds,
+    region="us-east-1",
     should_import_from_s3 = True # Feature tables in DynamoDB will be created via S3 import
 )
 ```


### PR DESCRIPTION
# Description

This PR adds the `get_dynamodb` method to the Python client for fetching previously registered DynamoDB providers.

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
