### PR TITLE
Bugfix: Get Source iterator fix. (blank modal)

### DIFF
--- a/metadata/dashboard/dashboard_metadata.go
+++ b/metadata/dashboard/dashboard_metadata.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/featureform/fferr"
 	filestore "github.com/featureform/filestore"
 	help "github.com/featureform/helpers"
 	"github.com/featureform/metadata"
@@ -1109,20 +1108,20 @@ func (m *MetadataServer) getSourceDataIterator(name, variant string, limit int64
 	m.logger.Infow("Getting Source Variant Iterator", "name", name, "variant", variant)
 	sv, err := m.client.GetSourceVariant(ctx, metadata.NameVariant{Name: name, Variant: variant})
 	if err != nil {
-		return nil, fferr.NewInternalError(fmt.Errorf("could not get source variant: %w", err))
+		return nil, err
 	}
 	providerEntry, err := sv.FetchProvider(m.client, ctx)
 	m.logger.Debugw("Fetched Source Variant Provider", "name", providerEntry.Name(), "type", providerEntry.Type())
 	if err != nil {
-		return nil, fferr.NewInternalError(fmt.Errorf("could not get fetch provider: %w", err))
+		return nil, err
 	}
 	p, err := provider.Get(pt.Type(providerEntry.Type()), providerEntry.SerializedConfig())
 	if err != nil {
-		return nil, fferr.NewInternalError(fmt.Errorf("could not get provider: %w", err))
+		return nil, err
 	}
 	store, err := p.AsOfflineStore()
 	if err != nil {
-		return nil, fferr.NewInternalError(fmt.Errorf("could not open as offline store: %w", err))
+		return nil, err
 	}
 	var primary provider.PrimaryTable
 	var providerErr error
@@ -1138,7 +1137,7 @@ func (m *MetadataServer) getSourceDataIterator(name, variant string, limit int64
 		primary, providerErr = store.GetPrimaryTable(provider.ResourceID{Name: name, Variant: variant, Type: provider.Primary})
 	}
 	if providerErr != nil {
-		return nil, fferr.NewInternalError(fmt.Errorf("could not get primary table: %w", err))
+		return nil, providerErr
 	}
 	return primary.IterateSegment(limit)
 }

--- a/metadata/dashboard/dashboard_metadata.go
+++ b/metadata/dashboard/dashboard_metadata.go
@@ -887,7 +887,7 @@ func (m *MetadataServer) GetSourceData(c *gin.Context) {
 	}
 	iter, err := m.getSourceDataIterator(name, variant, limit)
 	if err != nil {
-		fetchError := &FetchError{StatusCode: 500, Type: "GetSourceData - getSourceDataIterator() threw an exception"}
+		fetchError := &FetchError{StatusCode: 500, Type: fmt.Sprintf("GetSourceData - %s", err.Error())}
 		m.logger.Errorw(fetchError.Error(), "Metadata error", err)
 		c.JSON(fetchError.StatusCode, fetchError.Error())
 		return
@@ -1137,7 +1137,7 @@ func (m *MetadataServer) getSourceDataIterator(name, variant string, limit int64
 		primary, providerErr = store.GetPrimaryTable(provider.ResourceID{Name: name, Variant: variant, Type: provider.Primary})
 	}
 	if providerErr != nil {
-		return nil, errors.Wrap(err, "could not get primary table")
+		return nil, errors.Wrap(providerErr, "could not get primary table")
 	}
 	return primary.IterateSegment(limit)
 }

--- a/serving/serving.go
+++ b/serving/serving.go
@@ -460,7 +460,7 @@ func (serv *FeatureServer) getSourceDataIterator(name, variant string, limit int
 	}
 	if providerErr != nil {
 		serv.Logger.Errorw("Could not get primary table", "name", name, "variant", variant, "Error", providerErr)
-		return nil, err
+		return nil, providerErr
 	}
 	serv.Logger.Debugw("Getting source data iterator", "name", name, "variant", variant)
 	return primary.IterateSegment(limit)


### PR DESCRIPTION
# Description

This PR fixes an issue where the method `getSourceDataIterator()` function returns the incorrect error, resulting in a blank modal when the user clicks "Preview Result".

It also fixes the same issue in `serving.go`.

closes [ent-#803](https://github.com/featureform/featureform-enterprise/issues/803)

`working example`
<img width="688" alt="Screenshot 2024-03-18 at 3 38 41 PM" src="https://github.com/featureform/featureform/assets/34227093/ae0737e5-8f5a-4e01-8e91-a8078a1df0be">



<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts
