### PR TITLE
Bugfix: SQL Equivalence not working 

### DIFF
--- a/metadata/equivalence/source_variant.go
+++ b/metadata/equivalence/source_variant.go
@@ -309,6 +309,7 @@ func (s sqlTransformation) IsEquivalent(other Equivalencer) bool {
 
 	return isSqlEqual(s.Query, otherSQL.Query) &&
 		reflect.DeepEqual(s.Sources, otherSQL.Sources) &&
+		reflect.DeepEqual(s.IncrementalSources, otherSQL.IncrementalSources) &&
 		reflect.DeepEqual(s.ResourceSnowflakeConfig, otherSQL.ResourceSnowflakeConfig)
 }
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -648,6 +648,7 @@ func (resource *sourceVariantResource) IsEquivalent(other ResourceVariant) (bool
 	if err != nil {
 		return false, err
 	}
+
 	otherSv, err := equivalence.SourceVariantFromProto(otherCasted.serialized)
 	if err != nil {
 		return false, err

--- a/tests/end_to_end/features/autovariants.feature
+++ b/tests/end_to_end/features/autovariants.feature
@@ -7,41 +7,52 @@
 
 @av
 Feature: AutoVariants
-    Scenario: Same auto variant for same transformation
-        Given Featureform is installed
-        When I create a "hosted" "insecure" client for "localhost:7878"
-        And I register "s3" filestore with bucket "featureform-spark-testing" and root path "data"
-        And I get or register databricks
-        And I register transactions_short.csv
-        And I register "trans_av_1" transformation with auto variant
-        Then I should be able to reuse the same variant for the same "trans_av_1" transformation
-        And I can get the transformation as df
 
-    Scenario: User-defined variant and auto variant for same transformation
-        Given Featureform is installed
-        When I create a "hosted" "insecure" client for "localhost:7878"
-        And I register "s3" filestore with bucket "featureform-spark-testing" and root path "data"
-        And I get or register databricks
-        And I register transactions_short.csv
-        And I register a transformation with user-provided variant
-        Then I should be able to register a new auto variant transformation
-        And I can get the transformation as df
+  Scenario Outline: Same auto variant for same transformation
+    Given Featureform is installed
+    When I create a "hosted" "insecure" client for "localhost:7878"
+    And I register "s3" filestore with bucket "featureform-spark-testing" and root path "data"
+    And I get or register databricks
+    And I register transactions_short.csv
+    And I register "trans_av_1" transformation with auto variant of type "<transformation_type>"
+    Then I should be able to reuse the same variant for the same "trans_av_1" transformation of type "<transformation_type>"
+    And I can get the transformation as df
 
-    Scenario: Different auto variant for different transformation
-        Given Featureform is installed
-        When I create a "hosted" "insecure" client for "localhost:7878"
-        And I register "s3" filestore with bucket "featureform-spark-testing" and root path "data"
-        And I get or register databricks
-        When I register transactions_short.csv
-        And I register "trans_av_2" transformation with auto variant
-        Then I should be able to register a modified "trans_av_2" transformation with new auto variant
-        And I can get the transformation as df
+    Examples:
+      | transformation_type |
+      | sql                 |
+      | df                  |
 
-    Scenario: Create auto variant dataset and register a new dataset with user-defined variant
-        Given Featureform is installed
-        When I create a "hosted" "insecure" client for "localhost:7878"
-        And I register "s3" filestore with bucket "featureform-spark-testing" and root path "data"
-        And I get or register databricks
-        And I register transactions_short.csv
-        Then I should be able to register a source with user-defined variant
-        And I can get the source as df
+  Scenario: User-defined variant and auto variant for same transformation
+    Given Featureform is installed
+    When I create a "hosted" "insecure" client for "localhost:7878"
+    And I register "s3" filestore with bucket "featureform-spark-testing" and root path "data"
+    And I get or register databricks
+    And I register transactions_short.csv
+    And I register a transformation with user-provided variant
+    Then I should be able to register a new auto variant transformation
+    And I can get the transformation as df
+
+  Scenario Outline: Different auto variant for different transformation
+    Given Featureform is installed
+    When I create a "hosted" "insecure" client for "localhost:7878"
+    And I register "s3" filestore with bucket "featureform-spark-testing" and root path "data"
+    And I get or register databricks
+    When I register transactions_short.csv
+    And I register "trans_av_2" transformation with auto variant of type "<transformation_type>"
+    Then I should be able to register a modified "trans_av_2" transformation with new auto variant of type "<transformation_type>"
+    And I can get the transformation as df
+
+    Examples:
+      | transformation_type |
+      | sql                 |
+      | df                  |
+
+  Scenario: Create auto variant dataset and register a new dataset with user-defined variant
+    Given Featureform is installed
+    When I create a "hosted" "insecure" client for "localhost:7878"
+    And I register "s3" filestore with bucket "featureform-spark-testing" and root path "data"
+    And I get or register databricks
+    And I register transactions_short.csv
+    Then I should be able to register a source with user-defined variant
+    And I can get the source as df


### PR DESCRIPTION
# Description

FindEquivalent wasn't detecting equivalent changes because sources are not included in the client and only parsed when reaching the backend. The ideal solution is to just send the right data from the client (which we'll do eventually) but for now this fixes that bug by attaching sources in the findEquivalent call as well.  Added a new set of tests as well

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in equivalence checks for resource variants.
	- Added a new method to update and save the status of resource variants.
	- Introduced parameterized testing for transformation types in AutoVariants feature.

- **Bug Fixes**
	- Improved handling of nil values and error logging in various methods.

- **Documentation**
	- Updated test scenarios to streamline and improve maintainability.

- **Tests**
	- Enhanced step implementations to support multiple transformation types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->