### PR TITLE
Bump Python version, GitHub actions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,7 +43,6 @@ body:
         - "3.11"
         - "3.12"
         - "3.13"
-        - "3.14"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,10 +38,12 @@ body:
     attributes:
       label: What version of Python are you running?
       options:
-        - "3.7"
-        - "3.8"
         - "3.9"
         - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
             working-directory: ./embeddinghub
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v4
 
         - name: Set up Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v5
           with:
-            python-version: "2.7"
+            python-version: "3.14"
 
         - name: Install deps
           run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         - name: Set up Python
           uses: actions/setup-python@v5
           with:
-            python-version: "3.13"
+            python-version: "3.11"
 
         - name: Install deps
           run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         - name: Set up Python
           uses: actions/setup-python@v5
           with:
-            python-version: "3.14"
+            python-version: "3.13"
 
         - name: Install deps
           run: |

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.11'
       - run: pip install mkdocs mkdocs-material mkdocstrings-python mkdocs-gen-files mkdocs-literate-nav mkdocs-section-index
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.14'
+          python-version: '3.13'
       - run: pip install mkdocs mkdocs-material mkdocstrings-python mkdocs-gen-files mkdocs-literate-nav mkdocs-section-index
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -10,9 +10,9 @@ jobs:
         working-directory: ./client
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.14'
       - run: pip install mkdocs mkdocs-material mkdocstrings-python mkdocs-gen-files mkdocs-literate-nav mkdocs-section-index
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/databricks-job-cleanup.yml
+++ b/.github/workflows/databricks-job-cleanup.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.14'
+        python-version: '3.13'
 
     - name: Install dependencies
       run: pip install requests

--- a/.github/workflows/databricks-job-cleanup.yml
+++ b/.github/workflows/databricks-job-cleanup.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10.12'
+        python-version: '3.14'
 
     - name: Install dependencies
       run: pip install requests

--- a/.github/workflows/databricks-job-cleanup.yml
+++ b/.github/workflows/databricks-job-cleanup.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.11'
 
     - name: Install dependencies
       run: pip install requests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -310,7 +310,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
           check-latest: true
 
       - name: Set up Go

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -310,7 +310,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.13"
           check-latest: true
 
       - name: Set up Go

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -301,16 +301,16 @@ jobs:
         working-directory: ./
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
           names: api-server dashboard dashboard-metadata metadata serving k8s_runner k8s_runner_scikit backup
           path: /tmp
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.14"
           check-latest: true
 
       - name: Set up Go

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.13"
           cache: "pip" # caching pip dependencies
 
       - name: Configure AWS credentials
@@ -239,10 +239,10 @@ jobs:
         with:
           go-version: 1.21
 
-      - name: Set up Python 3.14
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.13"
 
       - name: Create and activate virtual environment
         run: |
@@ -288,7 +288,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.13"
 
       - name: Install pyspark packages
         run: |
@@ -328,7 +328,7 @@ jobs:
         # macos-14 switched to M1 chips which broke some of our
         # dependencies. We're hard pinning to macOS-13 for now.
         os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
           - os: windows-latest
             python-version: "3.11"
@@ -399,7 +399,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.13"
 
       - name: Install grpc_tools
         run: pip install grpcio-tools==1.62.2 build mypy-protobuf
@@ -562,7 +562,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.13"
 
       - name: Install grpc_tools
         run: pip install grpcio-tools==1.62.2 build mypy-protobuf
@@ -725,7 +725,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.13"
 
       - name: Install grpc_tools
         run: pip install grpcio-tools==1.62.2 build mypy-protobuf

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -399,7 +399,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - name: Install grpc_tools
         run: pip install grpcio-tools==1.62.2 build mypy-protobuf
@@ -562,7 +562,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - name: Install grpc_tools
         run: pip install grpcio-tools==1.62.2 build mypy-protobuf
@@ -725,7 +725,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - name: Install grpc_tools
         run: pip install grpcio-tools==1.62.2 build mypy-protobuf

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -75,10 +75,10 @@ jobs:
           CLICKHOUSE_DB: ${{ env.CLICKHOUSE_DB }}
           CLICKHOUSE_PASSWORD: ${{ env.CLICKHOUSE_PASSWORD }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.14"
           cache: "pip" # caching pip dependencies
 
       - name: Configure AWS credentials
@@ -239,10 +239,10 @@ jobs:
         with:
           go-version: 1.21
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.14"
 
       - name: Create and activate virtual environment
         run: |
@@ -288,7 +288,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.14"
 
       - name: Install pyspark packages
         run: |
@@ -328,7 +328,7 @@ jobs:
         # macos-14 switched to M1 chips which broke some of our
         # dependencies. We're hard pinning to macOS-13 for now.
         os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           - os: windows-latest
             python-version: "3.11"
@@ -397,9 +397,9 @@ jobs:
         with:
           go-version: 1.21
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.14"
 
       - name: Install grpc_tools
         run: pip install grpcio-tools==1.62.2 build mypy-protobuf
@@ -560,9 +560,9 @@ jobs:
         with:
           go-version: 1.21
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.14"
 
       - name: Install grpc_tools
         run: pip install grpcio-tools==1.62.2 build mypy-protobuf
@@ -723,9 +723,9 @@ jobs:
         with:
           go-version: 1.21
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.14"
 
       - name: Install grpc_tools
         run: pip install grpcio-tools==1.62.2 build mypy-protobuf

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
           cache: "pip" # caching pip dependencies
 
       - name: Configure AWS credentials
@@ -239,10 +239,10 @@ jobs:
         with:
           go-version: 1.21
 
-      - name: Set up Python 3.13
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
 
       - name: Create and activate virtual environment
         run: |
@@ -288,7 +288,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
 
       - name: Install pyspark packages
         run: |
@@ -399,7 +399,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
 
       - name: Install grpc_tools
         run: pip install grpcio-tools==1.62.2 build mypy-protobuf
@@ -562,7 +562,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
 
       - name: Install grpc_tools
         run: pip install grpcio-tools==1.62.2 build mypy-protobuf
@@ -725,7 +725,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
 
       - name: Install grpc_tools
         run: pip install grpcio-tools==1.62.2 build mypy-protobuf

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -328,7 +328,7 @@ jobs:
         # macos-14 switched to M1 chips which broke some of our
         # dependencies. We're hard pinning to macOS-13 for now.
         os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         exclude:
           - os: windows-latest
             python-version: "3.11"


### PR DESCRIPTION
# Description

Bump the Python version used in CI to 3.11, with the exception of the variant tests, as they require a change to the Spark provider to sync up the versions, which can be done at a later day to unblock PRs.

Additionally, bump the `setup-python` and `checkout` actions to the latest versions.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configurations across multiple files.
	- Upgraded GitHub Actions action versions (checkout, setup-python).
	- Updated Python version support from older versions to Python 3.11, 3.12, and 3.13.
	- Updated issue template to reflect supported Python versions (removed 3.7 and 3.8, added 3.11, 3.12, and 3.13).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->