### PR TITLE
Update Artifacts actions to v4

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Upload image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: api-server
           path: /tmp/api-server.tar
@@ -66,7 +66,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Upload image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: backup
           path: /tmp/backup.tar
@@ -92,7 +92,7 @@ jobs:
 #          push: false
 #          outputs: type=docker,dest=/tmp/coordinator.tar
 #      - name: Upload image
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: coordinator
 #          path: /tmp/coordinator.tar
@@ -124,7 +124,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Upload image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dashboard
           path: /tmp/dashboard.tar
@@ -156,7 +156,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Upload image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: metadata
           path: /tmp/metadata.tar
@@ -188,7 +188,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Upload image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: metadata-dashboard
           path: /tmp/metadata-dashboard.tar
@@ -220,7 +220,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Upload image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: serving
           path: /tmp/serving.tar
@@ -246,7 +246,7 @@ jobs:
 #          push: false
 #          outputs: type=docker,dest=/tmp/worker.tar
 #      - name: Upload image
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: worker
 #          path: /tmp/worker.tar
@@ -280,13 +280,13 @@ jobs:
         run: docker save local/k8s_runner:scikit-stable > /tmp/k8s_runner_scikit.tar
 
       - name: Upload Base Image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: k8s_runner
           path: /tmp/k8s_runner.tar
 
       - name: Upload Scikit Image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: k8s_runner_scikit
           path: /tmp/k8s_runner_scikit.tar
@@ -303,7 +303,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           names: api-server dashboard dashboard-metadata metadata serving k8s_runner k8s_runner_scikit backup
           path: /tmp

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -217,7 +217,7 @@ jobs:
 
       - name: Archive code coverage results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: search-coverage-reports
           path: ./cover.html
@@ -263,7 +263,7 @@ jobs:
           source venv/bin/activate
           ./pip_update.sh --no-dash
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: client
           path: ./client
@@ -281,7 +281,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Download Working Compiled Directories
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: client
           path: ./client
@@ -336,7 +336,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Download Working Compiled Directories
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: client
           path: ./client
@@ -482,7 +482,7 @@ jobs:
 
       - name: Archive behave test results without Autovariants
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: behave-reports-without-av
           path: ./tests/end_to_end/output/
@@ -528,7 +528,7 @@ jobs:
 
       - name: Upload Logs
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: featureform-non-av.log
           path: ./featureform-non-av.log
@@ -645,7 +645,7 @@ jobs:
 
       - name: Archive behave test results with Autovariants
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: behave-reports-av
           path: ./tests/end_to_end/output/
@@ -691,7 +691,7 @@ jobs:
 
       - name: Upload Logs
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: featureform-av.log
           path: ./featureform-av.log
@@ -838,7 +838,7 @@ jobs:
 
       - name: Upload Logs
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: featureform-e2e-pytest.log
           path: ./featureform-e2e-pytest.log


### PR DESCRIPTION
# Description

Update the [Upload Artifacts action](https://github.com/actions/upload-artifact) and [Download Artifacts action](https://github.com/actions/download-artifact) to use v4, as v3 is deprecated, and will stop working on January 30th.

After consulting the migration docs for each, it seems like none of the breaking changes apply to us, so it's as simple as just bumping the version used.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configurations
	- Upgraded artifact and environment setup action versions
		- Upgraded `upload-artifact` from v3 to v4
		- Upgraded `download-artifact` from v3 to v4
		- Upgraded `setup-python` from v4 to v5
		- Upgraded `setup-go` from v2 to v5
<!-- end of auto-generated comment: release notes by coderabbit.ai -->