### PR TITLE
Adds `coalesce(1)` when writing feature stats file

### DIFF
--- a/metadata/dashboard/dashboard_metadata.go
+++ b/metadata/dashboard/dashboard_metadata.go
@@ -1173,7 +1173,7 @@ func (m *MetadataServer) GetFeatureFileStats(c *gin.Context) {
 		return
 	}
 
-	filepath, err := FindFileWithPrefix(statsFiles, "part-00003")
+	filepath, err := FindFileWithPrefix(statsFiles, "part-00000")
 	if err != nil {
 		fetchError := &FetchError{StatusCode: 500, Type: "Could not find the stats file"}
 		m.logger.Errorw(fetchError.Error(), "error", err.Error())

--- a/provider/scripts/spark/offline_store_spark_runner.py
+++ b/provider/scripts/spark/offline_store_spark_runner.py
@@ -378,7 +378,7 @@ def execute_sql_query(
             try:
                 stats_directory = f"{output_uri.rstrip('/')}/stats"
                 stats_df = display_data_metrics(output_dataframe, spark)
-                stats_df.write.json(stats_directory, mode="overwrite")
+                stats_df.coalesce(1).write.json(stats_directory, mode="overwrite")
             except Exception as e:
                 print(e)
                 print("Failed to display data metrics")


### PR DESCRIPTION
# Description

This PR adds `coalesce(1)` when writing feature stats file to ensure consistency when reading the JSON stats for features.

## Type of change

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
