### PR TITLE
Move Common Metadata logic to a common package

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	cm "github.com/featureform/helpers/resource"
 	"io"
 	"net"
 	"net/http"
@@ -725,7 +726,7 @@ func (serv *MetadataServer) CreateLabelVariant(ctx context.Context, label *pb.La
 	serv.Logger.Infow("Creating Label Variant", "name", label.Name, "variant", label.Variant)
 	protoSource := label.Source
 	serv.Logger.Debugw("Finding label source", "name", protoSource.Name, "variant", protoSource.Variant)
-	source, err := serv.client.GetSourceVariant(ctx, metadata.NameVariant{protoSource.Name, protoSource.Variant})
+	source, err := serv.client.GetSourceVariant(ctx, cm.NameVariant{protoSource.Name, protoSource.Variant})
 	if err != nil {
 		serv.Logger.Errorw("Could not create label source variant", "error", err)
 		return nil, err
@@ -742,12 +743,12 @@ func (serv *MetadataServer) CreateLabelVariant(ctx context.Context, label *pb.La
 func (serv *MetadataServer) CreateTrainingSetVariant(ctx context.Context, train *pb.TrainingSetVariant) (*pb.Empty, error) {
 	serv.Logger.Infow("Creating Training Set Variant", "name", train.Name, "variant", train.Variant)
 	protoLabel := train.Label
-	label, err := serv.client.GetLabelVariant(ctx, metadata.NameVariant{protoLabel.Name, protoLabel.Variant})
+	label, err := serv.client.GetLabelVariant(ctx, cm.NameVariant{protoLabel.Name, protoLabel.Variant})
 	if err != nil {
 		return nil, err
 	}
 	for _, protoFeature := range train.Features {
-		_, err := serv.client.GetFeatureVariant(ctx, metadata.NameVariant{protoFeature.Name, protoFeature.Variant})
+		_, err := serv.client.GetFeatureVariant(ctx, cm.NameVariant{protoFeature.Name, protoFeature.Variant})
 		if err != nil {
 			return nil, err
 		}

--- a/coordinator/errors.go
+++ b/coordinator/errors.go
@@ -2,7 +2,7 @@ package coordinator
 
 import (
 	"fmt"
-	"github.com/featureform/metadata"
+	cm "github.com/featureform/helpers/resource"
 )
 
 type JobDoesNotExistError struct {
@@ -14,7 +14,7 @@ func (m JobDoesNotExistError) Error() string {
 }
 
 type ResourceAlreadyCompleteError struct {
-	resourceID metadata.ResourceID
+	resourceID cm.ResourceID
 }
 
 func (m ResourceAlreadyCompleteError) Error() string {
@@ -22,7 +22,7 @@ func (m ResourceAlreadyCompleteError) Error() string {
 }
 
 type ResourceAlreadyFailedError struct {
-	resourceID metadata.ResourceID
+	resourceID cm.ResourceID
 }
 
 func (m ResourceAlreadyFailedError) Error() string {

--- a/coordinator/scheduletest/main.go
+++ b/coordinator/scheduletest/main.go
@@ -168,8 +168,8 @@ func testScheduleTrainingSet() error {
 	tsName := createSafeUUID()
 	originalTableName := createSafeUUID()
 	sourceName := createSafeUUID()
-	tsID := metadata.ResourceID{Name: tsName, Variant: "", Type: metadata.TRAINING_SET_VARIANT}
-	sourceID := metadata.ResourceID{Name: sourceName, Variant: "", Type: metadata.SOURCE_VARIANT}
+	tsID := cm.ResourceID{Name: tsName, Variant: "", Type: metadata.TRAINING_SET_VARIANT}
+	sourceID := cm.ResourceID{Name: sourceName, Variant: "", Type: metadata.SOURCE_VARIANT}
 	if err := CreateOriginalPostgresTable(originalTableName); err != nil {
 		return fmt.Errorf("Could not create table in postgres: %v", err)
 	}
@@ -180,11 +180,11 @@ func testScheduleTrainingSet() error {
 	if err := coord.ExecuteJob(metadata.GetJobKey(sourceID)); err != nil {
 		return err
 	}
-	featureID := metadata.ResourceID{Name: featureName, Variant: "", Type: metadata.FEATURE_VARIANT}
+	featureID := cm.ResourceID{Name: featureName, Variant: "", Type: metadata.FEATURE_VARIANT}
 	if err := coord.ExecuteJob(metadata.GetJobKey(featureID)); err != nil {
 		return err
 	}
-	labelID := metadata.ResourceID{Name: labelName, Variant: "", Type: metadata.LABEL_VARIANT}
+	labelID := cm.ResourceID{Name: labelName, Variant: "", Type: metadata.LABEL_VARIANT}
 	if err := coord.ExecuteJob(metadata.GetJobKey(labelID)); err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func testScheduleTrainingSet() error {
 		return fmt.Errorf("Original training set values not set properly: %v", err)
 	}
 	// get original metadata timestamp for training set, before update
-	tsBeforeUpdate, err := metadataClient.GetTrainingSetVariant(ctx, metadata.NameVariant{Name: tsName, Variant: ""})
+	tsBeforeUpdate, err := metadataClient.GetTrainingSetVariant(ctx, cm.NameVariant{Name: tsName, Variant: ""})
 	if err != nil {
 		return fmt.Errorf("could not get training set: %v", err)
 	}
@@ -221,7 +221,7 @@ func testScheduleTrainingSet() error {
 		return fmt.Errorf("Updated training set values not set properly: %v", err)
 	}
 	// get metadata timestamp after update completed and check that it is more recent than original
-	tsAfterUpdate, err := metadataClient.GetTrainingSetVariant(ctx, metadata.NameVariant{Name: tsName, Variant: ""})
+	tsAfterUpdate, err := metadataClient.GetTrainingSetVariant(ctx, cm.NameVariant{Name: tsName, Variant: ""})
 	if err != nil {
 		return fmt.Errorf("could not get training set: %v", err)
 	}
@@ -272,7 +272,7 @@ func updateResourceTableValues(featureTable provider.OfflineTable, labelTable pr
 	return nil
 }
 
-func checkValuesCorrectlySet(tsID metadata.ResourceID, correctTable []provider.ResourceRecord) error {
+func checkValuesCorrectlySet(tsID cm.ResourceID, correctTable []provider.ResourceRecord) error {
 	providerTsID := provider.ResourceID{Name: tsID.Name, Variant: tsID.Variant, Type: provider.TrainingSet}
 	tsIterator, err := offlinePostgresStore.GetTrainingSet(providerTsID)
 	if err != nil {
@@ -291,7 +291,7 @@ func checkValuesCorrectlySet(tsID metadata.ResourceID, correctTable []provider.R
 	return nil
 }
 
-func kubernetesRanScheduledJob(resID metadata.ResourceID) error {
+func kubernetesRanScheduledJob(resID cm.ResourceID) error {
 	currentNameSpace, err := kubernetes.GetCurrentNamespace()
 	if err != nil {
 		return err
@@ -318,8 +318,8 @@ func testScheduleFeatureMaterialization() error {
 	featureName := createSafeUUID()
 	sourceName := createSafeUUID()
 	originalTableName := createSafeUUID()
-	featureID := metadata.ResourceID{Name: featureName, Variant: "", Type: metadata.FEATURE_VARIANT}
-	sourceID := metadata.ResourceID{Name: sourceName, Variant: "", Type: metadata.SOURCE_VARIANT}
+	featureID := cm.ResourceID{Name: featureName, Variant: "", Type: metadata.FEATURE_VARIANT}
+	sourceID := cm.ResourceID{Name: sourceName, Variant: "", Type: metadata.SOURCE_VARIANT}
 	// create postgres table with original data
 	if err := CreateOriginalPostgresTable(originalTableName); err != nil {
 		return fmt.Errorf("Could not create table in postgres: %v", err)
@@ -342,7 +342,7 @@ func testScheduleFeatureMaterialization() error {
 		return fmt.Errorf("tables not set correctly before update: %v", err)
 	}
 	// get last_updated timestamp of feature before update job runs
-	featureBeforeUpdate, err := metadataClient.GetFeatureVariant(ctx, metadata.NameVariant{Name: featureName, Variant: ""})
+	featureBeforeUpdate, err := metadataClient.GetFeatureVariant(ctx, cm.NameVariant{Name: featureName, Variant: ""})
 	if err != nil {
 		return fmt.Errorf("could not get training set: %v", err)
 	}
@@ -361,7 +361,7 @@ func testScheduleFeatureMaterialization() error {
 		return fmt.Errorf("Online table did not update to new values: %v", err)
 	}
 	// get timestamp of feature after update and compare to original timestamp
-	featureSecondTimestamp, err := metadataClient.GetFeatureVariant(ctx, metadata.NameVariant{Name: featureName, Variant: ""})
+	featureSecondTimestamp, err := metadataClient.GetFeatureVariant(ctx, cm.NameVariant{Name: featureName, Variant: ""})
 	if err != nil {
 		return fmt.Errorf("could not get online data: %v", err)
 	}
@@ -398,9 +398,9 @@ func testScheduleTransformation() error {
 	sourceName := strings.Replace(createSafeUUID(), "-", "", -1)
 	transformationName := strings.Replace(createSafeUUID(), "-", "", -1)
 	transformationQuery := fmt.Sprintf("SELECT * FROM {{%s.}}", sourceName)
-	sourceID := metadata.ResourceID{Name: sourceName, Variant: "", Type: metadata.SOURCE_VARIANT}
-	sourceNameVariants := []metadata.NameVariant{{Name: sourceName, Variant: ""}}
-	transformationID := metadata.ResourceID{Name: transformationName, Variant: "", Type: metadata.SOURCE_VARIANT}
+	sourceID := cm.ResourceID{Name: sourceName, Variant: "", Type: metadata.SOURCE_VARIANT}
+	sourceNameVariants := []cm.NameVariant{{Name: sourceName, Variant: ""}}
+	transformationID := cm.ResourceID{Name: transformationName, Variant: "", Type: metadata.SOURCE_VARIANT}
 	// initialize source data table
 	if err := CreateOriginalPostgresTable(tableName); err != nil {
 		return fmt.Errorf("Could not create non-featureform source table: %v", err)
@@ -422,7 +422,7 @@ func testScheduleTransformation() error {
 		return fmt.Errorf("Could not execute transformation job in coordinator: %v", err)
 	}
 	// get original timestamp for metadata transformation
-	originalTransformationMetadataRecord, err := metadataClient.GetSourceVariant(ctx, metadata.NameVariant{Name: transformationName, Variant: ""})
+	originalTransformationMetadataRecord, err := metadataClient.GetSourceVariant(ctx, cm.NameVariant{Name: transformationName, Variant: ""})
 	if err != nil {
 		return fmt.Errorf("could not get training set")
 	}
@@ -441,7 +441,7 @@ func testScheduleTransformation() error {
 		return fmt.Errorf("transformation table values did not update: %v", err)
 	}
 	// get timestamp of updated transformation table in metadata and check that timestamp is more recent than original
-	updatedTransformationMetadataRecord, err := metadataClient.GetSourceVariant(ctx, metadata.NameVariant{Name: transformationName, Variant: ""})
+	updatedTransformationMetadataRecord, err := metadataClient.GetSourceVariant(ctx, cm.NameVariant{Name: transformationName, Variant: ""})
 	if err != nil {
 		return fmt.Errorf("could not get training set: %v", err)
 	}
@@ -500,8 +500,8 @@ func testUpdateExistingSchedule() error {
 	featureName := createSafeUUID()
 	sourceName := createSafeUUID()
 	originalTableName := createSafeUUID()
-	featureID := metadata.ResourceID{Name: featureName, Variant: "", Type: metadata.FEATURE_VARIANT}
-	sourceID := metadata.ResourceID{Name: sourceName, Variant: "", Type: metadata.SOURCE_VARIANT}
+	featureID := cm.ResourceID{Name: featureName, Variant: "", Type: metadata.FEATURE_VARIANT}
+	sourceID := cm.ResourceID{Name: sourceName, Variant: "", Type: metadata.SOURCE_VARIANT}
 	if err := CreateOriginalPostgresTable(originalTableName); err != nil {
 		return fmt.Errorf("Could not create table in postgres: %v", err)
 	}
@@ -626,7 +626,7 @@ func createTrainingSetWithProvider(sourceName string, featureName string, labelN
 			Variant:     "",
 			Description: "",
 			Type:        string(provider.Int),
-			Source:      metadata.NameVariant{sourceName, ""},
+			Source:      cm.NameVariant{sourceName, ""},
 			Entity:      entityName,
 			Owner:       userName,
 			Provider:    providerName,
@@ -639,7 +639,7 @@ func createTrainingSetWithProvider(sourceName string, featureName string, labelN
 		metadata.FeatureDef{
 			Name:        featureName,
 			Variant:     "",
-			Source:      metadata.NameVariant{sourceName, ""},
+			Source:      cm.NameVariant{sourceName, ""},
 			Type:        string(provider.Int),
 			Entity:      entityName,
 			Owner:       userName,
@@ -657,8 +657,8 @@ func createTrainingSetWithProvider(sourceName string, featureName string, labelN
 			Description: "",
 			Owner:       userName,
 			Provider:    providerName,
-			Label:       metadata.NameVariant{labelName, ""},
-			Features:    []metadata.NameVariant{{featureName, ""}},
+			Label:       cm.NameVariant{labelName, ""},
+			Features:    []cm.NameVariant{{featureName, ""}},
 			Schedule:    schedule,
 		},
 	}
@@ -713,7 +713,7 @@ func materializeFeatureWithProvider(featureName string, sourceName string, origi
 		metadata.FeatureDef{
 			Name:        featureName,
 			Variant:     "",
-			Source:      metadata.NameVariant{sourceName, ""},
+			Source:      cm.NameVariant{sourceName, ""},
 			Type:        string(provider.Int),
 			Entity:      entityName,
 			Owner:       userName,
@@ -767,7 +767,7 @@ func createSourceWithProvider(sourceName string, tableName string) error {
 	return nil
 }
 
-func createTransformationWithProvider(sourceName string, transformationQuery string, sources []metadata.NameVariant, schedule string) error {
+func createTransformationWithProvider(sourceName string, transformationQuery string, sources []cm.NameVariant, schedule string) error {
 	userName := createSafeUUID()
 	providerName := createSafeUUID()
 	defs := []metadata.ResourceDef{

--- a/helpers/resource/name_variant.go
+++ b/helpers/resource/name_variant.go
@@ -1,0 +1,71 @@
+package resource
+
+import (
+	"fmt"
+	pb "github.com/featureform/metadata/proto"
+)
+
+type NameVariant struct {
+	Name    string
+	Variant string
+}
+
+func (variant NameVariant) Serialize() *pb.NameVariant {
+	return &pb.NameVariant{
+		Name:    variant.Name,
+		Variant: variant.Variant,
+	}
+}
+
+func (variant NameVariant) ClientString() string {
+	return fmt.Sprintf("%s.%s", variant.Name, variant.Variant)
+}
+
+func ParseNameVariant(serialized *pb.NameVariant) NameVariant {
+	return NameVariant{
+		Name:    serialized.Name,
+		Variant: serialized.Variant,
+	}
+}
+
+type NameVariants []NameVariant
+
+func (variants NameVariants) Serialize() []*pb.NameVariant {
+	serialized := make([]*pb.NameVariant, len(variants))
+	for i, variant := range variants {
+		serialized[i] = variant.Serialize()
+	}
+	return serialized
+}
+
+func ParseNameVariants(protos []*pb.NameVariant) NameVariants {
+	parsed := make([]NameVariant, len(protos))
+	for i, serialized := range protos {
+		parsed[i] = ParseNameVariant(serialized)
+	}
+	return parsed
+}
+
+func (variants NameVariants) Names() []string {
+	names := make([]string, len(variants))
+	for i, variant := range variants {
+		names[i] = variant.Name
+	}
+	return names
+}
+
+type Tags []string
+
+type Properties map[string]string
+
+func (properties Properties) Serialize() *pb.Properties {
+	serialized := &pb.Properties{
+		Property: map[string]*pb.Property{},
+	}
+
+	for key, val := range properties {
+		serialized.Property[key] = &pb.Property{Value: &pb.Property_StringValue{StringValue: val}}
+	}
+
+	return serialized
+}

--- a/helpers/resource/resources.go
+++ b/helpers/resource/resources.go
@@ -1,0 +1,108 @@
+package resource
+
+import (
+	"fmt"
+	pb "github.com/featureform/metadata/proto"
+)
+
+type Operation int
+
+const (
+	CREATE_OP Operation = iota
+)
+
+type ResourceType int32
+
+const (
+	FEATURE              ResourceType = ResourceType(pb.ResourceType_FEATURE)
+	FEATURE_VARIANT                   = ResourceType(pb.ResourceType_FEATURE_VARIANT)
+	LABEL                             = ResourceType(pb.ResourceType_LABEL)
+	LABEL_VARIANT                     = ResourceType(pb.ResourceType_LABEL_VARIANT)
+	USER                              = ResourceType(pb.ResourceType_USER)
+	ENTITY                            = ResourceType(pb.ResourceType_ENTITY)
+	PROVIDER                          = ResourceType(pb.ResourceType_PROVIDER)
+	SOURCE                            = ResourceType(pb.ResourceType_SOURCE)
+	SOURCE_VARIANT                    = ResourceType(pb.ResourceType_SOURCE_VARIANT)
+	TRAINING_SET                      = ResourceType(pb.ResourceType_TRAINING_SET)
+	TRAINING_SET_VARIANT              = ResourceType(pb.ResourceType_TRAINING_SET_VARIANT)
+	MODEL                             = ResourceType(pb.ResourceType_MODEL)
+)
+
+func (r ResourceType) String() string {
+	return pb.ResourceType_name[int32(r)]
+}
+
+func (r ResourceType) Serialized() pb.ResourceType {
+	return pb.ResourceType(r)
+}
+
+type ResourceStatus int32
+
+const (
+	NO_STATUS ResourceStatus = ResourceStatus(pb.ResourceStatus_NO_STATUS)
+	CREATED                  = ResourceStatus(pb.ResourceStatus_CREATED)
+	PENDING                  = ResourceStatus(pb.ResourceStatus_PENDING)
+	READY                    = ResourceStatus(pb.ResourceStatus_READY)
+	FAILED                   = ResourceStatus(pb.ResourceStatus_FAILED)
+)
+
+func (r ResourceStatus) String() string {
+	return pb.ResourceStatus_Status_name[int32(r)]
+}
+
+func (r ResourceStatus) Serialized() pb.ResourceStatus_Status {
+	return pb.ResourceStatus_Status(r)
+}
+
+type ComputationMode int32
+
+const (
+	PRECOMPUTED     ComputationMode = ComputationMode(pb.ComputationMode_PRECOMPUTED)
+	CLIENT_COMPUTED                 = ComputationMode(pb.ComputationMode_CLIENT_COMPUTED)
+)
+
+func (cm ComputationMode) Equals(mode pb.ComputationMode) bool {
+	return cm == ComputationMode(mode)
+}
+
+func (cm ComputationMode) String() string {
+	return pb.ComputationMode_name[int32(cm)]
+}
+
+var parentMapping = map[ResourceType]ResourceType{
+	FEATURE_VARIANT:      FEATURE,
+	LABEL_VARIANT:        LABEL,
+	SOURCE_VARIANT:       SOURCE,
+	TRAINING_SET_VARIANT: TRAINING_SET,
+}
+
+type ResourceID struct {
+	Name    string
+	Variant string
+	Type    ResourceType
+}
+
+func (id ResourceID) Proto() *pb.NameVariant {
+	return &pb.NameVariant{
+		Name:    id.Name,
+		Variant: id.Variant,
+	}
+}
+
+func (id ResourceID) Parent() (ResourceID, bool) {
+	parentType, has := parentMapping[id.Type]
+	if !has {
+		return ResourceID{}, false
+	}
+	return ResourceID{
+		Name: id.Name,
+		Type: parentType,
+	}, true
+}
+
+func (id ResourceID) String() string {
+	if id.Variant == "" {
+		return fmt.Sprintf("%s %s", id.Type, id.Name)
+	}
+	return fmt.Sprintf("%s %s (%s)", id.Type, id.Name, id.Variant)
+}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/featureform/helpers"
+	cm "github.com/featureform/helpers/resource"
 	"github.com/featureform/metadata"
 	"github.com/featureform/types"
 	"github.com/google/uuid"
@@ -32,7 +33,7 @@ type CronSchedule string
 const MaxJobNameLength = 52
 
 // CreateJobName Only the first value in prefixes will be used.
-func CreateJobName(id metadata.ResourceID, prefixes ...string) string {
+func CreateJobName(id cm.ResourceID, prefixes ...string) string {
 	jobNameBase := fmt.Sprintf("%s-%s-%s", id.Type, id.Name, id.Variant)
 
 	// if jobPrefix is provided, prepend it to jobNameBase
@@ -190,7 +191,7 @@ func newJobSpec(config KubernetesRunnerConfig, rsrcReqs v1.ResourceRequirements)
 type KubernetesRunnerConfig struct {
 	JobPrefix string
 	EnvVars   map[string]string
-	Resource  metadata.ResourceID
+	Resource  cm.ResourceID
 	Image     string
 	NumTasks  int32
 	Specs     metadata.KubernetesResourceSpecs
@@ -312,8 +313,8 @@ func (k KubernetesCompletionWatcher) Err() error {
 	return nil
 }
 
-func (k KubernetesRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{}
+func (k KubernetesRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{}
 }
 
 func (k KubernetesRunner) IsUpdateJob() bool {

--- a/metadata/client/main.go
+++ b/metadata/client/main.go
@@ -70,7 +70,7 @@ func main() {
 			Definition: metadata.TransformationSource{
 				TransformationType: metadata.SQLTransformationType{
 					Query: "SELECT * FROM {{Transactions.default}}",
-					Sources: []metadata.NameVariant{{
+					Sources: []cm.NameVariant{{
 						Name:    "Transactions",
 						Variant: "default"},
 					},
@@ -84,7 +84,7 @@ func main() {
 			Variant:     "default",
 			Description: "if a transaction is fraud",
 			Type:        "boolean",
-			Source:      metadata.NameVariant{"Transactions", "default"},
+			Source:      cm.NameVariant{"Transactions", "default"},
 			Entity:      "user",
 			Owner:       "Simba Khadder",
 			Location: metadata.ResourceVariantColumns{
@@ -97,7 +97,7 @@ func main() {
 		metadata.FeatureDef{
 			Name:        "number_of_fraud",
 			Variant:     "90d",
-			Source:      metadata.NameVariant{"Transactions", "default"},
+			Source:      cm.NameVariant{"Transactions", "default"},
 			Type:        "int",
 			Entity:      "user",
 			Owner:       "Simba Khadder",
@@ -112,7 +112,7 @@ func main() {
 		metadata.FeatureDef{
 			Name:        "user_2fa",
 			Variant:     "default",
-			Source:      metadata.NameVariant{"Transactions", "default"},
+			Source:      cm.NameVariant{"Transactions", "default"},
 			Type:        "boolean",
 			Entity:      "user",
 			Owner:       "Simba Khadder",
@@ -127,7 +127,7 @@ func main() {
 		metadata.FeatureDef{
 			Name:        "user_account_age",
 			Variant:     "default",
-			Source:      metadata.NameVariant{"Transactions", "default"},
+			Source:      cm.NameVariant{"Transactions", "default"},
 			Type:        "int",
 			Entity:      "user",
 			Owner:       "Simba Khadder",
@@ -142,7 +142,7 @@ func main() {
 		metadata.FeatureDef{
 			Name:        "user_credit_score",
 			Variant:     "default",
-			Source:      metadata.NameVariant{"Transactions", "default"},
+			Source:      cm.NameVariant{"Transactions", "default"},
 			Type:        "int",
 			Entity:      "user",
 			Owner:       "Simba Khadder",
@@ -157,7 +157,7 @@ func main() {
 		metadata.FeatureDef{
 			Name:        "user_transaction_count",
 			Variant:     "30d",
-			Source:      metadata.NameVariant{"Transactions", "default"},
+			Source:      cm.NameVariant{"Transactions", "default"},
 			Type:        "int",
 			Entity:      "user",
 			Owner:       "Simba Khadder",
@@ -172,7 +172,7 @@ func main() {
 		metadata.FeatureDef{
 			Name:        "avg_transaction_amt",
 			Variant:     "default",
-			Source:      metadata.NameVariant{"Transactions", "default"},
+			Source:      cm.NameVariant{"Transactions", "default"},
 			Type:        "int",
 			Entity:      "user",
 			Owner:       "Simba Khadder",
@@ -187,7 +187,7 @@ func main() {
 		metadata.FeatureDef{
 			Name:        "amt_spent",
 			Variant:     "30d",
-			Source:      metadata.NameVariant{"Transactions", "default"},
+			Source:      cm.NameVariant{"Transactions", "default"},
 			Type:        "int",
 			Entity:      "user",
 			Owner:       "Simba Khadder",
@@ -202,7 +202,7 @@ func main() {
 		metadata.FeatureDef{
 			Name:        "user_transaction_count",
 			Variant:     "7d",
-			Source:      metadata.NameVariant{"Transactions", "default"},
+			Source:      cm.NameVariant{"Transactions", "default"},
 			Type:        "int",
 			Entity:      "user",
 			Owner:       "Simba Khadder",
@@ -219,8 +219,8 @@ func main() {
 			Variant:     "default",
 			Description: "if a transaction is fraud",
 			Owner:       "Simba Khadder",
-			Label:       metadata.NameVariant{"is_fraud", "default"},
-			Features:    []metadata.NameVariant{{"user_transaction_count", "7d"}, {"number_of_fraud", "90d"}, {"amt_spent", "30d"}, {"avg_transaction_amt", "default"}, {"user_account_age", "default"}, {"user_credit_score", "default"}, {"user_2fa", "default"}},
+			Label:       cm.NameVariant{"is_fraud", "default"},
+			Features:    []cm.NameVariant{{"user_transaction_count", "7d"}, {"number_of_fraud", "90d"}, {"amt_spent", "30d"}, {"avg_transaction_amt", "default"}, {"user_account_age", "default"}, {"user_credit_score", "default"}, {"user_2fa", "default"}},
 			Provider:    "demo-postgres",
 		},
 		metadata.ModelDef{

--- a/metadata/dashboard/dashboard_metadata_test.go
+++ b/metadata/dashboard/dashboard_metadata_test.go
@@ -90,7 +90,7 @@ func TestPostTags(t *testing.T) {
 
 	MockJsonPost(ctx, params, tagList)
 
-	res := metadata.ResourceID{
+	res := cm.ResourceID{
 		Name:    name,
 		Variant: variant,
 		Type:    metadata.SOURCE_VARIANT,

--- a/metadata/errors.go
+++ b/metadata/errors.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"fmt"
+	cm "github.com/featureform/helpers/resource"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -15,7 +16,7 @@ func (e KeyNotFoundError) Error() string {
 }
 
 type ResourceExistsError struct {
-	ID ResourceID
+	ID cm.ResourceID
 }
 
 func (err *ResourceExistsError) Error() string {
@@ -33,7 +34,7 @@ func (err *ResourceExistsError) GRPCStatus() *status.Status {
 }
 
 type ResourceNotFoundError struct {
-	ID ResourceID
+	ID cm.ResourceID
 	E  error
 }
 
@@ -53,7 +54,7 @@ func (err *ResourceNotFoundError) GRPCStatus() *status.Status {
 }
 
 type ResourceChangedError struct {
-	ResourceID
+	cm.ResourceID
 }
 
 func (err *ResourceChangedError) Error() string {

--- a/provider/k8s.go
+++ b/provider/k8s.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	cm "github.com/featureform/helpers/resource"
 	"os"
 	"os/exec"
 	"strconv"
@@ -334,7 +335,7 @@ func (kube *KubernetesExecutor) ExecuteScript(envVars map[string]string, args *m
 		EnvVars:   envVars,
 		Image:     kube.image,
 		NumTasks:  1,
-		Resource: metadata.ResourceID{
+		Resource: cm.ResourceID{
 			Name:    envVars["RESOURCE_NAME"],
 			Variant: envVars["RESOURCE_VARIANT"],
 			Type:    ProviderToMetadataResourceType[OfflineResourceType(resourceType)],

--- a/provider/offline.go
+++ b/provider/offline.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	cm "github.com/featureform/helpers/resource"
 	"reflect"
 	"sort"
 	"strings"
@@ -38,11 +39,11 @@ const (
 	FeatureMaterialization
 )
 
-var ProviderToMetadataResourceType = map[OfflineResourceType]metadata.ResourceType{
-	Feature:        metadata.FEATURE_VARIANT,
-	TrainingSet:    metadata.TRAINING_SET_VARIANT,
-	Primary:        metadata.SOURCE_VARIANT,
-	Transformation: metadata.SOURCE_VARIANT,
+var ProviderToMetadataResourceType = map[OfflineResourceType]cm.ResourceType{
+	Feature:        cm.FEATURE_VARIANT,
+	TrainingSet:    cm.TRAINING_SET_VARIANT,
+	Primary:        cm.SOURCE_VARIANT,
+	Transformation: cm.SOURCE_VARIANT,
 }
 
 func (offlineType OfflineResourceType) String() string {

--- a/runner/copy.go
+++ b/runner/copy.go
@@ -7,9 +7,9 @@ package runner
 import (
 	"encoding/json"
 	"fmt"
+	cm "github.com/featureform/helpers/resource"
 	"sync"
 
-	"github.com/featureform/metadata"
 	"github.com/featureform/provider"
 	pc "github.com/featureform/provider/provider_config"
 	pt "github.com/featureform/provider/provider_type"
@@ -46,8 +46,8 @@ type ResultSync struct {
 	mu   sync.RWMutex
 }
 
-func (m *MaterializedChunkRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{}
+func (m *MaterializedChunkRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{}
 }
 
 func (m *MaterializedChunkRunner) IsUpdateJob() bool {

--- a/runner/create_transformation.go
+++ b/runner/create_transformation.go
@@ -7,6 +7,7 @@ package runner
 import (
 	"encoding/json"
 	"fmt"
+	cm "github.com/featureform/helpers/resource"
 
 	"github.com/featureform/metadata"
 	"github.com/featureform/provider"
@@ -68,8 +69,8 @@ type CreateTransformationRunner struct {
 	IsUpdate             bool
 }
 
-func (c CreateTransformationRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{
+func (c CreateTransformationRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{
 		Name:    c.TransformationConfig.TargetTableID.Name,
 		Variant: c.TransformationConfig.TargetTableID.Variant,
 		Type:    provider.ProviderToMetadataResourceType[c.TransformationConfig.TargetTableID.Type],

--- a/runner/library_test.go
+++ b/runner/library_test.go
@@ -6,7 +6,7 @@ package runner
 
 import (
 	"errors"
-	"github.com/featureform/metadata"
+	cm "github.com/featureform/helpers/resource"
 	"github.com/featureform/types"
 	"testing"
 )
@@ -19,8 +19,8 @@ func (m *MockRunner) Run() (types.CompletionWatcher, error) {
 	return &MockCompletionWatcher{}, nil
 }
 
-func (m *MockRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{}
+func (m *MockRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{}
 }
 
 func (m *MockRunner) IsUpdateJob() bool {

--- a/runner/materialize.go
+++ b/runner/materialize.go
@@ -7,6 +7,7 @@ package runner
 import (
 	"encoding/json"
 	"fmt"
+	cm "github.com/featureform/helpers/resource"
 
 	"go.uber.org/zap"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/featureform/helpers"
 	"github.com/featureform/kubernetes"
 	"github.com/featureform/logging"
-	"github.com/featureform/metadata"
 	"github.com/featureform/provider"
 	pc "github.com/featureform/provider/provider_config"
 	pt "github.com/featureform/provider/provider_type"
@@ -42,8 +42,8 @@ type MaterializeRunner struct {
 	Logger   *zap.SugaredLogger
 }
 
-func (m MaterializeRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{
+func (m MaterializeRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{
 		Name:    m.ID.Name,
 		Variant: m.ID.Variant,
 		Type:    provider.ProviderToMetadataResourceType[m.ID.Type],
@@ -185,7 +185,7 @@ func (m MaterializeRunner) Run() (types.CompletionWatcher, error) {
 			EnvVars:   envVars,
 			Image:     WORKER_IMAGE,
 			NumTasks:  int32(numChunks),
-			Resource:  metadata.ResourceID{Name: m.ID.Name, Variant: m.ID.Variant, Type: provider.ProviderToMetadataResourceType[m.ID.Type]},
+			Resource:  cm.ResourceID{Name: m.ID.Name, Variant: m.ID.Variant, Type: provider.ProviderToMetadataResourceType[m.ID.Type]},
 		}
 		kubernetesRunner, err := kubernetes.NewKubernetesRunner(kubernetesConfig)
 		if err != nil {

--- a/runner/materialize_test.go
+++ b/runner/materialize_test.go
@@ -5,9 +5,9 @@
 package runner
 
 import (
+	cm "github.com/featureform/helpers/resource"
 	"testing"
 
-	"github.com/featureform/metadata"
 	"github.com/featureform/provider"
 	"github.com/featureform/types"
 	"go.uber.org/zap/zaptest"
@@ -19,8 +19,8 @@ func (m mockChunkRunner) Run() (types.CompletionWatcher, error) {
 	return mockCompletionWatcher{}, nil
 }
 
-func (m mockChunkRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{}
+func (m mockChunkRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{}
 }
 
 func (m mockChunkRunner) IsUpdateJob() bool {

--- a/runner/register_source.go
+++ b/runner/register_source.go
@@ -7,8 +7,8 @@ package runner
 import (
 	"encoding/json"
 	"fmt"
+	cm "github.com/featureform/helpers/resource"
 
-	"github.com/featureform/metadata"
 	"github.com/featureform/provider"
 	pc "github.com/featureform/provider/provider_config"
 	pt "github.com/featureform/provider/provider_type"
@@ -44,8 +44,8 @@ type RegisterSourceRunner struct {
 	SourceTableName string
 }
 
-func (r RegisterSourceRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{
+func (r RegisterSourceRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{
 		Name:    r.ResourceID.Name,
 		Variant: r.ResourceID.Variant,
 		Type:    provider.ProviderToMetadataResourceType[r.ResourceID.Type],

--- a/runner/s3_import_dynamodb.go
+++ b/runner/s3_import_dynamodb.go
@@ -6,12 +6,12 @@ package runner
 
 import (
 	"fmt"
+	cm "github.com/featureform/helpers/resource"
 
 	"time"
 
 	"github.com/featureform/filestore"
 	"github.com/featureform/logging"
-	"github.com/featureform/metadata"
 	"github.com/featureform/provider"
 	pt "github.com/featureform/provider/provider_type"
 	"github.com/featureform/types"
@@ -45,8 +45,8 @@ type S3ImportDynamoDBRunner struct {
 	Logger      *zap.SugaredLogger
 }
 
-func (r S3ImportDynamoDBRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{
+func (r S3ImportDynamoDBRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{
 		Name:    r.ID.Name,
 		Variant: r.ID.Variant,
 		Type:    provider.ProviderToMetadataResourceType[r.ID.Type],

--- a/runner/training_set_runner.go
+++ b/runner/training_set_runner.go
@@ -7,8 +7,8 @@ package runner
 import (
 	"encoding/json"
 	"fmt"
+	cm "github.com/featureform/helpers/resource"
 
-	"github.com/featureform/metadata"
 	"github.com/featureform/provider"
 	pc "github.com/featureform/provider/provider_config"
 	pt "github.com/featureform/provider/provider_type"
@@ -51,8 +51,8 @@ type TrainingSetRunnerConfig struct {
 	IsUpdate      bool
 }
 
-func (t TrainingSetRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{
+func (t TrainingSetRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{
 		Name:    t.Def.ID.Name,
 		Variant: t.Def.ID.Variant,
 		Type:    provider.ProviderToMetadataResourceType[t.Def.ID.Type],

--- a/runner/worker/worker_test.go
+++ b/runner/worker/worker_test.go
@@ -26,7 +26,7 @@ type MockIndexRunner struct {
 }
 
 type MockUpdateRunner struct {
-	ResourceID metadata.ResourceID
+	ResourceID cm.ResourceID
 }
 
 type MockCompletionWatcher struct{}
@@ -35,8 +35,8 @@ func (m *MockRunner) Run() (types.CompletionWatcher, error) {
 	return &MockCompletionWatcher{}, nil
 }
 
-func (m *MockRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{}
+func (m *MockRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{}
 }
 
 func (m *MockRunner) IsUpdateJob() bool {
@@ -47,8 +47,8 @@ func (m *MockIndexRunner) Run() (types.CompletionWatcher, error) {
 	return &MockCompletionWatcher{}, nil
 }
 
-func (m *MockIndexRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{}
+func (m *MockIndexRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{}
 }
 
 func (m *MockIndexRunner) IsUpdateJob() bool {
@@ -64,7 +64,7 @@ func (m *MockUpdateRunner) Run() (types.CompletionWatcher, error) {
 	return &MockCompletionWatcher{}, nil
 }
 
-func (m *MockUpdateRunner) Resource() metadata.ResourceID {
+func (m *MockUpdateRunner) Resource() cm.ResourceID {
 	return m.ResourceID
 }
 
@@ -94,8 +94,8 @@ func (r *RunnerWithFailingWatcher) Run() (types.CompletionWatcher, error) {
 	return &FailingWatcher{}, nil
 }
 
-func (r *RunnerWithFailingWatcher) Resource() metadata.ResourceID {
-	return metadata.ResourceID{}
+func (r *RunnerWithFailingWatcher) Resource() cm.ResourceID {
+	return cm.ResourceID{}
 }
 
 func (r *RunnerWithFailingWatcher) IsUpdateJob() bool {
@@ -123,8 +123,8 @@ func (f *FailingRunner) Run() (types.CompletionWatcher, error) {
 	return nil, errors.New("Failed to run runner")
 }
 
-func (f *FailingRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{}
+func (f *FailingRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{}
 }
 
 func (f *FailingRunner) IsUpdateJob() bool {
@@ -137,8 +137,8 @@ func (f *FailingIndexRunner) Run() (types.CompletionWatcher, error) {
 	return &MockCompletionWatcher{}, nil
 }
 
-func (f *FailingIndexRunner) Resource() metadata.ResourceID {
-	return metadata.ResourceID{}
+func (f *FailingIndexRunner) Resource() cm.ResourceID {
+	return cm.ResourceID{}
 }
 
 func (f *FailingIndexRunner) IsUpdateJob() bool {
@@ -344,7 +344,7 @@ func TestRunnerRunFail(t *testing.T) {
 	}
 }
 
-func registerUpdateMockRunnerFactory(resID metadata.ResourceID) error {
+func registerUpdateMockRunnerFactory(resID cm.ResourceID) error {
 	mockRunner := &MockUpdateRunner{ResourceID: resID}
 	mockFactory := func(config runner.Config) (types.Runner, error) {
 		return mockRunner, nil
@@ -363,7 +363,7 @@ func TestBasicUpdateRunner(t *testing.T) {
 	resourceName := uuid.New().String()
 	resourceVariant := ""
 	resourceType := metadata.FEATURE_VARIANT
-	resourceID := metadata.ResourceID{resourceName, resourceVariant, resourceType}
+	resourceID := cm.ResourceID{resourceName, resourceVariant, resourceType}
 	if err := registerUpdateMockRunnerFactory(resourceID); err != nil {
 		t.Fatalf("Error registering mock runner factory: %v", err)
 	}

--- a/serving/features.go
+++ b/serving/features.go
@@ -3,6 +3,7 @@ package serving
 import (
 	"context"
 	"fmt"
+	cm "github.com/featureform/helpers/resource"
 	"github.com/featureform/metadata"
 	"github.com/featureform/metrics"
 	pb "github.com/featureform/proto"
@@ -100,7 +101,7 @@ func (serv *FeatureServer) getFeatureValues(ctx context.Context, name, variant s
 
 	var values []interface{}
 	switch meta.Mode() {
-	case metadata.PRECOMPUTED:
+	case cm.PRECOMPUTED:
 		if meta.Provider() == "" {
 			return nil, fmt.Errorf("feature %s:%s has no inference store", name, variant)
 		}
@@ -112,7 +113,7 @@ func (serv *FeatureServer) getFeatureValues(ctx context.Context, name, variant s
 		for _, val := range precomputedValues {
 			values = append(values, val.value)
 		}
-	case metadata.CLIENT_COMPUTED:
+	case cm.CLIENT_COMPUTED:
 		values = append(values, meta.LocationFunction())
 	default:
 		return nil, fmt.Errorf("unknown computation mode %v", meta.Mode())
@@ -129,7 +130,7 @@ func (serv *FeatureServer) getOrCacheFeatureMetadata(ctx context.Context, name, 
 	if feature, has := serv.Features.Load(serv.getNVCacheKey(name, variant)); has {
 		return feature.(*metadata.FeatureVariant), nil
 	} else {
-		metaFeature, err := serv.Metadata.GetFeatureVariant(ctx, metadata.NameVariant{name, variant})
+		metaFeature, err := serv.Metadata.GetFeatureVariant(ctx, cm.NameVariant{name, variant})
 		if err != nil {
 			logger.Errorw("metadata lookup failed", "Err", err)
 			obs.SetError()

--- a/serving/serving_test.go
+++ b/serving/serving_test.go
@@ -203,7 +203,7 @@ func allTypesResourceDefsFn(providerType string) []metadata.ResourceDef {
 			Variant:  "double",
 			Provider: "mockOnline",
 			Entity:   "mockEntity",
-			Source:   metadata.NameVariant{"mockSource", "var"},
+			Source:   cm.NameVariant{"mockSource", "var"},
 			Owner:    "Featureform",
 			Location: metadata.ResourceVariantColumns{
 				Entity: "col1",
@@ -218,7 +218,7 @@ func allTypesResourceDefsFn(providerType string) []metadata.ResourceDef {
 			Variant:  "float",
 			Provider: "mockOnline",
 			Entity:   "mockEntity",
-			Source:   metadata.NameVariant{"mockSource", "var"},
+			Source:   cm.NameVariant{"mockSource", "var"},
 			Owner:    "Featureform",
 			Location: metadata.ResourceVariantColumns{
 				Entity: "col1",
@@ -233,7 +233,7 @@ func allTypesResourceDefsFn(providerType string) []metadata.ResourceDef {
 			Variant:  "str",
 			Provider: "mockOnline",
 			Entity:   "mockEntity",
-			Source:   metadata.NameVariant{"mockSource", "var"},
+			Source:   cm.NameVariant{"mockSource", "var"},
 			Owner:    "Featureform",
 			Location: metadata.ResourceVariantColumns{
 				Entity: "col1",
@@ -248,7 +248,7 @@ func allTypesResourceDefsFn(providerType string) []metadata.ResourceDef {
 			Variant:  "int",
 			Provider: "mockOnline",
 			Entity:   "mockEntity",
-			Source:   metadata.NameVariant{"mockSource", "var"},
+			Source:   cm.NameVariant{"mockSource", "var"},
 			Owner:    "Featureform",
 			Location: metadata.ResourceVariantColumns{
 				Entity: "col1",
@@ -263,7 +263,7 @@ func allTypesResourceDefsFn(providerType string) []metadata.ResourceDef {
 			Variant:  "smallint",
 			Provider: "mockOnline",
 			Entity:   "mockEntity",
-			Source:   metadata.NameVariant{"mockSource", "var"},
+			Source:   cm.NameVariant{"mockSource", "var"},
 			Owner:    "Featureform",
 			Location: metadata.ResourceVariantColumns{
 				Entity: "col1",
@@ -278,7 +278,7 @@ func allTypesResourceDefsFn(providerType string) []metadata.ResourceDef {
 			Variant:  "bigint",
 			Provider: "mockOnline",
 			Entity:   "mockEntity",
-			Source:   metadata.NameVariant{"mockSource", "var"},
+			Source:   cm.NameVariant{"mockSource", "var"},
 			Owner:    "Featureform",
 			Location: metadata.ResourceVariantColumns{
 				Entity: "col1",
@@ -293,7 +293,7 @@ func allTypesResourceDefsFn(providerType string) []metadata.ResourceDef {
 			Variant:  "bool",
 			Provider: "mockOnline",
 			Entity:   "mockEntity",
-			Source:   metadata.NameVariant{"mockSource", "var"},
+			Source:   cm.NameVariant{"mockSource", "var"},
 			Owner:    "Featureform",
 			Location: metadata.ResourceVariantColumns{
 				Entity: "col1",
@@ -308,7 +308,7 @@ func allTypesResourceDefsFn(providerType string) []metadata.ResourceDef {
 			Variant:  "proto",
 			Provider: "mockOnline",
 			Entity:   "mockEntity",
-			Source:   metadata.NameVariant{"mockSource", "var"},
+			Source:   cm.NameVariant{"mockSource", "var"},
 			Owner:    "Featureform",
 			Location: metadata.ResourceVariantColumns{
 				Entity: "col1",
@@ -349,7 +349,7 @@ func simpleResourceDefsFn(providerType string) []metadata.ResourceDef {
 			Variant:  "variant",
 			Provider: "mockOnline",
 			Entity:   "mockEntity",
-			Source:   metadata.NameVariant{"mockSource", "var"},
+			Source:   cm.NameVariant{"mockSource", "var"},
 			Owner:    "Featureform",
 			Location: metadata.ResourceVariantColumns{
 				Entity: "col1",
@@ -364,7 +364,7 @@ func simpleResourceDefsFn(providerType string) []metadata.ResourceDef {
 			Variant:  "variant2",
 			Provider: "mockOnline",
 			Entity:   "mockEntity",
-			Source:   metadata.NameVariant{"mockSource", "var"},
+			Source:   cm.NameVariant{"mockSource", "var"},
 			Owner:    "Featureform",
 			Location: metadata.ResourceVariantColumns{
 				Entity: "col1",
@@ -379,7 +379,7 @@ func simpleResourceDefsFn(providerType string) []metadata.ResourceDef {
 			Variant:  "variant",
 			Provider: "mockOnline",
 			Entity:   "mockEntity",
-			Source:   metadata.NameVariant{"mockSource", "var"},
+			Source:   cm.NameVariant{"mockSource", "var"},
 			Owner:    "Featureform",
 			Location: metadata.ResourceVariantColumns{
 				Entity: "col1",
@@ -391,8 +391,8 @@ func simpleResourceDefsFn(providerType string) []metadata.ResourceDef {
 			Name:     "training-set",
 			Variant:  "variant",
 			Provider: "mockOnline",
-			Label:    metadata.NameVariant{"label", "variant"},
-			Features: metadata.NameVariants{{"feature", "variant"}},
+			Label:    cm.NameVariant{"label", "variant"},
+			Features: cm.NameVariants{{"feature", "variant"}},
 			Owner:    "Featureform",
 		},
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -1,12 +1,12 @@
 package types
 
 import (
-	"github.com/featureform/metadata"
+	cm "github.com/featureform/helpers/resource"
 )
 
 type Runner interface {
 	Run() (CompletionWatcher, error)
-	Resource() metadata.ResourceID
+	Resource() cm.ResourceID
 	IsUpdateJob() bool
 }
 


### PR DESCRIPTION
# Description

There are parts of the codebase that could use some of the logic built out in metadata.go. Namely, ResourceID and NameVariant. SlackClient and Errors and Tasks could use some of these thing but by importing metadata.go it results in cyclical dependenices. Moved some logic to helpers (which will later be changed to common)

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
