### PR TITLE
Bugfix: Fixing issue with Go Integration Tests Failing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,3 @@
-#  Unit tests, integration tests, and code coverage
-
 name: Testing
 on:
   push:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,3 +1,5 @@
+#  Unit tests, integration tests, and code coverage
+
 name: Testing
 on:
   push:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,5 @@
-name: Testing
+# Unit tests, integration tests, and code coverage
+name: Testing  
 on:
   push:
     branches:
@@ -36,6 +37,7 @@ env:
   PINECONE_PROJECT_ID: ${{ secrets.PINECONE_PROJECT_ID }}
   PINECONE_ENVIRONMENT: ${{ secrets.PINECONE_ENVIRONMENT }}
   PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+
 
 jobs:
   go-tests:

--- a/provider/spark_test_utils.go
+++ b/provider/spark_test_utils.go
@@ -1,12 +1,14 @@
 package provider
 
 import (
+	"testing"
+
 	fs "github.com/featureform/filestore"
 	"github.com/featureform/helpers"
 	pc "github.com/featureform/provider/provider_config"
 	pt "github.com/featureform/provider/provider_type"
+	"github.com/google/uuid"
 	"github.com/joho/godotenv"
-	"testing"
 )
 
 func GetTestingBlobDatabricks(t *testing.T) *SparkOfflineStore {
@@ -39,6 +41,7 @@ func GetTestingS3Databricks(t *testing.T) *SparkOfflineStore {
 		Credentials:  awsCreds,
 		BucketRegion: helpers.GetEnv("S3_BUCKET_REGION", "us-east-2"),
 		BucketPath:   helpers.GetEnv("S3_BUCKET_PATH", "featureform-spark-testing"),
+		Path:         uuid.NewString(),
 	}
 	t.Logf("S3 CONFIG TestingS3Databricks: %+v\n", s3Config)
 	return getTestingDatabricks(t, s3Config, fs.S3)

--- a/provider/table_import_test.go
+++ b/provider/table_import_test.go
@@ -96,7 +96,7 @@ func TestImportableOnlineStore(t *testing.T) {
 			},
 			BucketRegion: checkEnv("S3_BUCKET_REGION"),
 			BucketPath:   checkEnv("S3_BUCKET_PATH"),
-			Path:         "importable_online_store_test",
+			Path:         uuid.NewString(),
 		}
 
 		return &pc.SparkConfig{

--- a/provider/table_import_test.go
+++ b/provider/table_import_test.go
@@ -96,7 +96,7 @@ func TestImportableOnlineStore(t *testing.T) {
 			},
 			BucketRegion: checkEnv("S3_BUCKET_REGION"),
 			BucketPath:   checkEnv("S3_BUCKET_PATH"),
-			Path:         "",
+			Path:         "importable_online_store_test",
 		}
 
 		return &pc.SparkConfig{


### PR DESCRIPTION
# Description
There is an issue with the different in the pyspark script arguments between enterprise and oss. In order to fix it, we will have to update the args. 

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
