### PR TITLE
Clean up helm charts (OSS)

### DIFF
--- a/charts/featureform/README.md
+++ b/charts/featureform/README.md
@@ -8,21 +8,26 @@
 - helm
 
 ### Create Cluster
+
 In the terraform/ directory, run:
-````
+
+```
 terraform init
 terraform apply
-````
+```
+
 ### Setup kubeconfig
+
 In the terraform/ directory, run:
 
-``aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)``
-
+`aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)`
 
 ### Install Certificate Manager
+
 `helm repo add jetstack https://charts.jetstack.io`
 
 `helm repo update`
+
 ```
 helm install certmgr jetstack/cert-manager \
     --set installCRDs=true \
@@ -32,25 +37,27 @@ helm install certmgr jetstack/cert-manager \
 ```
 
 ### Install featureform
+
 Go to ff/serving/charts and run:
 
-`helm install <NAME> ./featureform/ --set global.hostname=<DOMAIN_NAME>` 
+`helm install <NAME> ./charts/featureform/ --set hostname=<DOMAIN_NAME>`
 
 Where <DOMAIN_NAME> is the desired domain name that you own
 and <NAME> is your choice of name for the helm release
 
 ### Create DNS Record
+
 Run:
-``kubectl get ingress``
+`kubectl get ingress`
 
 and select the url in the "ADDRESS" field. Something like:
 xxxxxxxxxxxxxxxxxx-xxxxxxxxxx.us-east-1.elb.amazonaws.com
 
 Then create a cname record directing your <DOMAIN_NAME> to the ADDRESS in your domain provider
 
-Featureform with automatically create a public TLS certificate for your hostname. 
+Featureform with automatically create a public TLS certificate for your hostname.
 The status can be checked with
-``kubectl get certificate``
+`kubectl get certificate`
 
 ### Usage
 

--- a/charts/featureform/templates/backup.yaml
+++ b/charts/featureform/templates/backup.yaml
@@ -12,8 +12,8 @@ spec:
       template:
         spec:
           containers:
-            - image: "{{ .Values.global.repo | default .Values.image.repository }}/backup:{{ .Values.global.version | default .Chart.AppVersion }}"
-              imagePullPolicy: {{ .Values.global.pullPolicy }}
+            - image: "{{ .Values.repository | default .Values.image.repository }}/backup:{{ .Values.versionOverride | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.pullPolicy }}
               name: featureform-backup
               env:
                 - name: ETCD_HOSTNAME

--- a/charts/featureform/values.yaml
+++ b/charts/featureform/values.yaml
@@ -199,7 +199,7 @@ backup:
 # Logging:
 # For instructions to see the dashboard, check here:
 # https://artifacthub.io/packages/helm/grafana/loki-stack
-# To disable, do --set global.logging.enabled=false
+# To disable, do --set logging.enabled=false
 # To get the dashboard password, do: kubectl get secret  featureform-grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
 # To view dashboard, do: kubectl port-forward  service/featureform-grafana 3000:80
 # Go to localhost 3000. User is admin

--- a/docs/deployment/kubernetes.mdx
+++ b/docs/deployment/kubernetes.mdx
@@ -5,17 +5,17 @@ description: "This guide will walk through deploying Featureform on Kubernetes. 
 
 ## Prerequisites
 
-* An existing Kubernetes Cluster in AWS
+- An existing Kubernetes Cluster in AWS
 
-* A domain name that can be directed at the Featureform load balancer
+- A domain name that can be directed at the Featureform load balancer
 
 ## Step 1: Add Helm repos
 
 Add Certificate Manager and Featureform Helm Repos.
 
 ```
-helm repo add featureform https://storage.googleapis.com/featureform-helm/ 
-helm repo add jetstack https://charts.jetstack.io 
+helm repo add featureform https://storage.googleapis.com/featureform-helm/
+helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ```
 
@@ -45,18 +45,18 @@ helm install  featureform/featureform \
 
 ### Custom helm flags
 
-| Name                       | Description                                                                                                                                   | Default                 |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| hostname            | The hostname where the cluster will be accessible. Required to terminate the TLS certificate for GRPC.                                        | "localhost"             |
-| versionOverride             | The Docker container tag to pull. The default value is overwritten with the latest deployment version when pulling from artifacthub.          | "0.0.0"                 |
-| repository                | The Docker repo to pull the images from.                                                                                                      | "featureformcom"        |
-| pullPolicy          | The container pull policies.                                                                                                                  | "Always"                |
-| selfSignedCert           | Will create a self-signed certificate for the hostname. Either localCert or publicCert must be enabled if generating a certificate.            | "true"                  |
-| publicCert          | Whether to use a public TLS certificate or a self-signed one. If true, the public certificate is generated for the provided global.hostname.   | "false"                 |
-| tlsSecretName       | Will set the name of the TLS secret for the ingress to use if manually adding a certificate.                                                  | "featureform-ca-secret" |
+| Name            | Description                                                                                                                                   | Default                 |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| hostname        | The hostname where the cluster will be accessible. Required to terminate the TLS certificate for GRPC.                                        | "localhost"             |
+| versionOverride | The Docker container tag to pull. The default value is overwritten with the latest deployment version when pulling from artifacthub.          | "0.0.0"                 |
+| repository      | The Docker repo to pull the images from.                                                                                                      | "featureformcom"        |
+| pullPolicy      | The container pull policies.                                                                                                                  | "Always"                |
+| selfSignedCert  | Will create a self-signed certificate for the hostname. Either selfSignedCert or publicCert must be enabled if generating a certificate.      | "true"                  |
+| publicCert      | Whether to use a public TLS certificate or a self-signed one. If true, the public certificate is generated for the provided hostname.         | "false"                 |
+| tlsSecretName   | Will set the name of the TLS secret for the ingress to use if manually adding a certificate.                                                  | "featureform-ca-secret" |
 | k8sRunnerEnable | If true, uses a Kubernetes Job to run Featureform jobs. If false, Featureform jobs are run in the coordinator container in a separate thread. | "false"                 |
-| nginx.enabled       | Will install nginx along with Featureform if true.                                                                                            | "true"                  |
-| logging             | Will enable logging fluentbit, loki, and graphana within the cluster.                                                                         | "true"                  |
+| nginx.enabled   | Will install nginx along with Featureform if true.                                                                                            | "true"                  |
+| logging         | Will enable logging fluentbit, loki, and graphana within the cluster.                                                                         | "true"                  |
 
 ## Step 3: Domain routing
 

--- a/terraform/gcp/featureform/featureform.tf
+++ b/terraform/gcp/featureform/featureform.tf
@@ -5,13 +5,13 @@ provider "helm" {
 }
 
 resource "helm_release" "certmgr" {
-  name = "cert-mgr"
+  name      = "cert-mgr"
   namespace = "default"
-  version = var.cert_manager_version
+  version   = var.cert_manager_version
 
   repository = "https://charts.jetstack.io"
-  chart = "cert-manager"
-  
+  chart      = "cert-manager"
+
   set {
     name  = "installCRDs"
     value = "true"
@@ -19,29 +19,29 @@ resource "helm_release" "certmgr" {
 }
 
 resource "helm_release" "featureform" {
-  name = "featureform"
+  name      = "featureform"
   namespace = "default"
 
   repository = "https://storage.googleapis.com/featureform-helm/"
-  chart = "featureform"
-  
+  chart      = "featureform"
+
   set {
-    name  = "global.hostname"
+    name  = "hostname"
     value = var.featureform_hostname
   }
-  
+
   set {
-    name  = "global.publicCert"
+    name  = "publicCert"
     value = var.featureform_public_cert
   }
 
   set {
-    name = "global.publicCert"
+    name  = "publicCert"
     value = "false"
   }
 
   set {
-    name = "global.localCert"
+    name  = "selfSignedCert"
     value = "true"
   }
 


### PR DESCRIPTION
# Description

This PR scrubs the remaining `global` refs in the OSS helm charts that we missed. 

closes [ent-#872](https://github.com/featureform/featureform-enterprise/issues/872)

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
