### PR TITLE
Bug: Add nil checks for nested structs that can be nil

### DIFF
--- a/metadata/equivalence/common.go
+++ b/metadata/equivalence/common.go
@@ -41,3 +41,46 @@ func (n nameVariant) IsEquivalent(other Equivalencer) bool {
 	}
 	return n.Name == otherNameVariant.Name && n.Variant == otherNameVariant.Variant
 }
+
+type resourceSnowflakeConfig struct {
+	DynamicTableConfig snowflakeDynamicTableConfig
+	Warehouse          string
+}
+
+type snowflakeDynamicTableConfig struct {
+	TargetLag   string
+	RefreshMode string
+	Initialize  string
+}
+
+func resourceSnowflakeConfigFromProto(proto *pb.ResourceSnowflakeConfig) resourceSnowflakeConfig {
+	if proto == nil {
+		return resourceSnowflakeConfig{}
+	}
+
+	dynamicTableConfig := proto.DynamicTableConfig
+	if dynamicTableConfig == nil {
+		return resourceSnowflakeConfig{
+			Warehouse: proto.Warehouse,
+		}
+	}
+
+	return resourceSnowflakeConfig{
+		DynamicTableConfig: snowflakeDynamicTableConfig{
+			TargetLag:   dynamicTableConfig.TargetLag,
+			RefreshMode: dynamicTableConfig.RefreshMode.String(),
+			Initialize:  dynamicTableConfig.Initialize.String(),
+		},
+		Warehouse: proto.Warehouse,
+	}
+}
+
+func (s snowflakeDynamicTableConfig) IsEquivalent(other Equivalencer) bool {
+	otherConfig, ok := other.(snowflakeDynamicTableConfig)
+	if !ok {
+		return false
+	}
+	return s.TargetLag == otherConfig.TargetLag &&
+		s.RefreshMode == otherConfig.RefreshMode &&
+		s.Initialize == otherConfig.Initialize
+}

--- a/metadata/equivalence/common_test.go
+++ b/metadata/equivalence/common_test.go
@@ -1,0 +1,56 @@
+package equivalence
+
+import (
+	pb "github.com/featureform/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestResourceSnowflakeConfigFromProto(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *pb.ResourceSnowflakeConfig
+		expected resourceSnowflakeConfig
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: resourceSnowflakeConfig{},
+		},
+		{
+			name: "warehouse only",
+			input: &pb.ResourceSnowflakeConfig{
+				Warehouse: "test_warehouse",
+			},
+			expected: resourceSnowflakeConfig{
+				Warehouse: "test_warehouse",
+			},
+		},
+		{
+			name: "full config",
+			input: &pb.ResourceSnowflakeConfig{
+				Warehouse: "test_warehouse",
+				DynamicTableConfig: &pb.SnowflakeDynamicTableConfig{
+					TargetLag:   "1h",
+					RefreshMode: pb.RefreshMode_REFRESH_MODE_FULL,
+					Initialize:  pb.Initialize_INITIALIZE_ON_SCHEDULE,
+				},
+			},
+			expected: resourceSnowflakeConfig{
+				Warehouse: "test_warehouse",
+				DynamicTableConfig: snowflakeDynamicTableConfig{
+					TargetLag:   "1h",
+					RefreshMode: "REFRESH_MODE_FULL",
+					Initialize:  "INITIALIZE_ON_SCHEDULE",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resourceSnowflakeConfigFromProto(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/metadata/equivalence/feature_variant.go
+++ b/metadata/equivalence/feature_variant.go
@@ -17,11 +17,12 @@ import (
 )
 
 type featureVariant struct {
-	Name            string
-	Provider        string
-	ValueType       types.ValueType
-	ComputationMode string // TODO move definition from metadata to common
-	Location        featureLocation
+	Name                    string
+	Provider                string
+	ValueType               types.ValueType
+	ComputationMode         string // TODO move definition from metadata to common
+	Location                featureLocation
+	ResourceSnowflakeConfig resourceSnowflakeConfig
 }
 
 func FeatureVariantFromProto(proto *pb.FeatureVariant) (featureVariant, error) {
@@ -45,11 +46,12 @@ func FeatureVariantFromProto(proto *pb.FeatureVariant) (featureVariant, error) {
 	}
 
 	return featureVariant{
-		Name:            proto.Name,
-		Provider:        proto.Provider,
-		ValueType:       valueType,
-		ComputationMode: proto.Mode.String(),
-		Location:        location,
+		Name:                    proto.Name,
+		Provider:                proto.Provider,
+		ValueType:               valueType,
+		ComputationMode:         proto.Mode.String(),
+		Location:                location,
+		ResourceSnowflakeConfig: resourceSnowflakeConfigFromProto(proto.ResourceSnowflakeConfig),
 	}, nil
 }
 
@@ -65,7 +67,8 @@ func (f featureVariant) IsEquivalent(other Equivalencer) bool {
 				f1.Provider == f2.Provider &&
 				f1.ValueType == f2.ValueType &&
 				f1.ComputationMode == f2.ComputationMode &&
-				f1.Location.IsEquivalent(f2.Location)
+				f1.Location.IsEquivalent(f2.Location) &&
+				reflect.DeepEqual(f1.ResourceSnowflakeConfig, f2.ResourceSnowflakeConfig)
 		}),
 	}
 

--- a/metadata/equivalence/label_variant_test.go
+++ b/metadata/equivalence/label_variant_test.go
@@ -8,6 +8,8 @@
 package equivalence
 
 import (
+	pb "github.com/featureform/metadata/proto"
+	"github.com/featureform/provider/types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,13 +28,13 @@ func TestLabelVariantIsEquivalent(t *testing.T) {
 				Name:   "Label1",
 				Source: nameVariant{Name: "Source1", Variant: "v1"},
 				Entity: "Entity1",
-				Type:   "Type1",
+				Type:   types.Int8,
 			},
 			lv2: labelVariant{
 				Name:   "Label1",
 				Source: nameVariant{Name: "Source1", Variant: "v1"},
 				Entity: "Entity1",
-				Type:   "Type1",
+				Type:   types.Int8,
 			},
 			expected: true,
 		},
@@ -42,13 +44,13 @@ func TestLabelVariantIsEquivalent(t *testing.T) {
 				Name:   "Label1",
 				Source: nameVariant{Name: "Source1", Variant: "v1"},
 				Entity: "Entity1",
-				Type:   "Type1",
+				Type:   types.Int8,
 			},
 			lv2: labelVariant{
 				Name:   "Label2", // Different Name
 				Source: nameVariant{Name: "Source1", Variant: "v1"},
 				Entity: "Entity1",
-				Type:   "Type1",
+				Type:   types.Int8,
 			},
 			expected: false,
 		},
@@ -58,13 +60,13 @@ func TestLabelVariantIsEquivalent(t *testing.T) {
 				Name:   "Label1",
 				Source: nameVariant{Name: "Source1", Variant: "v1"},
 				Entity: "Entity1",
-				Type:   "Type1",
+				Type:   types.Int8,
 			},
 			lv2: labelVariant{
 				Name:   "Label1",
 				Source: nameVariant{Name: "Source2", Variant: "v1"}, // Different Source.Name
 				Entity: "Entity1",
-				Type:   "Type1",
+				Type:   types.Int8,
 			},
 			expected: false,
 		},
@@ -74,13 +76,13 @@ func TestLabelVariantIsEquivalent(t *testing.T) {
 				Name:   "Label1",
 				Source: nameVariant{Name: "Source1", Variant: "v1"},
 				Entity: "Entity1",
-				Type:   "Type1",
+				Type:   types.Int8,
 			},
 			lv2: labelVariant{
 				Name:   "Label1",
 				Source: nameVariant{Name: "Source1", Variant: "v1"},
 				Entity: "Entity2", // Different Entity
-				Type:   "Type1",
+				Type:   types.Int8,
 			},
 			expected: false,
 		},
@@ -90,13 +92,13 @@ func TestLabelVariantIsEquivalent(t *testing.T) {
 				Name:   "Label1",
 				Source: nameVariant{Name: "Source1", Variant: "v1"},
 				Entity: "Entity1",
-				Type:   "Type1",
+				Type:   types.Int8,
 			},
 			lv2: labelVariant{
 				Name:   "Label1",
 				Source: nameVariant{Name: "Source1", Variant: "v1"},
 				Entity: "Entity1",
-				Type:   "Type2", // Different Type
+				Type:   types.Int16, // Different Type
 			},
 			expected: false,
 		},
@@ -107,14 +109,14 @@ func TestLabelVariantIsEquivalent(t *testing.T) {
 				Source:  nameVariant{Name: "Source1", Variant: "v1"},
 				Columns: column{Entity: "Entity1", Value: "Value1", Ts: "TS1"},
 				Entity:  "Entity1",
-				Type:    "Type1",
+				Type:    types.Int8,
 			},
 			lv2: labelVariant{
 				Name:    "Label1",
 				Source:  nameVariant{Name: "Source1", Variant: "v1"},
 				Columns: column{Entity: "Entity2", Value: "Value2", Ts: "TS2"}, // Different Columns
 				Entity:  "Entity1",
-				Type:    "Type1",
+				Type:    types.Int8,
 			},
 			expected: true, // Columns are not compared
 		},
@@ -124,6 +126,116 @@ func TestLabelVariantIsEquivalent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.lv1.IsEquivalent(tt.lv2)
 			assert.Equal(t, tt.expected, result, "IsEquivalent() mismatch in test case: %s", tt.name)
+		})
+	}
+}
+
+func TestLabelVariantFromProto(t *testing.T) {
+	valueType := &pb.ValueType{
+		Type: &pb.ValueType_Scalar{
+			Scalar: pb.ScalarType_FLOAT32,
+		},
+	}
+
+	vt, err := types.ValueTypeFromProto(valueType)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		input    *pb.LabelVariant
+		expected labelVariant
+		wantErr  bool
+	}{
+		{
+			name: "complete label variant with snowflake config",
+			input: &pb.LabelVariant{
+				Name:   "churn_label",
+				Entity: "user_id",
+				Type:   valueType,
+				Source: &pb.NameVariant{
+					Name:    "churn_events",
+					Variant: "v1",
+				},
+				ResourceSnowflakeConfig: &pb.ResourceSnowflakeConfig{
+					Warehouse: "compute_wh",
+					DynamicTableConfig: &pb.SnowflakeDynamicTableConfig{
+						TargetLag:   "1h",
+						RefreshMode: pb.RefreshMode_REFRESH_MODE_FULL,
+						Initialize:  pb.Initialize_INITIALIZE_ON_SCHEDULE,
+					},
+				},
+			},
+			expected: labelVariant{
+				Name:   "churn_label",
+				Entity: "user_id",
+				Type:   vt,
+				Source: nameVariant{
+					Name:    "churn_events",
+					Variant: "v1",
+				},
+				ResourceSnowflakeConfig: resourceSnowflakeConfig{
+					Warehouse: "compute_wh",
+					DynamicTableConfig: snowflakeDynamicTableConfig{
+						TargetLag:   "1h",
+						RefreshMode: "REFRESH_MODE_FULL",
+						Initialize:  "INITIALIZE_ON_SCHEDULE",
+					},
+				},
+			},
+		},
+		{
+			name: "minimal label variant without snowflake config",
+			input: &pb.LabelVariant{
+				Name:   "simple_label",
+				Entity: "customer_id",
+				Type:   valueType,
+				Source: &pb.NameVariant{
+					Name: "revenue_data",
+				},
+			},
+			expected: labelVariant{
+				Name:   "simple_label",
+				Entity: "customer_id",
+				Type:   vt,
+				Source: nameVariant{
+					Name: "revenue_data",
+				},
+				ResourceSnowflakeConfig: resourceSnowflakeConfig{},
+			},
+		},
+		{
+			name: "label variant with source only",
+			input: &pb.LabelVariant{
+				Name:   "categorical_label",
+				Entity: "product_id",
+				Type:   valueType,
+				Source: &pb.NameVariant{
+					Name:    "product_categories",
+					Variant: "latest",
+				},
+			},
+			expected: labelVariant{
+				Name:   "categorical_label",
+				Entity: "product_id",
+				Type:   vt,
+				Source: nameVariant{
+					Name:    "product_categories",
+					Variant: "latest",
+				},
+				ResourceSnowflakeConfig: resourceSnowflakeConfig{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := LabelVariantFromProto(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/metadata/equivalence/training_set_variant.go
+++ b/metadata/equivalence/training_set_variant.go
@@ -15,18 +15,20 @@ import (
 )
 
 type trainingSetVariant struct {
-	Name        string
-	Features    []nameVariant
-	Label       nameVariant
-	LagFeatures []featureLag
+	Name                    string
+	Features                []nameVariant
+	Label                   nameVariant
+	LagFeatures             []featureLag
+	ResourceSnowflakeConfig resourceSnowflakeConfig
 }
 
 func TrainingSetVariantFromProto(proto *pb.TrainingSetVariant) (trainingSetVariant, error) {
 	return trainingSetVariant{
-		Name:        proto.Name,
-		Features:    nameVariantsFromProto(proto.Features),
-		Label:       nameVariantFromProto(proto.Label),
-		LagFeatures: featureLagsFromProto(proto.FeatureLags),
+		Name:                    proto.Name,
+		Features:                nameVariantsFromProto(proto.Features),
+		Label:                   nameVariantFromProto(proto.Label),
+		LagFeatures:             featureLagsFromProto(proto.FeatureLags),
+		ResourceSnowflakeConfig: resourceSnowflakeConfigFromProto(proto.ResourceSnowflakeConfig),
 	}, nil
 }
 
@@ -41,7 +43,8 @@ func (t trainingSetVariant) IsEquivalent(other Equivalencer) bool {
 			return t1.Name == t2.Name &&
 				reflect.DeepEqual(t1.Features, t2.Features) &&
 				reflect.DeepEqual(t1.LagFeatures, t2.LagFeatures) &&
-				t1.Label.IsEquivalent(t2.Label)
+				t1.Label.IsEquivalent(t2.Label) &&
+				reflect.DeepEqual(t1.ResourceSnowflakeConfig, t2.ResourceSnowflakeConfig)
 		}),
 	}
 


### PR DESCRIPTION
# Description

Adds nil checks for k8s args and resourceSnowflakeConfig where nested struct can be nil.

Also, added resourceSnowflakeConfig to features, ts's, and labels

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added Snowflake configuration support across various metadata variant types.
	- Introduced new configuration types for managing Snowflake resource settings.
	- Enhanced equivalence checking for metadata variants with the addition of `ResourceSnowflakeConfig`.

- **Improvements**
	- Updated type conversions for feature, label, and training set variants.
	- Improved error handling during configuration parsing.
	- Enhanced type safety for configuration management.

- **Testing**
	- Added comprehensive test coverage for new Snowflake configuration functionality.
	- Implemented test cases for configuration conversion and equivalence checking.
	- Added tests for handling various scenarios in training set and feature variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->