### PR TITLE
Correctness: adds validation for common entity between label and features 

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1391,7 +1391,7 @@ func (resource *trainingSetVariantResource) Validate(ctx context.Context, lookup
 		case pb.ComputationMode_CLIENT_COMPUTED:
 			return fferr.NewInvalidArgumentErrorf("feature %s has unsupported computation mode %s", feature.Name, featureVariant.serialized.Mode)
 		default:
-			return fferr.NewInternalError(fmt.Errorf("feature %s has unknown computation mode %s", feature.Name, featureVariant.serialized.Mode))
+			return fferr.NewInternalErrorf("feature %s has unknown computation mode %s", feature.Name, featureVariant.serialized.Mode)
 		}
 	}
 	return nil

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1364,6 +1364,39 @@ func (resource *trainingSetVariantResource) Owner() string {
 	return resource.serialized.Owner
 }
 
+func (resource *trainingSetVariantResource) Validate(ctx context.Context, lookup ResourceLookup) error {
+	label, err := lookup.Lookup(ctx, ResourceID{Name: resource.serialized.Label.Name, Variant: resource.serialized.Label.Variant, Type: LABEL_VARIANT})
+	if err != nil {
+		return err
+	}
+	labelVariant, isLabelVariant := label.(*labelVariantResource)
+	if !isLabelVariant {
+		return fferr.NewDatasetNotFoundError(resource.ID().Name, resource.ID().Variant, fmt.Errorf("label variant not found"))
+	}
+	entityMap := map[string]struct{}{labelVariant.serialized.Entity: {}}
+	for _, feature := range resource.serialized.Features {
+		featureResource, err := lookup.Lookup(ctx, ResourceID{Name: feature.Name, Variant: feature.Variant, Type: FEATURE_VARIANT})
+		if err != nil {
+			return err
+		}
+		featureVariant, isFeatureVariant := featureResource.(*featureVariantResource)
+		if !isFeatureVariant {
+			return fferr.NewDatasetNotFoundError(feature.Name, feature.Variant, fmt.Errorf("feature variant not found"))
+		}
+		switch featureVariant.serialized.Mode {
+		case pb.ComputationMode_PRECOMPUTED:
+			if _, exists := entityMap[featureVariant.serialized.Entity]; !exists {
+				return fferr.NewInvalidArgumentErrorf("feature %s entity %s does not match label entity %s", feature.Name, featureVariant.serialized.Entity, labelVariant.serialized.Entity)
+			}
+		case pb.ComputationMode_CLIENT_COMPUTED:
+			return fferr.NewInvalidArgumentErrorf("feature %s has unsupported computation mode %s", feature.Name, featureVariant.serialized.Mode)
+		default:
+			return fferr.NewInternalError(fmt.Errorf("feature %s has unknown computation mode %s", feature.Name, featureVariant.serialized.Mode))
+		}
+	}
+	return nil
+}
+
 type modelResource struct {
 	serialized *pb.Model
 }
@@ -2261,6 +2294,10 @@ func (serv *MetadataServer) CreateTrainingSetVariant(ctx context.Context, varian
 	logger.Info("Creating TrainingSet Variant")
 
 	variant := variantRequest.TrainingSetVariant
+	tsRes := &trainingSetVariantResource{variant}
+	if err := tsRes.Validate(ctx, serv.lookup); err != nil {
+		return nil, err
+	}
 	variant.Created = tspb.New(time.Now())
 	taskTarget := scheduling.NameVariant{Name: variant.Name, Variant: variant.Variant, ResourceType: TRAINING_SET_VARIANT.String()}
 	task, err := serv.taskManager.CreateTask("mytask", scheduling.ResourceCreation, taskTarget)
@@ -2268,7 +2305,8 @@ func (serv *MetadataServer) CreateTrainingSetVariant(ctx context.Context, varian
 		return nil, err
 	}
 	variant.TaskIdList = []string{task.ID.String()}
-	return serv.genericCreate(ctx, &trainingSetVariantResource{variant}, func(name, variant string) Resource {
+
+	return serv.genericCreate(ctx, tsRes, func(name, variant string) Resource {
 		return &trainingSetResource{
 			&pb.TrainingSet{
 				Name:           name,


### PR DESCRIPTION
# Description

This PR introduces validation for training set creation that enforces that a label and its features share a common entity.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced validation for training set variants to ensure correct configuration of label and feature variants.
  - Added validation checks to prevent creating training set variants with unsupported computation modes and mismatched entities.

- **Tests**
  - Introduced new test cases to validate training set variant creation logic.
  - Added comprehensive test for checking entity consistency in training set definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->