### PR TITLE
Enable CGO for go builds (CGO_ENABLED=1)

### DIFF
--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -34,8 +34,7 @@ COPY ./types ./types
 COPY ./coordinator/main/main.go ./coordinator/main/main.go
 
 # Building Go app
-# CGD_ENABLED=0 is used to avoid the libc differences in alpine and ubuntu
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
 RUN go build ./coordinator/main/main.go
 
 FROM ubuntu:22.04

--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -103,3 +103,4 @@ RUN cat $SPARK_SCRIPT_PATH | md5sum \
 
 EXPOSE 8080
 ENTRYPOINT ["/app/main"]
+

--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -103,4 +103,3 @@ RUN cat $SPARK_SCRIPT_PATH | md5sum \
 
 EXPOSE 8080
 ENTRYPOINT ["/app/main"]
-

--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -1,7 +1,7 @@
 # RUN docker build -f ./coordinator/Dockerfile . -t coordinator from /serving
 # docker tag coordinator:latest featureformcom/coordinator:latest
 # docker push featureformcom/coordinator:latest
-FROM golang:1.21-alpine as builder
+FROM golang:1.21 as builder
 
 WORKDIR /app
 

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -4,7 +4,7 @@
 # docker build -f ./runner/Dockerfile . -t worker in /serving
 # docker tag worker:latest featureformcom/worker:latest
 # docker push featureformcom/worker:latest
-FROM golang:1.2
+FROM golang:1.21
 
 WORKDIR /app
 

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -34,8 +34,7 @@ COPY metadata/search/* ./metadata/search/
 COPY ./provider/ ./provider/
 COPY runner/worker/main/main.go ./runner/worker/main/main.go
 
-# CGD_ENABLED=0 is used to avoid the libc differences in alpine and ubuntu
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
 RUN go build -o worker ./runner/worker/main
 
 FROM ubuntu:22.04

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -4,7 +4,7 @@
 # docker build -f ./runner/Dockerfile . -t worker in /serving
 # docker tag worker:latest featureformcom/worker:latest
 # docker push featureformcom/worker:latest
-FROM golang:1.21-alpine
+FROM golang:1.2
 
 WORKDIR /app
 

--- a/runner/Dockerfile.debug
+++ b/runner/Dockerfile.debug
@@ -103,4 +103,3 @@ RUN curl https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connecto
 EXPOSE 40005
 
 CMD ["/go/bin/dlv", "--listen=:40005", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "./worker"]
-

--- a/runner/Dockerfile.debug
+++ b/runner/Dockerfile.debug
@@ -4,7 +4,7 @@
 # docker build -f ./runner/Dockerfile . -t worker in /serving
 # docker tag worker:latest featureformcom/worker:latest
 # docker push featureformcom/worker:latest
-FROM golang:1.21-alpine as builder
+FROM golang:1.21 as builder
 
 WORKDIR /app
 

--- a/runner/Dockerfile.debug
+++ b/runner/Dockerfile.debug
@@ -103,3 +103,4 @@ RUN curl https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connecto
 EXPOSE 40005
 
 CMD ["/go/bin/dlv", "--listen=:40005", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "./worker"]
+

--- a/runner/Dockerfile.debug
+++ b/runner/Dockerfile.debug
@@ -32,8 +32,7 @@ COPY ./provider/ ./provider/
 COPY runner/worker/main/main.go ./runner/worker/main/main.go
 
 
-# CGD_ENABLED=0 is used to avoid the libc differences in alpine and ubuntu
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN go build -gcflags="all=-N -l" -o worker ./runner/worker/main
 


### PR DESCRIPTION
# Description
**Please include a summary of the changes and the related issue.**
Set CGO_ENABLED = 1 for go builds in docker files.

**Why is this change required? What problem does it solve?**
Required to use [IKV](https://docs.inlined.io/) as an online store in featureform. IKV uses native C code linked into Go with CGo. https://github.com/featureform/featureform/pull/1369

**If it fixes an open issue, please link to the issue here**
No open issue.

## Type of change
Dockerfile config change (Go build configuration)

### Does this correspond to an open issue?
No issue.

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
