### PR TITLE
Feature: adds session_params to Snowflake config

### DIFF
--- a/client/src/featureform/client.py
+++ b/client/src/featureform/client.py
@@ -15,7 +15,7 @@ from pyiceberg.table import Table
 from typeguard import typechecked
 
 from .constants import NO_RECORD_LIMIT
-from .enums import FileFormat, DataResourceType
+from .enums import FileFormat, DataResourceType, RefreshMode, Initialize
 from .proto import metadata_pb2 as pb
 from .register import (
     FeatureColumnResource,
@@ -879,6 +879,7 @@ class Client(ResourceClient, ServingClient):
             role=deserialized_config["Role"],
             organization=deserialized_config["Organization"],
             catalog=catalog,
+            session_params=deserialized_config["SessionParams"]
         )
 
         offline_provider = self.__create_provider(

--- a/client/src/featureform/enums.py
+++ b/client/src/featureform/enums.py
@@ -322,3 +322,47 @@ class Initialize(Enum):
             raise ValueError(f"Initialize value not supported: {value}")
         except AttributeError:
             raise ValueError(f"Initialize value required: received {value}")
+
+
+class SnowflakeSessionParamKey(Enum):
+    ABORT_DETACHED_QUERY = "abort_detached_query"
+    AUTOCOMMIT = "autocommit"
+    BINARY_INPUT_FORMAT = "binary_input_format"
+    BINARY_OUTPUT_FORMAT = "binary_output_format"
+    DATE_INPUT_FORMAT = "date_input_format"
+    DATE_OUTPUT_FORMAT = "date_output_format"
+    ERROR_ON_NONDETERMINISTIC_MERGE = "error_on_nondeterministic_merge"
+    ERROR_ON_NONDETERMINISTIC_UPDATE = "error_on_nondeterministic_update"
+    GEOGRAPHY_OUTPUT_FORMAT = "geography_output_format"
+    HYBRID_TABLE_LOCK_TIMEOUT = "hybrid_table_lock_timeout"
+    JSON_INDENT = "json_indent"
+    LOG_LEVEL = "log_level"
+    LOCK_TIMEOUT = "lock_timeout"
+    QUERY_TAG = "query_tag"
+    ROWS_PER_RESULTSET = "rows_per_resultset"
+    S3_STAGE_VPCE_DNS_NAME = "s3_stage_vpce_dns_name"
+    SEARCH_PATH = "search_path"
+    SIMULATED_DATA_SHARING_CONSUMER = "simulated_data_sharing_consumer"
+    STATEMENT_TIMEOUT_IN_SECONDS = "statement_timeout_in_seconds"
+    STRICT_JSON_OUTPUT = "strict_json_output"
+    TIMESTAMP_DAY_IS_ALWAYS_24H = "timestamp_day_is_always_24h"
+    TIMESTAMP_INPUT_FORMAT = "timestamp_input_format"
+    TIMESTAMP_LTZ_OUTPUT_FORMAT = "timestamp_ltz_output_format"
+    TIMESTAMP_NTZ_OUTPUT_FORMAT = "timestamp_ntz_output_format"
+    TIMESTAMP_OUTPUT_FORMAT = "timestamp_output_format"
+    TIMESTAMP_TYPE_MAPPING = "timestamp_type_mapping"
+    TIMESTAMP_TZ_OUTPUT_FORMAT = "timestamp_tz_output_format"
+    TIMEZONE = "timezone"
+    TIME_INPUT_FORMAT = "time_input_format"
+    TIME_OUTPUT_FORMAT = "time_output_format"
+    TRACE_LEVEL = "trace_level"
+    TRANSACTION_DEFAULT_ISOLATION_LEVEL = "transaction_default_isolation_level"
+    TWO_DIGIT_CENTURY_START = "two_digit_century_start"
+    UNSUPPORTED_DDL_ACTION = "unsupported_ddl_action"
+    USE_CACHED_RESULT = "use_cached_result"
+    WEEK_OF_YEAR_POLICY = "week_of_year_policy"
+    WEEK_START = "week_start"
+
+    @classmethod
+    def validate_key(cls, key: str) -> bool:
+        return key.lower() in cls._value2member_map_

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -3382,6 +3382,7 @@ class Registrar:
         tags: List[str] = [],
         properties: dict = {},
         catalog: Optional[SnowflakeCatalog] = None,
+        session_params: Optional[Dict[str, str]] = None
     ):
         """Register a Snowflake provider.
 
@@ -3428,6 +3429,7 @@ class Registrar:
             warehouse=warehouse,
             role=role,
             catalog=catalog,
+            session_params=session_params,
         )
         provider = Provider(
             name=name,

--- a/provider/connection/connection_configs.json
+++ b/provider/connection/connection_configs.json
@@ -98,7 +98,8 @@
     "Database": "",
     "Warehouse": "warehouse",
     "Role": "role",
-    "Catalog": null
+    "Catalog": null,
+    "SessionParams": null
   },
   "SnowflakeConfigDynamicTables": {
     "Username": "username",
@@ -119,7 +120,8 @@
         "RefreshMode": "AUTO",
         "Initialize": "ON_CREATE"
       }
-    }
+    },
+    "SessionParams": null
   },
   "MysqlConfig": {
     "Host": "host",

--- a/provider/provider_config/snowflake_config_test.go
+++ b/provider/provider_config/snowflake_config_test.go
@@ -16,12 +16,13 @@ import (
 
 func TestSnowflakeConfigMutableFields(t *testing.T) {
 	expected := ss.StringSet{
-		"Username":  true,
-		"Password":  true,
-		"Role":      true,
-		"Schema":    true,
-		"Database":  true,
-		"Warehouse": true,
+		"Username":      true,
+		"Password":      true,
+		"Role":          true,
+		"Schema":        true,
+		"Database":      true,
+		"Warehouse":     true,
+		"SessionParams": true,
 	}
 
 	config := SnowflakeConfig{
@@ -88,6 +89,7 @@ func TestSnowflakeConfigDifferingFields(t *testing.T) {
 				Schema:         "fraud",
 				Warehouse:      "ff_wh_xs",
 				Role:           "sysadmin",
+				SessionParams:  map[string]string{"query_tag": "featureform"},
 			},
 			b: SnowflakeConfig{
 				Username:       "fformer2",
@@ -99,12 +101,14 @@ func TestSnowflakeConfigDifferingFields(t *testing.T) {
 				Schema:         "fraud",
 				Warehouse:      "ff_wh_xs",
 				Role:           "featureformerrole",
+				SessionParams:  map[string]string{"query_tag": "ff"},
 			},
 		}, ss.StringSet{
-			"Username": true,
-			"Password": true,
-			"Role":     true,
-			"Database": true,
+			"Username":      true,
+			"Password":      true,
+			"Role":          true,
+			"Database":      true,
+			"SessionParams": true,
 		}},
 	}
 
@@ -142,7 +146,7 @@ func TestSnowflakeConfigSerializationDeserialization(t *testing.T) {
 			Warehouse:      "ff_wh_xs",
 			Role:           "sysadmin",
 			Catalog:        nil,
-		}, []byte(`{"Username":"featureformer","Password":"password","AccountLocator":"xy12345.snowflakecomputing.com","Organization":"featureform","Account":"featureform-test","Database":"transactions_db","Schema":"fraud","Warehouse":"ff_wh_xs","Role":"sysadmin","Catalog":null}`)},
+		}, []byte(`{"Username":"featureformer","Password":"password","AccountLocator":"xy12345.snowflakecomputing.com","Organization":"featureform","Account":"featureform-test","Database":"transactions_db","Schema":"fraud","Warehouse":"ff_wh_xs","Role":"sysadmin","Catalog":null,"SessionParams":null}`)},
 		{"With Catalog", SnowflakeConfig{
 			Username:       "featureformer",
 			Password:       "password",
@@ -162,7 +166,28 @@ func TestSnowflakeConfigSerializationDeserialization(t *testing.T) {
 					Initialize:  "initialize",
 				},
 			},
-		}, []byte(`{"Username":"featureformer","Password":"password","AccountLocator":"xy12345.snowflakecomputing.com","Organization":"featureform","Account":"featureform-test","Database":"transactions_db","Schema":"fraud","Warehouse":"ff_wh_xs","Role":"sysadmin","Catalog":{"ExternalVolume":"external_volume","BaseLocation":"base_location","TableConfig":{"TargetLag":"target_lag","RefreshMode":"refresh_mode","Initialize":"initialize"}}}`)},
+		}, []byte(`{"Username":"featureformer","Password":"password","AccountLocator":"xy12345.snowflakecomputing.com","Organization":"featureform","Account":"featureform-test","Database":"transactions_db","Schema":"fraud","Warehouse":"ff_wh_xs","Role":"sysadmin","Catalog":{"ExternalVolume":"external_volume","BaseLocation":"base_location","TableConfig":{"TargetLag":"target_lag","RefreshMode":"refresh_mode","Initialize":"initialize"}},"SessionParams":null}`)},
+		{"With Catalog And Session Params", SnowflakeConfig{
+			Username:       "featureformer",
+			Password:       "password",
+			AccountLocator: "xy12345.snowflakecomputing.com",
+			Organization:   "featureform",
+			Account:        "featureform-test",
+			Database:       "transactions_db",
+			Schema:         "fraud",
+			Warehouse:      "ff_wh_xs",
+			Role:           "sysadmin",
+			Catalog: &SnowflakeCatalogConfig{
+				ExternalVolume: "external_volume",
+				BaseLocation:   "base_location",
+				TableConfig: SnowflakeTableConfig{
+					TargetLag:   "target_lag",
+					RefreshMode: "refresh_mode",
+					Initialize:  "initialize",
+				},
+			},
+			SessionParams: map[string]string{"query_tag": "featureform"},
+		}, []byte(`{"Username":"featureformer","Password":"password","AccountLocator":"xy12345.snowflakecomputing.com","Organization":"featureform","Account":"featureform-test","Database":"transactions_db","Schema":"fraud","Warehouse":"ff_wh_xs","Role":"sysadmin","Catalog":{"ExternalVolume":"external_volume","BaseLocation":"base_location","TableConfig":{"TargetLag":"target_lag","RefreshMode":"refresh_mode","Initialize":"initialize"}},"SessionParams":{"query_tag":"featureform"}}`)},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

This PR introduces the ability for users to provider [session parameters](https://docs.snowflake.com/en/sql-reference/sql/alter-session) to a Snowflake provider to ensure these params are set when establishing a connection (e.g. `query_tag`).

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts
