### PR TITLE
Temp. set codecov github_check to `false`

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-github_checks: true
+github_checks: false
 codecov:
   branch: main
   require_ci_to_pass: true

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -12,6 +12,7 @@
 ### Select type(s) of change
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Chore (non-breaking change that modifies some code)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update


### PR DESCRIPTION

# Description

This PR sets the codecov `github_check` to `false` until we better define our coverage strategy in open-source. 

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
