### PR TITLE
Fix variant error switching

### DIFF
--- a/dashboard/src/components/entitypage/EntityPageView.js
+++ b/dashboard/src/components/entitypage/EntityPageView.js
@@ -526,7 +526,10 @@ const EntityPageView = ({
                           </>
                         ) : (
                           <>
-                            <Typography variant='body1'>
+                            <Typography
+                              variant='body1'
+                              style={{ whiteSpace: 'pre-line' }}
+                            >
                               {metadata['error']}
                             </Typography>
                           </>

--- a/dashboard/src/components/entitypage/EntityPageView.js
+++ b/dashboard/src/components/entitypage/EntityPageView.js
@@ -30,7 +30,7 @@ import MetricsDropdown from './elements/MetricsDropdown';
 import StatsDropdown from './elements/StatsDropdown';
 import TagBox from './elements/TagBox.js';
 import VariantControl from './elements/VariantControl';
-import ErrorModal from './ErrorModal.js';
+import ErrorModal, { ERROR_MSG_MAX } from './ErrorModal.js';
 
 SyntaxHighlighter.registerLanguage('python', python);
 SyntaxHighlighter.registerLanguage('sql', sql);
@@ -516,11 +516,21 @@ const EntityPageView = ({
                       )}
                     {metadata['error'] && metadata['error'] !== '' && (
                       <>
-                        <b>Error Message:</b>
-                        <ErrorModal
-                          buttonTxt='See More'
-                          errorTxt={metadata['error']}
-                        />
+                        <strong>Error Message:</strong>
+                        {metadata['error'].length > ERROR_MSG_MAX ? (
+                          <>
+                            <ErrorModal
+                              buttonTxt='See More'
+                              errorTxt={metadata['error']}
+                            />
+                          </>
+                        ) : (
+                          <>
+                            <Typography variant='body1'>
+                              {metadata['error']}
+                            </Typography>
+                          </>
+                        )}
                       </>
                     )}
                     {metadata['source-type'] && (

--- a/dashboard/src/components/entitypage/ErrorModal.js
+++ b/dashboard/src/components/entitypage/ErrorModal.js
@@ -25,7 +25,7 @@ export default function ErrorModal({ errorTxt = '', buttonTxt = '' }) {
 
   const copyToClipBoard = (error = '') => {
     if (error) {
-      navigator.clipboard.writeText(error);
+      navigator?.clipboard?.writeText(error);
       setOpenSnack(true);
     }
   };
@@ -53,7 +53,11 @@ export default function ErrorModal({ errorTxt = '', buttonTxt = '' }) {
           <Typography>Copied to clipboard!</Typography>
         </Alert>
       </Snackbar>
-      <Typography style={{whiteSpace: 'pre-line'}} data-testid='errorMessageId' variant='body1'>
+      <Typography
+        style={{ whiteSpace: 'pre-line' }}
+        data-testid='errorMessageId'
+        variant='body1'
+      >
         {`${truncated + (isShowMore ? '...' : '')}`}
       </Typography>
       {isShowMore && (
@@ -80,6 +84,7 @@ export default function ErrorModal({ errorTxt = '', buttonTxt = '' }) {
           <Tooltip title='Copy to Clipboard'>
             <Button
               role='none'
+              data-testid='copyBtn'
               onClick={() => copyToClipBoard(errorTxt)}
               fontSize={11.5}
             >

--- a/dashboard/src/components/entitypage/ErrorModal.test.js
+++ b/dashboard/src/components/entitypage/ErrorModal.test.js
@@ -24,6 +24,7 @@ describe('Error modal tests', () => {
   const ERROR_MSG_ID = 'errorMessageId';
   const TITLE_ID = 'errorModalTitleId';
   const FULL_TXT_ID = 'fullTextContent';
+  const COPY_BTN_ID = 'copyBtn';
 
   const getTestBody = (errorTxt = '', buttonTxt = 'Show More') => {
     const testBody = (
@@ -79,6 +80,8 @@ describe('Error modal tests', () => {
 
     //when:
     const foundFullError = helper.getByTestId(FULL_TXT_ID);
+    const foundCopyBtn = helper.getByTestId(COPY_BTN_ID);
+    fireEvent.click(foundCopyBtn);
 
     //then: the full error is found
     expect(foundFullError.textContent).toBe(errorMsg);


### PR DESCRIPTION
# Description

This PR fixes an issue where switching to a different variant will not update the `error` field and requires a hard-refresh.

`example`
(see resource_variant)

https://github.com/featureform/featureform/assets/34227093/d21367b3-9752-4d35-9883-648dad7a7ec2






closes [ent-#806](https://github.com/featureform/featureform-enterprise/issues/806)

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
