### PR TITLE
Add ArgoCD and Argo Rollout capabilities to charts

### DIFF
--- a/charts/featureform/templates/api-server/rollout.yaml
+++ b/charts/featureform/templates/api-server/rollout.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.argo.rollouts.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: featureform-api-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: featureform-api-server
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: featureform-api-server
+    scaleDown: onsuccess
+  strategy:
+    blueGreen:
+      activeService: featureform-api-server
+      autoPromotionEnabled: false
+{{ end }}

--- a/charts/featureform/templates/api-server/rollout.yaml
+++ b/charts/featureform/templates/api-server/rollout.yaml
@@ -1,3 +1,10 @@
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#  Copyright 2024 FeatureForm Inc.
+#
+
 {{ if .Values.argo.rollouts.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/charts/featureform/templates/coordinator/rollout.yaml
+++ b/charts/featureform/templates/coordinator/rollout.yaml
@@ -1,3 +1,10 @@
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#  Copyright 2024 FeatureForm Inc.
+#
+
 {{ if .Values.argo.rollouts.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/charts/featureform/templates/coordinator/rollout.yaml
+++ b/charts/featureform/templates/coordinator/rollout.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.argo.rollouts.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: featureform-coordinator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: featureform-coordinator
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: featureform-coordinator
+    scaleDown: onsuccess
+  strategy:
+    blueGreen:
+      activeService: featureform-coordinator
+      autoPromotionEnabled: false
+{{ end }}

--- a/charts/featureform/templates/dashboard-metadata/rollout.yaml
+++ b/charts/featureform/templates/dashboard-metadata/rollout.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.argo.rollouts.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: featureform-dashboard-metadata
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: featureform-dashboard-metadata
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: featureform-dashboard-metadata
+    scaleDown: onsuccess
+  strategy:
+    blueGreen:
+      activeService: featureform-dashboard-metadata
+      autoPromotionEnabled: false
+{{ end }}

--- a/charts/featureform/templates/dashboard-metadata/rollout.yaml
+++ b/charts/featureform/templates/dashboard-metadata/rollout.yaml
@@ -1,3 +1,10 @@
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#  Copyright 2024 FeatureForm Inc.
+#
+
 {{ if .Values.argo.rollouts.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/charts/featureform/templates/dashboard/rollout.yaml
+++ b/charts/featureform/templates/dashboard/rollout.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.argo.rollouts.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: featureform-dashboard
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: featureform-dashboard
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: featureform-dashboard
+    scaleDown: onsuccess
+  strategy:
+    blueGreen:
+      activeService: featureform-dashboard
+      autoPromotionEnabled: false
+{{ end }}

--- a/charts/featureform/templates/dashboard/rollout.yaml
+++ b/charts/featureform/templates/dashboard/rollout.yaml
@@ -1,3 +1,10 @@
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#  Copyright 2024 FeatureForm Inc.
+#
+
 {{ if .Values.argo.rollouts.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/charts/featureform/templates/feature-server/rollout.yaml
+++ b/charts/featureform/templates/feature-server/rollout.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.argo.rollouts.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: featureform-feature-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: featureform-feature-server
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: featureform-feature-server
+    scaleDown: onsuccess
+  strategy:
+    blueGreen:
+      activeService: featureform-feature-server
+      autoPromotionEnabled: false
+{{ end }}

--- a/charts/featureform/templates/feature-server/rollout.yaml
+++ b/charts/featureform/templates/feature-server/rollout.yaml
@@ -1,3 +1,10 @@
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#  Copyright 2024 FeatureForm Inc.
+#
+
 {{ if .Values.argo.rollouts.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/charts/featureform/templates/ingress/argo.yaml
+++ b/charts/featureform/templates/ingress/argo.yaml
@@ -1,0 +1,13 @@
+# This is necessary because ingress doesn't work across namespaces boundaries,
+# so we need a bridge from the application to the argo namespace.
+{{ if .Values.argo.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: argo-svc-bridge
+spec:
+  type: ExternalName
+  externalName: argo-argocd-server.argo
+  ports:
+    - port: 80
+{{ end }}

--- a/charts/featureform/templates/ingress/grpc-ingress.yaml
+++ b/charts/featureform/templates/ingress/grpc-ingress.yaml
@@ -43,11 +43,16 @@ spec:
                 name: featureform-api-server
                 port:
                   number: {{ .Values.grpcIngressPort }}
-
-
-
+          {{- if .Values.argo.enabled }}
+          - path: /argocd/
+            pathType: Prefix
+            backend:
+              service:
+                name: argo-svc-bridge
+                port:
+                  name: https
+          {{- end }}
   tls:
     - hosts:
         -  {{ .Values.hostname }}
       secretName: {{ .Values.tlsSecretName }}
-

--- a/charts/featureform/templates/ingress/http-ingress.yaml
+++ b/charts/featureform/templates/ingress/http-ingress.yaml
@@ -58,6 +58,15 @@ spec:
                 name: featureform-api-server
                 port:
                   number: 8443
+          {{- if .Values.argo.enabled }}
+          - path: /argocd/
+            pathType: Prefix
+            backend:
+              service:
+                name: argo-svc-bridge
+                port:
+                  number: 80
+          {{- end }}
           - path: /
             pathType: Prefix
             backend:

--- a/charts/featureform/templates/metadata/rollout.yaml
+++ b/charts/featureform/templates/metadata/rollout.yaml
@@ -1,3 +1,10 @@
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#  Copyright 2024 FeatureForm Inc.
+#
+
 {{ if .Values.argo.rollouts.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/charts/featureform/templates/metadata/rollout.yaml
+++ b/charts/featureform/templates/metadata/rollout.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.argo.rollouts.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: featureform-metadata-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: featureform-metadata-server
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: featureform-metadata-server
+    scaleDown: onsuccess
+  strategy:
+    blueGreen:
+      activeService: featureform-metadata-server
+      autoPromotionEnabled: false
+{{ end }}

--- a/charts/featureform/templates/prometheus/rollout.yaml
+++ b/charts/featureform/templates/prometheus/rollout.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.argo.rollouts.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: featureform-prometheus-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: featureform-prometheus-server
+  workloadRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: featureform-prometheus-deployment
+    scaleDown: onsuccess
+  strategy:
+    blueGreen:
+      activeService: featureform-prometheus-service
+      autoPromotionEnabled: false
+{{ end }}

--- a/charts/featureform/templates/prometheus/rollout.yaml
+++ b/charts/featureform/templates/prometheus/rollout.yaml
@@ -1,3 +1,10 @@
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#  Copyright 2024 FeatureForm Inc.
+#
+
 {{ if .Values.argo.rollouts.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout

--- a/charts/featureform/values.yaml
+++ b/charts/featureform/values.yaml
@@ -57,6 +57,16 @@ dashboardUrl: ""
 # If true, restarts pods on update even if no changes have been made
 restartOnUpdate: false
 
+argo:
+  # Enables path forwarding of /argocd/ to the Argo web server. Note this still requires installation of Argo,
+  # done outside of this chart itself as it is a global service across the cluster.
+  enabled: false
+
+  rollouts:
+    # Enables the creation of Rollout objects for all of the different deployments, to be used as part
+    # of Argo Rollouts CD. Must have Argo Rollouts installed on the cluster.
+    enabled: false
+
 logging:
   # When enabled, will use the loki stack for logging
   enabled: true


### PR DESCRIPTION
Adds Argo Rollout files, which are the Argo equivalent of Deployments. These are required in order to use the capabilities of Argo rollouts.

Additionally, adds configuration so that /argocd/ can be forwarded to the Argo web server.

Note that installing ArgoCD and Argo Rollouts on the cluster is a prerequisite for these to work, since these are cluster-wide dependencies (this can be done through the infrastructure repo, through the use of Terraform modules that provision it).

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
