### PR TITLE
Bugfix: Adds variant to materialization IDs for SQL providers

### DIFF
--- a/provider/bigquery.go
+++ b/provider/bigquery.go
@@ -1031,7 +1031,7 @@ func (store *bqOfflineStore) CreateMaterialization(id ResourceID, options ...Mat
 		return nil, fmt.Errorf("get resource table: %v", err)
 	}
 
-	matID := MaterializationID(id.Name)
+	matID := MaterializationID(fmt.Sprintf("%s__%s", id.Name, id.Variant))
 	matTableName := store.getMaterializationTableName(matID)
 	materializeQry := store.query.materializationCreate(matTableName, resTable.name)
 
@@ -1098,7 +1098,7 @@ func (store *bqOfflineStore) GetMaterialization(id MaterializationID) (Materiali
 }
 
 func (store *bqOfflineStore) UpdateMaterialization(id ResourceID) (Materialization, error) {
-	matID := MaterializationID(id.Name)
+	matID := MaterializationID(fmt.Sprintf("%s__%s", id.Name, id.Variant))
 	tableName := store.getMaterializationTableName(matID)
 	getMatQry := store.query.materializationExists(tableName)
 	resTable, err := store.getbqResourceTable(id)

--- a/provider/sql.go
+++ b/provider/sql.go
@@ -596,7 +596,7 @@ func (it *sqlBatchFeatureIterator) Close() error {
 }
 
 // Takes a list of feature resource IDs and creates a table view joining all the feature values based on the entity
-// Note: This table view doesnt store timestamps
+// Note: This table view doesn't store timestamps
 func (store *sqlOfflineStore) GetBatchFeatures(ids []ResourceID) (BatchFeatureIterator, error) {
 
 	// if tables is empty, return an empty iterator
@@ -610,9 +610,9 @@ func (store *sqlOfflineStore) GetBatchFeatures(ids []ResourceID) (BatchFeatureIt
 	featureColumns := ""
 	var matIDs []string
 
-	tableName0 := sanitize(store.getMaterializationTableName(MaterializationID(ids[0].Name)))
+	tableName0 := sanitize(store.getMaterializationTableName(MaterializationID(fmt.Sprintf("%s__%s", ids[0].Name, ids[0].Variant))))
 	for i, tableID := range ids {
-		matID := MaterializationID(tableID.Name)
+		matID := MaterializationID(fmt.Sprintf("%s__%s", tableID.Name, tableID.Variant))
 		matIDs = append(matIDs, string(matID))
 		matTableName := sanitize(store.getMaterializationTableName(matID))
 
@@ -678,7 +678,7 @@ func (store *sqlOfflineStore) CreateMaterialization(id ResourceID, options ...Ma
 		return nil, err
 	}
 
-	matID := MaterializationID(id.Name)
+	matID := MaterializationID(fmt.Sprintf("%s__%s", id.Name, id.Variant))
 	matTableName := store.getMaterializationTableName(matID)
 	materializeQueries := store.query.materializationCreate(matTableName, resTable.name)
 	for _, materializeQry := range materializeQueries {
@@ -723,7 +723,7 @@ func (store *sqlOfflineStore) GetMaterialization(id MaterializationID) (Material
 }
 
 func (store *sqlOfflineStore) UpdateMaterialization(id ResourceID) (Materialization, error) {
-	matID := MaterializationID(id.Name)
+	matID := MaterializationID(fmt.Sprintf("%s__%s", id.Name, id.Variant))
 	tableName := store.getMaterializationTableName(matID)
 	getMatQry := store.query.materializationExists()
 	resTable, err := store.getsqlResourceTable(id)


### PR DESCRIPTION
# Description

This PR introduces the use the variant in creating materialization IDs to avoid having a feature with the same name fail due to a previously registered feature.

## Type of change

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
