### PR TITLE
Utilizing AWS Secret Manager to Pull Secrets

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -91,9 +91,28 @@ jobs:
           python-version: '3.10'
           cache: 'pip' # caching pip dependencies
 
-      - name: Check directory
-        run: |
-          ls -la
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_GITHUB_ROLE }}
+      
+      - name: Get AWS Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: ${{ secrets.AWS_SECRET_PREFIX }}/*
+          parse-json-secrets: true
+      
+      - name: Get Firestore Credentials
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: ${{ secrets.FIRESTORE_SECRET }}
+          parse-json-secrets: false
+
+      - name: Get BigQuery Credentials
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: ${{ secrets.BIGQUERY_JSON_SECRET }}
+          parse-json-secrets: false
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -138,14 +157,14 @@ jobs:
         uses: jsdaniell/create-json@1.1.2
         with:
           name: "./provider/firestore_credentials.json"
-          json: ${{ secrets.FIRESTORE_CREDENTIALS_FILE }}
+          json: ${{ env.${{ secrets.FIRESTORE_SECRET }} }}
 
       - name: create-json
         id: create-json-2
         uses: jsdaniell/create-json@1.1.2
         with:
           name: "./provider/bigquery_credentials.json"
-          json: ${{ secrets.BIGQUERY_CREDENTIALS_FILE }}
+          json: ${{ env.${{ secrets.BIGQUERY_CREDENTIALS_FILE }} }}
 
       - name: Check credentials location
         run: |

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,24 @@ test_filestore
 	Description:
 		Runs golang unit tests
 
+get_secrets
+	Requirements:
+		- python 3.7-3.10
+		- AWS Credentials with access to Secrets Manager
+		- boto3 > 1.34 (needs `SecretsManager.Client.batch_get_secret_value`)
+	
+	Description:
+		Gets secrets from AWS Secrets Manager and writes them to .env file in root of repository
+
+update_secrets
+	Requirements:
+		- python 3.7-3.10
+		- AWS Credentials with access to Secrets Manager
+		- boto3 > 1.34 (needs `SecretsManager.Client.batch_get_secret_value`)
+	
+	Description:
+		Updates secrets from AWS Secrets Manager and writes them to .env file in root of repository
+
 endef
 export HELP_BODY
 
@@ -398,3 +416,11 @@ reset_e2e:  			 			## Resets Cluster. Requires install_etcd
 	while ! echo exit | nc localhost 2379; do sleep 10; done
 	etcdctl --user=root:secretpassword del "" --prefix
 	-helm uninstall quickstart
+
+
+##############################################  SECRETS ################################################################
+get_secrets:
+	python scripts/secret_manager.py
+
+update_secrets:
+	python scripts/secret_manager.py --update

--- a/scripts/secret_manager.py
+++ b/scripts/secret_manager.py
@@ -1,0 +1,76 @@
+import os
+import json
+import argparse
+
+import boto3
+
+# Get Current Directory
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+PARENT_DIR = os.path.dirname(CURRENT_DIR)
+FILE_NAME = ".env"
+
+FILE_PATH = os.path.join(PARENT_DIR, FILE_NAME)
+
+
+def main(arg):
+    client = boto3.client("secretsmanager")
+    secrets_with_values = get_secrets_with_values(client)
+
+    if arg.update or not os.path.exists(FILE_PATH):
+        print(f"Writing secrets to {FILE_PATH}")
+        with open(FILE_PATH, "w") as f:
+            for key, value in secrets_with_values.items():
+                f.write(f"{key}={value}\n")
+    else:
+        print("File already exists. Use --update or make update_secrets to overwrite.")
+
+
+def get_secrets_with_values(client):
+    secrets = {}
+
+    next_token = ""
+    testing_only_secrets = [
+        {
+            "Key": "name",
+            "Values": [
+                "testing/",
+            ],
+        }
+    ]
+
+    while True:
+        if not next_token:
+            response = client.batch_get_secret_value(
+                Filters=testing_only_secrets,
+            )
+        else:
+            response = client.batch_get_secret_value(
+                Filters=testing_only_secrets,
+                NextToken=next_token,
+            )
+
+        for s in response["SecretValues"]:
+            secret_value = json.loads(s["SecretString"])
+            for key, value in secret_value.items():
+                secrets[key] = f'"{value}"'
+
+        next_token = response.get("NextToken", "")
+        if not next_token:
+            break
+
+    print(f"Found {len(secrets)} secrets")
+    return secrets
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(description="Featureform Secret Manager")
+    parser.add_argument(
+        "--update",
+        action="store_true",
+    )
+
+    return parser.parse_args(args)
+
+
+if __name__ == "__main__":
+    main(parse_args())


### PR DESCRIPTION
# Description
Going forward we will be able to leverage AWS Secret Manager to maintain a list of secrets that will be used both within CICD and locally. 

**Local**: 
To generate the `.env` file:
```
make get_secrets
```

To update the `.env` file:
```
make update_secrets
```

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
