### PR TITLE
Removes "coming soon" in streaming documentation

### DIFF
--- a/docs/getting-started/transforming-data.mdx
+++ b/docs/getting-started/transforming-data.mdx
@@ -35,7 +35,7 @@ titanic = postgres.register_table(
 
 ### Streams
 
-Streaming support coming soon in Enterprise Featureform. [Book a call with us today!](https://calendly.com/d/y5h-jpf-gj7/featureform-intro-call)
+Streaming support in Enterprise Featureform. [Book a call with us today!](https://calendly.com/d/y5h-jpf-gj7/featureform-intro-call)
 
 ## Defining transformations
 


### PR DESCRIPTION
# Description

Removes "coming soon" in streaming documentation.

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
