### PR TITLE
Add support for Goose migrations

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -395,6 +395,42 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  db_migration:
+    name: Build DB Migration Job
+    environment: Deployment
+    defaults:
+      run:
+        working-directory: ./
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set production tag
+        run: ./.github/helpers/set_release_type.sh ${{ inputs.type }} $GITHUB_ENV ${{ inputs.version }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and export
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./db/Dockerfile
+          tags: featureformcom/db_migration:${{ env.TAG }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+
   helm:
     name: Package Helm
     environment: Deployment

--- a/Makefile
+++ b/Makefile
@@ -565,6 +565,7 @@ minikube_build_images: gen_grpc   ## Build Docker images for Minikube
 	minikube image build -f ./provider/scripts/k8s/Dockerfile -t local/k8s_runner:stable . & \
 	minikube image build -f ./provider/scripts/k8s/Dockerfile.scikit -t local/k8s_runner:stable-scikit . & \
 	minikube image build -f ./search_loader/Dockerfile -t local/search-loader:stable . & \
+	minikube image build -f ./db/Dockerfile -t local/db_migration:stable . & \
 	wait; \
 	echo "Build Complete"
 

--- a/charts/featureform/templates/db/upgrade.yaml
+++ b/charts/featureform/templates/db/upgrade.yaml
@@ -28,5 +28,8 @@ spec:
             - name: GOOSE_DRIVER
               value: postgres
             - name: GOOSE_DBSTRING
-              value: postgres://{{ .Values.psql.user }}:{{ .Values.psql.password }}@{{ .Values.psql.host }}:{{ .Values.psql.port }}/{{ .Values.psql.db }}
+              valueFrom:
+                secretKeyRef:
+                  name: psql-secret-literal
+                  key: connection-string
 {{ end }}

--- a/charts/featureform/templates/db/upgrade.yaml
+++ b/charts/featureform/templates/db/upgrade.yaml
@@ -22,7 +22,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: db-migration-up
-          image: "{{ .Values.repository | default .Values.repository }}/{{ .Values.psql.migration.image.name }}:{{ .Values.versionOverride | default .Chart.AppVersion }}"
+          image: "{{ .Values.repository }}/{{ .Values.psql.migration.image.name }}:{{ .Values.versionOverride | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.pullPolicy }}
           env:
             - name: GOOSE_DRIVER

--- a/charts/featureform/templates/db/upgrade.yaml
+++ b/charts/featureform/templates/db/upgrade.yaml
@@ -1,0 +1,32 @@
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#  Copyright 2024 FeatureForm Inc.
+#
+
+{{ if eq .Values.stateProvider "psql" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: featureform-db-migration-up
+  labels:
+    chart: featureform
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: db-migration-up
+          image: "{{ .Values.repository | default .Values.repository }}/{{ .Values.psql.migration.image.name }}:{{ .Values.versionOverride | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.pullPolicy }}
+          env:
+            - name: GOOSE_DRIVER
+              value: postgres
+            - name: GOOSE_DBSTRING
+              value: postgres://{{ .Values.psql.user }}:{{ .Values.psql.password }}@{{ .Values.psql.host }}:{{ .Values.psql.port }}/{{ .Values.psql.db }}
+{{ end }}

--- a/charts/featureform/templates/secrets/postgres.yaml
+++ b/charts/featureform/templates/secrets/postgres.yaml
@@ -10,8 +10,13 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: psql-secret-literal
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    # Needed to ensure this is created before the DB migration pre-install job.
+    "helm.sh/hook-weight": "-6"
 type: kubernetes.io/basic-auth
 stringData:
   user: {{ .Values.psql.user | quote }}
   password: {{ .Values.psql.password | quote }}
+  connection-string: "postgres://{{ .Values.psql.user }}:{{ .Values.psql.password | urlquery }}@{{ .Values.psql.host }}:{{ .Values.psql.port }}/{{ .Values.psql.db }}"
 {{ end }}

--- a/charts/featureform/values.yaml
+++ b/charts/featureform/values.yaml
@@ -104,6 +104,9 @@ psql:
   # If true, automatically creates a secret stored in templates/secrets/postgres.yaml.
   # If false, does not apply the template. The template can be created manually
   createSecret: false
+  migration:
+    image:
+      name: db-migration-up
 
 # search loader job
 searchjob:

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -11,7 +11,8 @@ ENV GOOSE_DBSTRING='postgres://postgres:password@localhost:5432/postgres?sslmode
 
 WORKDIR /db
 
-COPY --from=builder ./app/goose ./
-COPY ./migrations ./migrations
+COPY --from=builder ./app/goose ./goose
+COPY ./db/entrypoint.sh ./entrypoint.sh
+COPY ./db/migrations ./migrations
 
-ENTRYPOINT ["./goose", "up", "-dir", "./migrations"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.21 AS builder
+
+WORKDIR /app
+
+RUN GOBIN=/app go install github.com/pressly/goose/v3/cmd/goose@v3.23.0
+
+FROM ubuntu:22.04
+
+ENV GOOSE_DRIVER=postgres
+ENV GOOSE_DBSTRING='postgres://postgres:password@localhost:5432/postgres?sslmode=disable'
+
+WORKDIR /db
+
+COPY --from=builder ./app/goose ./
+COPY ./migrations ./migrations
+
+ENTRYPOINT ["./goose", "up", "-dir", "./migrations"]

--- a/db/entrypoint.sh
+++ b/db/entrypoint.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
+
+# Ensure goose binary is available
+if ! command -v ./goose &> /dev/null; then
+    echo "Error: goose binary not found in current directory" >&2
+    exit 1
+fi
+
+echo "Starting database migration..."
 
 if [ -z "${MIGRATION_VERSION}" ]; then
+  echo "No specific version specified, migrating to latest version"
   ./goose up -dir ./migrations
 else
+  echo "Migrating to version: ${MIGRATION_VERSION}"
   ./goose up-to "${MIGRATION_VERSION}" -dir ./migrations
 fi
+
+echo "Migration completed successfully"

--- a/db/entrypoint.sh
+++ b/db/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "${MIGRATION_VERSION}" ]; then
+  ./goose up -dir ./migrations
+else
+  ./goose up-to "${MIGRATION_VERSION}" -dir ./migrations
+fi

--- a/db/entrypoint.sh
+++ b/db/entrypoint.sh
@@ -10,7 +10,7 @@ fi
 
 echo "Starting database migration..."
 
-if [ -z "${MIGRATION_VERSION}" ]; then
+if [ -z "${MIGRATION_VERSION:-}" ]; then
   echo "No specific version specified, migrating to latest version"
   ./goose up -dir ./migrations
 else


### PR DESCRIPTION
# Description

- Adds a new folder where we'll store db migrations.
- Create a Dockerfile with an image that can be run as a job to 'up' migrate the db.
- Creates Helm pre-install, pre-upgrade hooks for this new image.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that modifies some code)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a database migration tool integrated into the deployment process for PostgreSQL.
	- Added a new configuration for specifying the migration image in the Helm chart.
	- Enhanced management of PostgreSQL credentials with a connection string in Kubernetes Secrets.
	- Added a new job in the GitHub Actions workflow for building Docker images for database migrations.
	- New Minikube-related commands for building and managing Docker images.

- **Chores**
	- Created a Dockerfile for the database migration tool using Goose.
	- Configured a Kubernetes Job for executing database migrations during deployment phases.
	- Added an entrypoint script for managing database migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->