### PR TITLE
Feature: implements training set types for Snowflake (#1726)

### DIFF
--- a/client/src/featureform/enums.py
+++ b/client/src/featureform/enums.py
@@ -404,3 +404,37 @@ class SnowflakeSessionParamKey(Enum):
     @classmethod
     def validate_key(cls, key: str) -> bool:
         return key.lower() in cls._value2member_map_
+
+
+class TrainingSetType(Enum):
+    # Dynamic training sets are updated when new rows are added to upstream tables;
+    # mechanism of update will depend on the offline provider (e.g. Snowflake uses dynamic tables).
+    DYNAMIC = pb.TrainingSetType.TRAINING_SET_TYPE_DYNAMIC
+    # Static training sets are not updated when new rows are added to upstream tables; they are
+    # created as regular tables and are not updated.
+    STATIC = pb.TrainingSetType.TRAINING_SET_TYPE_STATIC
+    # View training sets are created as views and are only evaluated when queried by a user
+    # (e.g. when fetching the training set for model training).
+    VIEW = pb.TrainingSetType.TRAINING_SET_TYPE_VIEW
+
+    @classmethod
+    def from_proto(cls, proto_value):
+        try:
+            return cls(proto_value)
+        except ValueError:
+            return None
+
+    def to_proto(self):
+        return self.value
+
+    def to_string(self):
+        return self.name
+
+    @classmethod
+    def from_string(cls, value):
+        try:
+            return cls[value.upper()]
+        except KeyError:
+            raise ValueError(f"Training Set Type value not supported: {value}")
+        except AttributeError:
+            raise ValueError(f"Training Set Type value required: received {value}")

--- a/coordinator/tasks/trainingset.go
+++ b/coordinator/tasks/trainingset.go
@@ -160,6 +160,7 @@ func (t *TrainingSetTask) Run() error {
 		FeatureSourceMappings:   featureSourceMappings,
 		LagFeatures:             lagFeaturesList,
 		ResourceSnowflakeConfig: resourceSnowflakeConfig,
+		Type:                    ts.TrainingSetType(),
 	}
 
 	return t.runTrainingSetJob(trainingSetDef, store)

--- a/metadata/equivalence/training_set_variant.go
+++ b/metadata/equivalence/training_set_variant.go
@@ -10,9 +10,40 @@ package equivalence
 import (
 	"reflect"
 
+	"github.com/featureform/fferr"
+	"github.com/featureform/logging"
 	pb "github.com/featureform/metadata/proto"
 	"github.com/google/go-cmp/cmp"
 )
+
+type trainingSetType string
+
+const (
+	dynamicTrainingSet trainingSetType = "DYNAMIC"
+	staticTrainingSet  trainingSetType = "STATIC"
+	viewTrainingSet    trainingSetType = "VIEW"
+	nilTrainingSet     trainingSetType = ""
+)
+
+func trainingSetTypeFromProto(proto pb.TrainingSetType) (trainingSetType, error) {
+	logger := logging.GlobalLogger.Named("trainingSetTypeFromProto")
+	trainingSetType := nilTrainingSet
+	switch proto {
+	case pb.TrainingSetType_TRAINING_SET_TYPE_DYNAMIC:
+		trainingSetType = dynamicTrainingSet
+	case pb.TrainingSetType_TRAINING_SET_TYPE_STATIC:
+		trainingSetType = staticTrainingSet
+	case pb.TrainingSetType_TRAINING_SET_TYPE_VIEW:
+		trainingSetType = viewTrainingSet
+	case pb.TrainingSetType_TRAINING_SET_TYPE_UNSPECIFIED:
+		logger.DPanic("Training set type unspecified")
+		return trainingSetType, fferr.NewInvalidArgumentErrorf("Training set type unspecified")
+	default:
+		logger.DPanicf("Unknown training set type %v", proto)
+		return trainingSetType, fferr.NewInternalErrorf("Unknown training set type %v", proto)
+	}
+	return trainingSetType, nil
+}
 
 type trainingSetVariant struct {
 	Name                    string
@@ -20,15 +51,21 @@ type trainingSetVariant struct {
 	Label                   nameVariant
 	LagFeatures             []featureLag
 	ResourceSnowflakeConfig resourceSnowflakeConfig
+	Type                    trainingSetType
 }
 
 func TrainingSetVariantFromProto(proto *pb.TrainingSetVariant) (trainingSetVariant, error) {
+	trainingSetType, err := trainingSetTypeFromProto(proto.Type)
+	if err != nil {
+		return trainingSetVariant{}, err
+	}
 	return trainingSetVariant{
 		Name:                    proto.Name,
 		Features:                nameVariantsFromProto(proto.Features),
 		Label:                   nameVariantFromProto(proto.Label),
 		LagFeatures:             featureLagsFromProto(proto.FeatureLags),
 		ResourceSnowflakeConfig: resourceSnowflakeConfigFromProto(proto.ResourceSnowflakeConfig),
+		Type:                    trainingSetType,
 	}, nil
 }
 
@@ -44,7 +81,8 @@ func (t trainingSetVariant) IsEquivalent(other Equivalencer) bool {
 				reflect.DeepEqual(t1.Features, t2.Features) &&
 				reflect.DeepEqual(t1.LagFeatures, t2.LagFeatures) &&
 				t1.Label.IsEquivalent(t2.Label) &&
-				reflect.DeepEqual(t1.ResourceSnowflakeConfig, t2.ResourceSnowflakeConfig)
+				reflect.DeepEqual(t1.ResourceSnowflakeConfig, t2.ResourceSnowflakeConfig) &&
+				t1.Type == t2.Type
 		}),
 	}
 

--- a/metadata/equivalence/training_set_variant_test.go
+++ b/metadata/equivalence/training_set_variant_test.go
@@ -8,10 +8,11 @@
 package equivalence
 
 import (
-	pb "github.com/featureform/metadata/proto"
-	"google.golang.org/protobuf/types/known/durationpb"
 	"testing"
 	"time"
+
+	pb "github.com/featureform/metadata/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -143,6 +144,28 @@ func TestTrainingSetVariantIsEquivalent(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "Different TrainingSetTypes",
+			ts1: trainingSetVariant{
+				Name: "set1",
+				Features: []nameVariant{
+					{Name: "feature1", Variant: "v1"},
+					{Name: "feature2", Variant: "v1"},
+				},
+				Label: nameVariant{Name: "label1", Variant: "v1"},
+				Type:  dynamicTrainingSet,
+			},
+			ts2: trainingSetVariant{
+				Name: "set1",
+				Features: []nameVariant{
+					{Name: "feature1", Variant: "v1"},
+					{Name: "feature2", Variant: "v1"},
+				},
+				Label: nameVariant{Name: "label1", Variant: "v1"},
+				Type:  viewTrainingSet,
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -264,6 +287,7 @@ func TestTrainingSetVariantFromProto(t *testing.T) {
 						Initialize:  pb.Initialize_INITIALIZE_ON_SCHEDULE,
 					},
 				},
+				Type: pb.TrainingSetType_TRAINING_SET_TYPE_DYNAMIC,
 			},
 			expected: trainingSetVariant{
 				Name: "test_variant",
@@ -288,6 +312,7 @@ func TestTrainingSetVariantFromProto(t *testing.T) {
 						Initialize:  "INITIALIZE_ON_SCHEDULE",
 					},
 				},
+				Type: dynamicTrainingSet,
 			},
 		},
 		{
@@ -308,6 +333,7 @@ func TestTrainingSetVariantFromProto(t *testing.T) {
 					},
 				},
 				ResourceSnowflakeConfig: nil, // explicitly nil
+				Type:                    pb.TrainingSetType_TRAINING_SET_TYPE_DYNAMIC,
 			},
 			expected: trainingSetVariant{
 				Name: "no_snowflake",
@@ -325,10 +351,83 @@ func TestTrainingSetVariantFromProto(t *testing.T) {
 					},
 				},
 				ResourceSnowflakeConfig: resourceSnowflakeConfig{}, // empty config
+				Type:                    dynamicTrainingSet,
 			},
 		},
 		{
 			name: "minimal training set variant",
+			input: &pb.TrainingSetVariant{
+				Name: "minimal_variant",
+				Features: []*pb.NameVariant{
+					{Name: "feature1"},
+				},
+				Label: &pb.NameVariant{
+					Name: "label",
+				},
+				Type: pb.TrainingSetType_TRAINING_SET_TYPE_DYNAMIC,
+			},
+			expected: trainingSetVariant{
+				Name: "minimal_variant",
+				Features: []nameVariant{
+					{Name: "feature1"},
+				},
+				Label: nameVariant{
+					Name: "label",
+				},
+				ResourceSnowflakeConfig: resourceSnowflakeConfig{}, // empty config
+				Type:                    dynamicTrainingSet,
+			},
+		},
+		{
+			name: "static training set variant",
+			input: &pb.TrainingSetVariant{
+				Name: "minimal_variant",
+				Features: []*pb.NameVariant{
+					{Name: "feature1"},
+				},
+				Label: &pb.NameVariant{
+					Name: "label",
+				},
+				Type: pb.TrainingSetType_TRAINING_SET_TYPE_STATIC,
+			},
+			expected: trainingSetVariant{
+				Name: "minimal_variant",
+				Features: []nameVariant{
+					{Name: "feature1"},
+				},
+				Label: nameVariant{
+					Name: "label",
+				},
+				ResourceSnowflakeConfig: resourceSnowflakeConfig{}, // empty config
+				Type:                    staticTrainingSet,
+			},
+		},
+		{
+			name: "view training set variant",
+			input: &pb.TrainingSetVariant{
+				Name: "minimal_variant",
+				Features: []*pb.NameVariant{
+					{Name: "feature1"},
+				},
+				Label: &pb.NameVariant{
+					Name: "label",
+				},
+				Type: pb.TrainingSetType_TRAINING_SET_TYPE_VIEW,
+			},
+			expected: trainingSetVariant{
+				Name: "minimal_variant",
+				Features: []nameVariant{
+					{Name: "feature1"},
+				},
+				Label: nameVariant{
+					Name: "label",
+				},
+				ResourceSnowflakeConfig: resourceSnowflakeConfig{}, // empty config
+				Type:                    viewTrainingSet,
+			},
+		},
+		{
+			name: "unset training set type",
 			input: &pb.TrainingSetVariant{
 				Name: "minimal_variant",
 				Features: []*pb.NameVariant{
@@ -348,6 +447,7 @@ func TestTrainingSetVariantFromProto(t *testing.T) {
 				},
 				ResourceSnowflakeConfig: resourceSnowflakeConfig{}, // empty config
 			},
+			wantErr: true,
 		},
 	}
 

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -2511,6 +2511,7 @@ func Test_GetEquivalent(t *testing.T) {
 		Owner:      "Featureform",
 		Tags:       Tags{},
 		Properties: Properties{},
+		Type:       DynamicTrainingSet,
 	}
 
 	defaultResourceVariant := &pb.ResourceVariant{}

--- a/metadata/proto/metadata.proto
+++ b/metadata/proto/metadata.proto
@@ -408,23 +408,24 @@ message TrainingSet {
 }
 
 message TrainingSetVariant {
-  string name = 1;
-  string variant = 2;
-  string description = 3;
-  string owner = 4;
-  google.protobuf.Timestamp created = 5;
-  string provider = 6;
-  ResourceStatus status = 7;
-  repeated NameVariant features = 8;
-  NameVariant label = 9;
-  google.protobuf.Timestamp last_updated = 13;
-  string schedule = 14;
-  repeated FeatureLag feature_lags = 15;
-  Tags tags = 16;
-  Properties properties = 17;
-  string task_id = 18 [deprecated = true];
-  repeated string task_id_list = 19;
-  ResourceSnowflakeConfig resource_snowflake_config = 20;
+    string name = 1;
+    string variant = 2;
+    string description = 3;
+    string owner = 4;
+    google.protobuf.Timestamp created = 5;
+    string provider = 6;
+    ResourceStatus status = 7;
+    repeated NameVariant features = 8;
+    NameVariant label = 9;
+    google.protobuf.Timestamp last_updated = 13;
+    string schedule = 14;
+    repeated FeatureLag feature_lags = 15;
+    Tags tags = 16;
+    Properties properties = 17;
+    string task_id = 18 [deprecated=true];
+    repeated string task_id_list = 19;
+    ResourceSnowflakeConfig resource_snowflake_config = 20;
+    TrainingSetType type = 21;
 }
 
 message TrainingSetVariantRequest {
@@ -726,4 +727,14 @@ message PruneResourceRequest {
 }
 
 message PruneResourceResponse {
+    string target_lag = 1;
+    RefreshMode refresh_mode = 2;
+    Initialize initialize = 3;
+}
+
+enum TrainingSetType {
+    TRAINING_SET_TYPE_UNSPECIFIED = 0;
+    TRAINING_SET_TYPE_DYNAMIC = 1;
+    TRAINING_SET_TYPE_STATIC = 2;
+    TRAINING_SET_TYPE_VIEW = 3;
 }

--- a/provider/correctness_test.go
+++ b/provider/correctness_test.go
@@ -738,6 +738,7 @@ func getTrainingSetDatasetTS(storeType pt.Type, storeConfig pc.SerializedConfig)
 				{ProviderType: storeType, ProviderConfig: storeConfig, TimestampColumnName: "MEASURED_ON", Location: loc, Columns: &metadata.ResourceVariantColumns{Entity: "LOCATION_ID", Value: "SWELL_PERIOD_SEC", TS: "MEASURED_ON"}, EntityMappings: &metadata.EntityMappings{Mappings: []metadata.EntityMapping{{Name: "Location", EntityColumn: "LOCATION_ID"}}, ValueColumn: "SWELL_PERIOD_SEC", TimestampColumn: "MEASURED_ON"}},
 				{ProviderType: storeType, ProviderConfig: storeConfig, TimestampColumnName: "MEASURED_ON", Location: loc, Columns: &metadata.ResourceVariantColumns{Entity: "LOCATION_ID", Value: "WIND_SPEED_KTS", TS: "MEASURED_ON"}, EntityMappings: &metadata.EntityMappings{Mappings: []metadata.EntityMapping{{Name: "Location", EntityColumn: "LOCATION_ID"}}, ValueColumn: "WIND_SPEED_KTS", TimestampColumn: "MEASURED_ON"}},
 			},
+			Type: metadata.DynamicTrainingSet,
 		},
 	}
 }
@@ -821,6 +822,7 @@ func getTrainingSetFeaturesTSLabelsNoTS(storeType pt.Type, storeConfig pc.Serial
 				{ProviderType: storeType, ProviderConfig: storeConfig, TimestampColumnName: "MEASURED_ON", Location: loc, Columns: &metadata.ResourceVariantColumns{Entity: "LOCATION_ID", Value: "SWELL_PERIOD_SEC", TS: "MEASURED_ON"}, EntityMappings: &metadata.EntityMappings{Mappings: []metadata.EntityMapping{{Name: "Location", EntityColumn: "LOCATION_ID"}}, ValueColumn: "SWELL_PERIOD_SEC", TimestampColumn: "MEASURED_ON"}},
 				{ProviderType: storeType, ProviderConfig: storeConfig, TimestampColumnName: "MEASURED_ON", Location: loc, Columns: &metadata.ResourceVariantColumns{Entity: "LOCATION_ID", Value: "WIND_SPEED_KTS", TS: "MEASURED_ON"}, EntityMappings: &metadata.EntityMappings{Mappings: []metadata.EntityMapping{{Name: "Location", EntityColumn: "LOCATION_ID"}}, ValueColumn: "WIND_SPEED_KTS", TimestampColumn: "MEASURED_ON"}},
 			},
+			Type: metadata.DynamicTrainingSet,
 		},
 	}
 }
@@ -915,6 +917,7 @@ func getTrainingSetDatasetFeaturesNoTSLabelTS(storeType pt.Type, storeConfig pc.
 				{ProviderType: storeType, ProviderConfig: storeConfig, Location: loc, Columns: &metadata.ResourceVariantColumns{Entity: "SURFER_ID", Value: "WEIGHT_KG"}, EntityMappings: &metadata.EntityMappings{Mappings: []metadata.EntityMapping{{Name: "surfer", EntityColumn: "SURFER_ID"}}, ValueColumn: "WEIGHT_KG"}},
 				{ProviderType: storeType, ProviderConfig: storeConfig, Location: loc, Columns: &metadata.ResourceVariantColumns{Entity: "SURFER_ID", Value: "HEIGHT_CM"}, EntityMappings: &metadata.EntityMappings{Mappings: []metadata.EntityMapping{{Name: "surfer", EntityColumn: "SURFER_ID"}}, ValueColumn: "HEIGHT_CM"}},
 			},
+			Type: metadata.DynamicTrainingSet,
 		},
 	}
 }
@@ -995,6 +998,7 @@ func getTrainingSetDatasetNoTS(storeType pt.Type, storeConfig pc.SerializedConfi
 				{ProviderType: storeType, ProviderConfig: storeConfig, Location: loc, Columns: &metadata.ResourceVariantColumns{Entity: "SURFER_ID", Value: "FAV_SPOT"}, EntityMappings: &metadata.EntityMappings{Mappings: []metadata.EntityMapping{{Name: "surfer", EntityColumn: "SURFER_ID"}}, ValueColumn: "FAV_SPOT"}},
 				{ProviderType: storeType, ProviderConfig: storeConfig, Location: loc, Columns: &metadata.ResourceVariantColumns{Entity: "SURFER_ID", Value: "MOST_USED_BOARD_TYPE"}, EntityMappings: &metadata.EntityMappings{Mappings: []metadata.EntityMapping{{Name: "surfer", EntityColumn: "SURFER_ID"}}, ValueColumn: "MOST_USED_BOARD_TYPE"}},
 			},
+			Type: metadata.DynamicTrainingSet,
 		},
 	}
 }

--- a/provider/offline.go
+++ b/provider/offline.go
@@ -173,6 +173,7 @@ type TrainingSetDef struct {
 	FeatureSourceMappings   []SourceMapping
 	LagFeatures             []LagFeatureDef
 	ResourceSnowflakeConfig *metadata.ResourceSnowflakeConfig
+	Type                    metadata.TrainingSetType
 }
 
 type TrainingSetDefJSON struct {

--- a/provider/snowflake.go
+++ b/provider/snowflake.go
@@ -73,113 +73,132 @@ type snowflakeOfflineStore struct {
 }
 
 func (sf *snowflakeOfflineStore) CreateTransformation(config TransformationConfig, opts ...TransformationOption) error {
-	sf.logger.Debugw("Snowflake offline store creating transformation ...", "config", config)
+	logger := sf.logger.WithResource(logging.SourceVariant, config.TargetTableID.Name, config.TargetTableID.Variant).With("config", config)
+	logger.Info("Snowflake offline store creating transformation ...")
 	if len(opts) > 0 {
-		sf.logger.Errorw("Snowflake off does not support transformation options")
+		logger.Errorw("Snowflake off does not support transformation options")
 		return fferr.NewInternalErrorf("Snowflake off does not support transformation options")
 	}
 	tableName, err := sf.sqlOfflineStore.getTransformationTableName(config.TargetTableID)
 	if err != nil {
-		sf.logger.Errorw("Failed to get transformation table name", "error", err)
+		logger.Errorw("Failed to get transformation table name", "error", err)
 		return err
 	}
 	var snowflakeConfig pc.SnowflakeConfig
 	if err := snowflakeConfig.Deserialize(sf.sqlOfflineStore.Config()); err != nil {
-		sf.logger.Errorw("Failed to deserialize snowflake config", "error", err)
+		logger.Errorw("Failed to deserialize snowflake config", "error", err)
 		return err
 	}
+	logger.Debugw("Snowflake catalog config for SQL transformation", "catalog", snowflakeConfig.Catalog)
 	// Given our API design allows for users to define Dynamic Iceberg Table configurations at the catalog level, it's possible
 	// that config.SnowflakeDynamicTableConfig is nil. In this case, we'll create a new empty config to facilitate the merge with the catalog config.
 	resConfig := config.ResourceSnowflakeConfig
 	if resConfig == nil {
+		logger.Debugw("Resource table config for SQL transformation is empty")
 		resConfig = &metadata.ResourceSnowflakeConfig{}
 	}
+	logger.Debugw("Resource table config for SQL transformation before Merge with Snowflake Config", "config", resConfig)
 	if err := resConfig.Merge(&snowflakeConfig); err != nil {
-		sf.logger.Errorw("Failed to merge dynamic table config", "error", err)
+		logger.Errorw("Failed to merge dynamic table config", "error", err)
 		return err
 	}
-	query, err := sf.sfQueries.dynamicIcebergTableCreate(tableName, config.Query, *resConfig)
-	if err != nil {
-		sf.logger.Errorw("Failed to create dynamic iceberg table query", "error", err)
+	logger.Debugw("Resource table config for SQL transformation after Merge with Snowflake Config", "config", resConfig)
+	if err := resConfig.Validate(); err != nil {
+		logger.Errorw("Failed to validate dynamic table config", "error", err)
 		return err
 	}
-	sf.logger.Debugw("Creating Dynamic Iceberg Table for source", "query", query)
+	query := sf.sfQueries.dynamicIcebergTableCreate(tableName, config.Query, *resConfig)
+	logger.Debugw("Creating Dynamic Iceberg Table for source", "query", query)
 	if _, err := sf.sqlOfflineStore.db.Exec(query); err != nil {
+		logger.Errorw("Failed to create dynamic iceberg table", "error", err)
 		wrapped := fferr.NewResourceExecutionError(pt.SnowflakeOffline.String(), config.TargetTableID.Name, config.TargetTableID.Variant, fferr.ResourceType(config.TargetTableID.Type.String()), err)
-		sf.logger.Errorw("Failed to create dynamic iceberg table", "error", err)
 		return sf.handleErr(wrapped, err)
 	}
+	logger.Info("Successfully created transformation")
 	return nil
 }
 
 func (sf *snowflakeOfflineStore) UpdateTransformation(config TransformationConfig, opts ...TransformationOption) error {
+	sf.logger.Errorw("Snowflake Offline Store does not currently support updating transformations", "config", config, "opts", opts)
 	return fferr.NewInternalErrorf("Snowflake Offline Store does not currently support updating transformations")
 }
 
 // RegisterResourceFromSourceTable creates a new table in the database for labels, but not features. Unlike the sqlOfflineStore implementation, which
 // creates a resource table for features, there's no need here for the intermediate table between source transformation and materialization table.
 func (sf *snowflakeOfflineStore) RegisterResourceFromSourceTable(id ResourceID, schema ResourceSchema, opts ...ResourceOption) (OfflineTable, error) {
-	sf.logger.Debugw("Snowflake offline store creating resource table...", "id", id, "schema", schema, "opts", opts)
+	logger := sf.logger.With("id", id, "schema", schema, "opts", opts)
+	logger.Info("Snowflake offline store creating resource table...")
 	if id.Type == Feature {
-		sf.logger.Debugw("Snowflake Offline Store does not support creating resource tables for features")
+		logger.Debugw("Snowflake Offline Store does not support creating resource tables for features")
 		return nil, nil
 	}
 	if err := id.check(Label); err != nil {
+		logger.Errorw("Failed to validate resource ID", "error", err)
 		return nil, err
 	}
 	if len(opts) == 0 || opts[0].Type() != SnowflakeDynamicTableResource {
+		logger.Errorw("Snowflake Offline Store requires Dynamic Table Resource Options")
 		return nil, fferr.NewInternalErrorf("Snowflake Offline Store requires Dynamic Table Resource Options")
 	}
 	opt, isSnowflakeConfigOpt := opts[0].(*ResourceSnowflakeConfigOption)
 	if !isSnowflakeConfigOpt {
+		logger.Errorw("Snowflake Offline Store requires Resource Config Options; received %T", opts[0])
 		return nil, fferr.NewInternalErrorf("Snowflake Offline Store requires Resource Config Options; received %T", opts[0])
 	}
 	tableConfig := opt.Config
 	if tableConfig == nil {
+		logger.Debugw("Resource table config for label resource is empty")
 		tableConfig = &metadata.SnowflakeDynamicTableConfig{}
 	}
+	logger.Debugw("Resource table config for label resource before Merge with Snowflake Config", "config", tableConfig)
 	resConfig := &metadata.ResourceSnowflakeConfig{
 		DynamicTableConfig: tableConfig,
 		Warehouse:          opt.Warehouse,
 	}
 	var snowflakeConfig pc.SnowflakeConfig
 	if err := snowflakeConfig.Deserialize(sf.sqlOfflineStore.Config()); err != nil {
-		sf.logger.Errorw("Failed to deserialize snowflake config", "error", err)
+		logger.Errorw("Failed to deserialize snowflake config", "error", err)
 		return nil, err
 	}
+	logger.Debugw("Snowflake catalog config for label resource", "config", snowflakeConfig.Catalog)
 	if err := resConfig.Merge(&snowflakeConfig); err != nil {
-		sf.logger.Errorw("Failed to merge dynamic table config", "error", err)
+		logger.Errorw("Failed to merge dynamic table config", "error", err)
 		return nil, err
 	}
+	logger.Debugw("Resource table config for label resource after Merge with Snowflake Config", "config", resConfig)
 	if exists, err := sf.sqlOfflineStore.tableExistsForResourceId(id); err != nil {
+		logger.Errorw("Failed to check if table exists", "error", err)
 		return nil, err
 	} else if exists {
+		logger.Errorw("Table already exists", "id", id)
 		return nil, fferr.NewDatasetAlreadyExistsError(id.Name, id.Variant, nil)
 	}
 	if err := schema.Validate(); err != nil {
-		sf.logger.Errorw("Failed to validate schema", "error", err)
+		logger.Errorw("Failed to validate schema", "error", err)
 		return nil, err
 	}
 	resourceAsQuery, err := sf.sfQueries.resourceTableAsQuery(schema)
 	if err != nil {
-		sf.logger.Errorw("Failed to create resource table as query", "error", err)
+		logger.Errorw("Failed to create resource table as query", "error", err)
 		return nil, err
 	}
 	tableName, err := ps.ResourceToTableName(id.Type.String(), id.Name, id.Variant)
 	if err != nil {
+		logger.Errorw("Failed to get resource table name", "error", err)
 		return nil, err
 	}
-	query, err := sf.sfQueries.dynamicIcebergTableCreate(tableName, resourceAsQuery, *resConfig)
-	if err != nil {
-		sf.logger.Errorw("Failed to create dynamic iceberg table query", "error", err)
+	if err := resConfig.Validate(); err != nil {
+		logger.Errorw("Failed to validate dynamic table config", "error", err)
 		return nil, err
 	}
-	sf.logger.Debugw("Creating Dynamic Iceberg Table for label variant", "query", query)
+	query := sf.sfQueries.dynamicIcebergTableCreate(tableName, resourceAsQuery, *resConfig)
+	logger.Debugw("Creating Dynamic Iceberg Table for label variant", "query", query)
 	if _, err := sf.sqlOfflineStore.db.Exec(query); err != nil {
+		logger.Errorw("Failed to create dynamic iceberg table", "error", err)
 		wrapped := fferr.NewResourceExecutionError(pt.SnowflakeOffline.String(), id.Name, id.Variant, fferr.LABEL_VARIANT, err)
-		sf.logger.Errorw("Failed to create dynamic iceberg table", "error", err)
 		return nil, sf.handleErr(wrapped, err)
 	}
+	logger.Info("Successfully created resource table")
 	return &snowflakeOfflineTable{
 		sqlOfflineTable: sqlOfflineTable{
 			db:           sf.sqlOfflineStore.db,
@@ -192,34 +211,41 @@ func (sf *snowflakeOfflineStore) RegisterResourceFromSourceTable(id ResourceID, 
 }
 
 func (sf *snowflakeOfflineStore) GetResourceTable(id ResourceID) (OfflineTable, error) {
-	sf.logger.Debugw("Snowflake offline store getting resource table...", "id", id)
+	logger := sf.logger.WithResource(logging.LabelVariant, id.Name, id.Variant)
+	logger.Info("Snowflake offline store getting resource table...")
 	if id.Type == Feature {
-		sf.logger.Debugw("Snowflake Offline Store does not support resource tables for features")
+		logger.Debugw("Snowflake Offline Store does not support resource tables for features")
 		return nil, nil
 	}
 	if err := id.check(Label); err != nil {
+		logger.Errorw("Failed to validate resource ID", "error", err)
 		return nil, err
 	}
 	config := pc.SnowflakeConfig{}
 	if err := config.Deserialize(sf.sqlOfflineStore.Config()); err != nil {
+		logger.Errorw("Failed to deserialize snowflake config", "error", err)
 		return nil, err
 	}
 	tableName, err := ps.ResourceToTableName(id.Type.String(), id.Name, id.Variant)
 	if err != nil {
+		logger.Errorw("Failed to get resource table name", "error", err)
 		return nil, err
 	}
 	var schema = config.Schema
 	if schema == "" {
+		logger.Debug("Schema is empty, defaulting to PUBLIC")
 		schema = "PUBLIC"
 	}
 	loc := pl.NewFullyQualifiedSQLLocation(config.Database, schema, tableName)
 
 	if exists, err := sf.sqlOfflineStore.tableExists(loc); err != nil {
+		logger.Errorw("Failed to check if table exists", "error", err)
 		return nil, err
 	} else if !exists {
+		logger.Errorw("Table does not exist", "location", loc.Location())
 		return nil, fferr.NewDatasetNotFoundError(id.Name, id.Variant, nil)
 	}
-
+	logger.Info("Successfully retrieved resource table")
 	return &snowflakeOfflineTable{
 		sqlOfflineTable: sqlOfflineTable{
 			db:           sf.sqlOfflineStore.db,
@@ -232,55 +258,55 @@ func (sf *snowflakeOfflineStore) GetResourceTable(id ResourceID) (OfflineTable, 
 }
 
 func (sf *snowflakeOfflineStore) CreateMaterialization(id ResourceID, opts MaterializationOptions) (Materialization, error) {
+	logger := sf.logger.WithResource(logging.FeatureVariant, id.Name, id.Variant)
 	if err := id.check(Feature); err != nil {
+		logger.Errorw("Failed to validate resource ID", "error", err)
 		return nil, err
 	}
 	var snowflakeConfig pc.SnowflakeConfig
 	if err := snowflakeConfig.Deserialize(sf.sqlOfflineStore.Config()); err != nil {
-		sf.logger.Errorw("Failed to deserialize snowflake config", "error", err)
+		logger.Errorw("Failed to deserialize snowflake config", "error", err)
 		return nil, err
 	}
 	resConfig := opts.ResourceSnowflakeConfig
 	if resConfig == nil {
+		logger.Debugw("Resource table config for materialization is empty")
 		resConfig = &metadata.ResourceSnowflakeConfig{}
 	}
-	sf.logger.Debugw("Dynamic Table Config before Merge with Snowflake Config", "config", resConfig)
+	logger.Debugw("Dynamic Table Config before Merge with Snowflake Config", "config", resConfig)
 	if err := resConfig.Merge(&snowflakeConfig); err != nil {
-		sf.logger.Errorw("Failed to merge dynamic table config", "error", err)
+		logger.Errorw("Failed to merge dynamic table config", "error", err)
 		return nil, err
 	}
 
-	// It seems that Snowflake can mistakenly choose a full refresh for a query that's compliant
-	// with an incremental refresh, and given our materialization query has been written to be
-	// incremental, we're hardcoding INCREMENTAL here to avoid the issue where our materialization
-	// tables update fully.
-	resConfig.DynamicTableConfig.RefreshMode = metadata.IncrementalRefresh
-
-	sf.logger.Debugw(("Dynamic Table Config after Merge with Snowflake Config"), "config", resConfig)
+	logger.Debugw(("Dynamic Table Config after Merge with Snowflake Config"), "config", resConfig)
 	tableName, err := ps.ResourceToTableName(FeatureMaterialization.String(), id.Name, id.Variant)
 	if err != nil {
+		logger.Errorw("Failed to get materialization table name", "error", err)
 		return nil, err
 	}
 	if err := opts.Schema.Validate(); err != nil {
-		sf.logger.Errorw("Failed to validate schema", "error", err)
+		logger.Errorw("Failed to validate schema", "error", err)
 		return nil, err
 	}
 	sqlLoc, isSqlLoc := opts.Schema.SourceTable.(*pl.SQLLocation)
 	if !isSqlLoc {
+		logger.Errorw("Source table is not an SQL location", "location_type", fmt.Sprintf("%T", opts.Schema.SourceTable))
 		return nil, fferr.NewInvalidArgumentErrorf("source table is not an SQL location")
 	}
 	materializationAsQuery := sf.sfQueries.materializationCreateAsQuery(opts.Schema.Entity, opts.Schema.Value, opts.Schema.TS, SanitizeSqlLocation(sqlLoc.TableLocation()))
-	query, err := sf.sfQueries.dynamicIcebergTableCreate(tableName, materializationAsQuery, *resConfig)
-	if err != nil {
-		sf.logger.Errorw("Failed to create dynamic iceberg table query", "error", err)
+	if err := resConfig.Validate(); err != nil {
+		logger.Errorw("Failed to validate dynamic table config", "error", err)
 		return nil, err
 	}
-	sf.logger.Debugw("Creating Dynamic Iceberg Table for materialization", "query", query)
+	query := sf.sfQueries.dynamicIcebergTableCreate(tableName, materializationAsQuery, *resConfig)
+	logger.Debugw("Creating Dynamic Iceberg Table for materialization", "query", query)
 	if _, err := sf.sqlOfflineStore.db.Exec(query); err != nil {
+		logger.Errorw("Failed to create dynamic iceberg table", "error", err)
 		wrapped := fferr.NewResourceExecutionError(pt.SnowflakeOffline.String(), id.Name, id.Variant, fferr.FEATURE_MATERIALIZATION, err)
-		sf.logger.Errorw("Failed to create dynamic iceberg table", "error", err)
 		return nil, sf.handleErr(wrapped, err)
 	}
+	logger.Info("Successfully created materialization")
 	return &sqlMaterialization{
 		id:           MaterializationID(fmt.Sprintf("%s__%s", id.Name, id.Variant)),
 		db:           sf.sqlOfflineStore.db,
@@ -292,49 +318,73 @@ func (sf *snowflakeOfflineStore) CreateMaterialization(id ResourceID, opts Mater
 }
 
 func (sf *snowflakeOfflineStore) UpdateMaterialization(id ResourceID, opts MaterializationOptions) (Materialization, error) {
+	sf.logger.Errorw("Snowflake Offline Store does not currently support updating materializations", "id", id, "opts", opts)
 	return nil, fferr.NewInternalErrorf("Snowflake Offline Store does not currently support updating materializations")
 }
 
 func (sf *snowflakeOfflineStore) CreateTrainingSet(def TrainingSetDef) error {
+	logger := sf.logger.WithResource(logging.TrainingSetVariant, def.ID.Name, def.ID.Variant).With("training_set_type", def.Type)
+	logger.Debugw("Snowflake offline store creating training set ...")
 	if err := def.check(); err != nil {
+		logger.Errorw("Failed to validate training set definition", "error", err)
 		return err
 	}
 	var snowflakeConfig pc.SnowflakeConfig
 	if err := snowflakeConfig.Deserialize(sf.sqlOfflineStore.Config()); err != nil {
-		sf.logger.Errorw("Failed to deserialize snowflake config", "error", err)
+		logger.Errorw("Failed to deserialize snowflake config", "error", err)
 		return err
 	}
 	resConfig := def.ResourceSnowflakeConfig
 	if resConfig == nil {
+		logger.Debugw("Resource table config for training set is empty")
 		resConfig = &metadata.ResourceSnowflakeConfig{}
 	}
 	if err := resConfig.Merge(&snowflakeConfig); err != nil {
-		sf.logger.Errorw("Failed to merge dynamic table config", "error", err)
+		logger.Errorw("Failed to merge dynamic table config", "error", err)
 		return err
 	}
 	tableName, err := sf.sqlOfflineStore.getTrainingSetName(def.ID)
 	if err != nil {
+		logger.Errorw("Failed to get training set table name", "error", err)
 		return err
 	}
-	ts, err := sf.buildTrainingSetQuery(def)
+	tsQuery, err := sf.buildTrainingSetQuery(def)
 	if err != nil {
+		logger.Errorw("Failed to build training set query", "error", err)
 		return err
 	}
-	query, err := sf.sfQueries.dynamicIcebergTableCreate(tableName, ts, *resConfig)
-	if err != nil {
-		sf.logger.Errorw("Failed to create dynamic iceberg table query", "error", err)
-		return err
+	var ctaQuery string
+	switch def.Type {
+	case metadata.DynamicTrainingSet:
+		if err := resConfig.Validate(); err != nil {
+			logger.Errorw("Failed to validate dynamic table config", "error", err)
+			return err
+		}
+		ctaQuery = sf.sfQueries.dynamicIcebergTableCreate(tableName, tsQuery, *resConfig)
+	case metadata.StaticTrainingSet:
+		if err := resConfig.Validate(); err != nil {
+			logger.Errorw("Failed to validate dynamic table config", "error", err)
+			return err
+		}
+		ctaQuery = sf.sfQueries.staticIcebergTableCreate(tableName, tsQuery, *resConfig)
+	case metadata.ViewTrainingSet:
+		ctaQuery = sf.sfQueries.viewCreate(tableName, tsQuery)
+	default:
+		logger.Errorw("Unsupported training set type", "type", def.Type)
+		return fferr.NewInternalErrorf("Unsupported training set type: %v", def.Type)
 	}
-	sf.logger.Debugw("Creating Dynamic Iceberg Table for training set", "query", query)
-	if _, err := sf.sqlOfflineStore.db.Exec(query); err != nil {
+	logger.Debugw("Creating Dynamic Iceberg Table for training set", "query", ctaQuery)
+	if _, err := sf.sqlOfflineStore.db.Exec(ctaQuery); err != nil {
 		wrapped := fferr.NewResourceExecutionError(pt.SnowflakeOffline.String(), def.ID.Name, def.ID.Variant, fferr.TRAINING_SET_VARIANT, err)
-		sf.logger.Errorw("Failed to create dynamic iceberg table", "error", err)
+		logger.Errorw("Failed to create dynamic iceberg table", "error", err)
 		return sf.handleErr(wrapped, err)
 	}
+	logger.Info("Successfully created training set")
 	return nil
 }
 
 func (sf *snowflakeOfflineStore) UpdateTrainingSet(def TrainingSetDef) error {
+	sf.logger.Errorw("Snowflake Offline Store does not currently support updating training sets", "def", def)
 	return fferr.NewInternalErrorf("Snowflake Offline Store does not currently support updating training sets")
 }
 
@@ -347,24 +397,28 @@ func (sf *snowflakeOfflineStore) AsOfflineStore() (OfflineStore, error) {
 }
 
 func (sf snowflakeOfflineStore) Delete(location pl.Location) error {
+	logger := sf.logger.With("location", location.Location())
 	if exists, err := sf.sqlOfflineStore.tableExists(location); err != nil {
+		logger.Errorw("Failed to check if table exists", "error", err)
 		return err
 	} else if !exists {
+		logger.Errorw("Table does not exist")
 		return fferr.NewDatasetLocationNotFoundError(location.Location(), nil)
 	}
 
 	sqlLoc, isSqlLoc := location.(*pl.SQLLocation)
 	if !isSqlLoc {
+		logger.Errorw("Location is not an SQL location", "location_type", fmt.Sprintf("%T", location))
 		return fferr.NewInternalErrorf("location is not an SQL location")
 	}
 
 	query := sf.sfQueries.dropTableQuery(*sqlLoc)
-	sf.logger.Debugw("Deleting table", "query", query)
-
+	logger.Debugw("Dropping table", "query", query)
 	if _, err := sf.db.Exec(query); err != nil {
+		logger.Errorw("Failed to drop table", "error", err)
 		return sf.handleErr(fferr.NewExecutionError(pt.SnowflakeOffline.String(), err), err)
 	}
-
+	logger.Info("Successfully dropped table")
 	return nil
 }
 

--- a/provider/snowflake_queries_test.go
+++ b/provider/snowflake_queries_test.go
@@ -68,10 +68,7 @@ func TestSnowflakeDynamicIcebergTableQuery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := snowflakeSQLQueries{}.dynamicIcebergTableCreate(tt.table, tt.query, tt.config)
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-			}
+			actual := snowflakeSQLQueries{}.dynamicIcebergTableCreate(tt.table, tt.query, tt.config)
 
 			if actual != tt.expected {
 				t.Errorf("Expected %v, but instead found %v", tt.expected, actual)

--- a/provider/snowflake_test.go
+++ b/provider/snowflake_test.go
@@ -209,6 +209,54 @@ func (s *snowflakeOfflineStoreTester) CheckWarehouse(id ResourceID, expectedWh s
 	return warehouse == expectedWh, nil
 }
 
+func (s *snowflakeOfflineStoreTester) AssertTrainingSetType(t *testing.T, id ResourceID, tsType metadata.TrainingSetType) {
+	db, err := s.sqlOfflineStore.getDb("", "")
+	if err != nil {
+		t.Fatalf("could not get database: %v", err)
+	}
+
+	tableName, err := ps.ResourceToTableName(TrainingSet.String(), id.Name, id.Variant)
+	if err != nil {
+		t.Fatalf("could not get table name: %v", err)
+	}
+
+	query := fmt.Sprintf("SELECT TABLE_TYPE, IS_DYNAMIC, IS_ICEBERG FROM information_schema.tables WHERE TABLE_NAME = '%s'", tableName)
+
+	r := db.QueryRow(query)
+
+	var tableType string
+	var isDynamic string
+	var isIceberg string
+
+	if err := r.Scan(&tableType, &isDynamic, &isIceberg); err != nil {
+		if err == sql.ErrNoRows {
+			// Handle the case where no rows were returned
+			t.Fatal("No tables found with the specified name.")
+		}
+		t.Fatalf("could not get table name: %v", err)
+	}
+
+	var isCorrectTrainingSetType bool
+	var tsTypeErr error
+	switch tsType {
+	case metadata.DynamicTrainingSet:
+		isCorrectTrainingSetType = tableType == "BASE TABLE" && isDynamic == "YES" && isIceberg == "YES"
+	case metadata.StaticTrainingSet:
+		isCorrectTrainingSetType = tableType == "BASE TABLE" && isDynamic == "NO" && isIceberg == "YES"
+	case metadata.ViewTrainingSet:
+		isCorrectTrainingSetType = tableType == "VIEW" && isDynamic == "NO" && isIceberg == "NO"
+	default:
+		tsTypeErr = fferr.NewInvalidArgumentErrorf("invalid training set type: %s", tsType)
+	}
+
+	if tsTypeErr != nil {
+		t.Fatalf("failed to check training set type: %v", err)
+	}
+	if !isCorrectTrainingSetType {
+		t.Fatalf("expected training set to be of type %s", tsType)
+	}
+}
+
 // TESTS
 
 func TestSnowflakeTransformations(t *testing.T) {
@@ -279,6 +327,31 @@ func TestSnowflakeTrainingSets(t *testing.T) {
 			RegisterTrainingSet(t, tester, constTestCase)
 		})
 	}
+}
+
+func TestSnowflakeTrainingSetTypes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration tests")
+	}
+
+	tester := getConfiguredTester(t, false)
+
+	tsTypes := map[metadata.TrainingSetType]trainingSetDatasetType{
+		metadata.DynamicTrainingSet: tsDatasetFeaturesLabelTS,
+		metadata.StaticTrainingSet:  tsDatasetFeaturesTSLabelNoTS,
+		metadata.ViewTrainingSet:    tsDatasetFeaturesNoTSLabelTS,
+	}
+
+	for tsType, dataSetType := range tsTypes {
+		constName := string(tsType)
+		constTsType := tsType
+		constDataSetType := dataSetType
+		t.Run(constName, func(t *testing.T) {
+			t.Parallel()
+			RegisterTrainingSetWithType(t, tester, constDataSetType, constTsType)
+		})
+	}
+
 }
 
 func TestSnowflakeSchemas(t *testing.T) {
@@ -956,6 +1029,34 @@ func RegisterTrainingSet(t *testing.T, tester offlineSqlTest, tsDatasetType trai
 		t.Fatalf("could not get training set: %v", err)
 	}
 	tsTest.data.Assert(t, ts)
+}
+
+func RegisterTrainingSetWithType(t *testing.T, tester offlineSqlTest, tsDatasetType trainingSetDatasetType, tsType metadata.TrainingSetType) {
+	tsTest := newSQLTrainingSetTest(tester.storeTester, tsDatasetType)
+	_ = initSqlPrimaryDataset(t, tsTest.tester, tsTest.data.location, tsTest.data.schema, tsTest.data.records)
+	_ = initSqlPrimaryDataset(t, tsTest.tester, tsTest.data.labelLocation, tsTest.data.labelSchema, tsTest.data.labelRecords)
+
+	res, err := tsTest.tester.RegisterResourceFromSourceTable(tsTest.data.labelID, tsTest.data.labelResourceSchema, &ResourceSnowflakeConfigOption{})
+	if err != nil {
+		t.Fatalf("could not register label table: %v", err)
+	}
+	tsTest.data.def.LabelSourceMapping.Location = res.Location()
+	tsTest.data.def.Type = tsType
+	if err := tsTest.tester.CreateTrainingSet(tsTest.data.def); err != nil {
+		t.Fatalf("could not create training set: %v", err)
+	}
+	ts, err := tsTest.tester.GetTrainingSet(tsTest.data.id)
+	if err != nil {
+		t.Fatalf("could not get training set: %v", err)
+	}
+	tsTest.data.Assert(t, ts)
+
+	snowflakeTester, isSnowflakeTester := tester.storeTester.(*snowflakeOfflineStoreTester)
+	if !isSnowflakeTester {
+		t.Fatalf("expected store tester to be snowflakeOfflineStoreTester")
+	}
+
+	snowflakeTester.AssertTrainingSetType(t, tsTest.data.id, tsType)
 }
 
 func DeleteTableTest(t *testing.T, tester offlineSqlTest) {

--- a/tests/end_to_end/pytest/snowflake/test_snowflake.py
+++ b/tests/end_to_end/pytest/snowflake/test_snowflake.py
@@ -135,8 +135,16 @@ def test_snowflake_multi_entity_label_registration(
     )
 
 
+@pytest.mark.parametrize(
+    "ts_type",
+    [
+        ff.TrainingSetType.DYNAMIC,
+        ff.TrainingSetType.STATIC,
+        ff.TrainingSetType.VIEW,
+    ],
+)
 def test_snowflake_training_set_registration(
-    ff_client, redis_fixture, snowflake_fixture, snowflake_transactions_dataset
+    ff_client, redis_fixture, snowflake_fixture, snowflake_transactions_dataset, ts_type
 ):
     @snowflake_fixture.sql_transformation(inputs=[snowflake_transactions_dataset])
     def snowflake_avg_transactions_ts(tbl):
@@ -160,6 +168,7 @@ def test_snowflake_training_set_registration(
         name="snowflake_training_set",
         features=[SnowflakeUser.avg_transactions_ts],
         label=SnowflakeUser.fraudulent_ts,
+        type=ts_type,
     )
 
     ff_client.apply(asynchronous=False, verbose=True)


### PR DESCRIPTION
# Description

This PR introduces the concept of 3 different training set types:

* Dynamic (Default) - training sets will automatically update when upstream tables have changes
* Static - training sets will be created once and will not change
* View - training sets will only be "evaluating" when the training set 

## Type of change

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced support for different training set types: Dynamic, Static, and View.
  - Enhanced training set registration with type-specific configurations.
  - Added functionality for multi-entity label registration in Snowflake.

- **Improvements**
  - Added more granular type handling for training sets across multiple components.
  - Improved logging and error handling for training set operations.
  - Extended protobuf definitions to support training set type classification.

- **Technical Updates**
  - Updated client, metadata, and provider interfaces to accommodate training set type variations.
  - Implemented type conversion methods between different representations.
  - Enhanced test coverage for training set types and registration processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->