### PR TITLE
Bugfix: Can't materialize more than 100k rows/entities from BigQuery to Redis 

### DIFF
--- a/provider/bigquery.go
+++ b/provider/bigquery.go
@@ -214,6 +214,15 @@ func (it *bqGenericTableIterator) Values() GenericRecord {
 
 func (it *bqGenericTableIterator) Columns() []string {
 	var columns []string
+	// As the documentation for bigquery.Schema notes:
+	// > The schema of the table. In some scenarios it will only be available after the first call to Next(),
+	//   like when a call to Query.Read uses the jobs.query API for an optimized query path.
+	// Given this possibility, we should check if the schema is empty and if so, call Next() to populate it.
+	// Given Columns is only called to fetch the data sources columns list, we can safely call Next() here
+	// without concern for skipping a value in the iteration.
+	if len(it.iter.Schema) == 0 {
+		it.Next()
+	}
 	for _, col := range it.iter.Schema {
 		columns = append(columns, col.Name)
 	}

--- a/runner/materialize.go
+++ b/runner/materialize.go
@@ -158,7 +158,7 @@ func (m MaterializeRunner) Run() (types.CompletionWatcher, error) {
 			numChunks += 1
 		}
 	}
-	m.Logger.Infow("Creating chunks", "name", m.ID.Name, "variant", m.ID.Variant, "count", numChunks)
+	m.Logger.Infow("Creating chunks", "name", m.ID.Name, "variant", m.ID.Variant, "count", numChunks, "chunkSize", chunkSize)
 	config := &MaterializedChunkRunnerConfig{
 		OnlineType:     m.Online.Type(),
 		OfflineType:    m.Offline.Type(),
@@ -197,7 +197,13 @@ func (m MaterializeRunner) Run() (types.CompletionWatcher, error) {
 		m.Logger.Infow("Making Local Runner", "name", m.ID.Name, "variant", m.ID.Variant)
 		completionList := make([]types.CompletionWatcher, int(numChunks))
 		for i := 0; i < int(numChunks); i++ {
-			localRunner, err := Create(COPY_TO_ONLINE, serializedConfig)
+			m.Logger.Infow("Creating materialization chunk", "name", m.ID.Name, "variant", m.ID.Variant, "chunkIndex", i, "chunkSize", chunkSize)
+			config.ChunkIdx = int64(i)
+			serializedChunkConfig, err := config.Serialize()
+			if err != nil {
+				return nil, err
+			}
+			localRunner, err := Create(COPY_TO_ONLINE, serializedChunkConfig)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
# Description

This PR introduces a fix for a user-reported issue that identified that only 100K rows/entities were being materialized to the online store despite there being 500K records.

## Type of change

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
