### PR TITLE
Fix image name mismatch

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -425,7 +425,7 @@ jobs:
         with:
           context: .
           file: ./db/Dockerfile
-          tags: featureformcom/db_migration:${{ env.TAG }}
+          tags: featureformcom/db-migration-up:${{ env.TAG }}
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -395,7 +395,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  db_migration:
+  db-migration-up:
     name: Build DB Migration Job
     environment: Deployment
     defaults:

--- a/Makefile
+++ b/Makefile
@@ -567,7 +567,7 @@ minikube_build_images: gen_grpc   ## Build Docker images for Minikube
 	minikube image build -f ./search_loader/Dockerfile -t local/search-loader:stable . & \
 	minikube image build -f ./streamer/Dockerfile -t local/iceberg-streamer:stable . & \
 	minikube image build -f ./streamer_proxy/Dockerfile -t local/iceberg-proxy:stable . & \
-	minikube image build -f ./db/Dockerfile -t local/db_migration:stable . & \
+	minikube image build -f ./db/Dockerfile -t local/db-migration-up:stable . & \
 	wait; \
 	echo "Build Complete"
 

--- a/streamer_proxy/Dockerfile
+++ b/streamer_proxy/Dockerfile
@@ -5,7 +5,7 @@
 #  Copyright 2024 FeatureForm Inc.
 #
 
-FROM golang:1.21-alpine as Builder
+FROM golang:1.22-alpine as Builder
 WORKDIR /app
 
 COPY go.mod ./


### PR DESCRIPTION
Sets the migration job's image name to match the chart value: `db-migration-up`

Also updates the streamer_proxy's Dockerfile to match the latest go version from go.mod. (to `1.22`)

# Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Docker image tags for database migration from `db_migration` to `db-migration-up` in GitHub Actions workflow and Makefile.
	- Updated base image in Dockerfile from `golang:1.21-alpine` to `golang:1.22-alpine`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->