### PR TITLE
Cleanup cert management in Helm charts

### DIFF
--- a/charts/featureform/templates/ingress/certificate.yaml
+++ b/charts/featureform/templates/ingress/certificate.yaml
@@ -5,15 +5,15 @@
 #  Copyright 2024 FeatureForm Inc.
 #
 
-{{ if .Values.publicCert }}
+{{ if .Values.cert.publicCert }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .Release.Name }}-featureform-prod
+  name: {{ .Release.Name }}-featureform
 spec:
-  secretName: featureform-ca-secret
+  secretName: {{ .Values.cert.tlsSecretName }}
   issuerRef:
-    name: letsencrypt-prod
+    name: letsencrypt
   dnsNames:
     - {{ .Values.hostname }}
 {{ end }}

--- a/charts/featureform/templates/ingress/http-ingress.yaml
+++ b/charts/featureform/templates/ingress/http-ingress.yaml
@@ -15,12 +15,16 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/proxy-body-size: 64ms
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    cert-manager.io/issuer: letsencrypt-prod
+    cert-manager.io/issuer: letsencrypt
     {{ if eq .Values.embeddedIngress.enabled false }}
     kots.io/exclude: "true"
     {{ end }}
   name: http-ingress
 spec:
+  tls:
+    - hosts:
+        -  {{ .Values.hostname }}
+      secretName: {{ .Values.cert.tlsSecretName }}
   defaultBackend:
     service:
       name: featureform-dashboard
@@ -65,6 +69,3 @@ spec:
                 name: featureform-dashboard
                 port:
                   number: 80
-
-
-

--- a/charts/featureform/templates/ingress/issuer.yaml
+++ b/charts/featureform/templates/ingress/issuer.yaml
@@ -5,14 +5,19 @@
 #  Copyright 2024 FeatureForm Inc.
 #
 
-{{ if .Values.publicCert }}
+{{ if .Values.cert.publicCert }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: letsencrypt-prod
+  name: letsencrypt
 spec:
   acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
+    server: {{
+              ternary
+              "https://acme-v02.api.letsencrypt.org/directory"
+              "https://acme-staging-v02.api.letsencrypt.org/directory"
+              .Values.cert.letsencryptProd
+            }}
     email: sterling@featureform.com
     privateKeySecretRef:
       name: account-key-prod

--- a/charts/featureform/templates/ingress/localhostcert.yaml
+++ b/charts/featureform/templates/ingress/localhostcert.yaml
@@ -5,22 +5,22 @@
 #  Copyright 2024 FeatureForm Inc.
 #
 
-{{ if .Values.selfSignedCert }}
+{{ if .Values.cert.selfSignedCert }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: letsencrypt-prod
+  name: letsencrypt
 spec:
   selfSigned: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: featureform-ca-cert
+  name: {{ .Values.cert.tlsSecretName }}
 spec:
   secretName: featureform-ca
   dnsNames:
     - {{ .Values.hostname }}
   issuerRef:
-    name: letsencrypt-prod
+    name: letsencrypt
 {{ end }}

--- a/charts/featureform/values.yaml
+++ b/charts/featureform/values.yaml
@@ -20,16 +20,25 @@ repository: "featureformenterprise"
 # Global pull policy
 pullPolicy: "Always"
 
-# If a public certificate should be generated automatically through lets encrypt and used
-publicCert: false
+cert:
+  # If a public certificate should be generated automatically through lets encrypt and used
+  publicCert: false
 
-# Will automatically create a self-signed cert that can be used if enabled
-selfSignedCert: true
+  # Will automatically create a self-signed cert that can be used if enabled
+  selfSignedCert: true
 
-# Note: If post publicCert and selfSignedCert are disabled, an existing certificate will need to be supplied
+  # Whether to use the prod letsencrypt endpoint or the staging. The production endpoint returns
+  # certificates that are trusted be well-known Certificate Authorities, however they have a low
+  # request limit (approximately 5 / week at the time of writing). During testing of infrastructure,
+  # this might be too low, so they also have a staging endpoint, with a much higher limit, but
+  # by default they're not trusted by any well-known CA (but you can add the certs manually).
+  # See https://letsencrypt.org/docs/staging-environment/
+  letsencryptProd: true
 
-# Name of the certificate
-tlsSecretName: "featureform-ca-secret"
+  # Note: If post publicCert and selfSignedCert are disabled, an existing certificate will need to be supplied
+
+  # Name of the certificate
+  tlsSecretName: "featureform-ca-secret"
 
 # If enabled, will run jobs on individual pods instead of in a coordinator thread
 k8sRunnerEnable: false


### PR DESCRIPTION
Cleanup some of the cert management around the Helm charts. This includes:

- Removing hardcoded secret names (and use the previously defined one in config)
- Add config for the endpoint of Let's Encrypt that we want to target, for testing infrastructure purposes
- Grouping cert configs together.

Note: These changes require backwards incompatible changes (as we are changing the location of some of the configuration values to group them together). If we feel like this would be an unnecessary burden, we can change back the location of the configuration values and leave the rest of the changes.

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Cleanup
# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
