### PR TITLE
Cleanup: removes label resource table for Snowflake (#1762)

### DIFF
--- a/coordinator/tasks/label.go
+++ b/coordinator/tasks/label.go
@@ -10,7 +10,6 @@ package tasks
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/featureform/provider/provider_schema"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/featureform/metadata"
 	"github.com/featureform/provider"
 	pl "github.com/featureform/provider/location"
-	pt "github.com/featureform/provider/provider_type"
 	"github.com/featureform/scheduling"
 )
 
@@ -119,24 +117,9 @@ func (t *LabelTask) Run() error {
 		logger.Errorw("Failed to add run log", "error", err)
 		return err
 	}
-	logger.Debugw("Checking source store type", "type", fmt.Sprintf("%T", sourceStore))
-	opts := make([]provider.ResourceOption, 0)
-	if sourceStore.Type() == pt.SnowflakeOffline {
-		logger.Debugw("Source store is snowflake")
-		tempConfig, err := label.ResourceSnowflakeConfig()
-		if err != nil {
-			logger.Errorw("Failed to get snowflake config", "error", err)
-			return err
-		}
-		snowflakeDynamicTableConfigOpts := &provider.ResourceSnowflakeConfigOption{
-			Config:    tempConfig.DynamicTableConfig,
-			Warehouse: tempConfig.Warehouse,
-		}
-		opts = append(opts, snowflakeDynamicTableConfigOpts)
-	}
-
-	if _, err := sourceStore.RegisterResourceFromSourceTable(labelID, schema, opts...); err != nil {
-		logger.Errorw("Failed to register resource from source table", "id", labelID, "opts length", len(opts), "error", err)
+	logger.Debugw("Calling offline store to register resource from source table")
+	if _, err := sourceStore.RegisterResourceFromSourceTable(labelID, schema); err != nil {
+		logger.Errorw("Failed to register resource from source table", "id", labelID, "error", err)
 		return err
 	}
 	logger.Debugw("Resource Table Created", "id", labelID, "schema", schema)

--- a/coordinator/tasks/trainingset.go
+++ b/coordinator/tasks/trainingset.go
@@ -31,8 +31,8 @@ type TrainingSetTask struct {
 }
 
 func (t *TrainingSetTask) Run() error {
-	ctx := t.logger.AttachToContext(context.Background())
 	logger := t.logger.With("%#v\n", t.taskDef.Target)
+	ctx := logger.AttachToContext(context.Background())
 	nv, ok := t.taskDef.Target.(scheduling.NameVariant)
 	if !ok {
 		logger.Errorw("cannot create a training set from target type", "type", t.taskDef.TargetType)

--- a/helpers/stringset/string_set.go
+++ b/helpers/stringset/string_set.go
@@ -7,7 +7,23 @@
 
 package stringset
 
+// func NewStringSet(initial ...string) StringSet {
+// 	ss := make(StringSet)
+
+// 	for _, str := range initial {
+// 		ss[str] = true
+// 	}
+
+// 	return ss
+// }
+
 type StringSet map[string]bool
+
+func (a StringSet) Add(items ...string) {
+	for _, item := range items {
+		a[item] = true
+	}
+}
 
 func (a StringSet) Contains(b StringSet) bool {
 	for str := range b {
@@ -16,4 +32,22 @@ func (a StringSet) Contains(b StringSet) bool {
 		}
 	}
 	return true
+}
+
+func (a StringSet) Difference(b StringSet) StringSet {
+	diff := make(StringSet)
+	for str := range a {
+		if _, ok := b[str]; !ok {
+			diff[str] = true
+		}
+	}
+	return diff
+}
+
+func (a StringSet) List() []string {
+	list := make([]string, 0, len(a))
+	for str := range a {
+		list = append(list, str)
+	}
+	return list
 }

--- a/helpers/stringset/string_set.go
+++ b/helpers/stringset/string_set.go
@@ -7,16 +7,6 @@
 
 package stringset
 
-// func NewStringSet(initial ...string) StringSet {
-// 	ss := make(StringSet)
-
-// 	for _, str := range initial {
-// 		ss[str] = true
-// 	}
-
-// 	return ss
-// }
-
 type StringSet map[string]bool
 
 func (a StringSet) Add(items ...string) {
@@ -34,6 +24,8 @@ func (a StringSet) Contains(b StringSet) bool {
 	return true
 }
 
+// Difference returns a new StringSet containing elements in a that are not in b.
+// For example: a = {"a": true, "b": true}, b = {"b": true} => diff = {"a": true}
 func (a StringSet) Difference(b StringSet) StringSet {
 	diff := make(StringSet)
 	for str := range a {

--- a/helpers/stringset/string_set_test.go
+++ b/helpers/stringset/string_set_test.go
@@ -58,3 +58,15 @@ func TestStringSetEmptySetB(t *testing.T) {
 		t.Errorf("Expected set A to contain empty set B, but instead received: %v", actual)
 	}
 }
+
+func TestStringSetDifference(t *testing.T) {
+	setA := StringSet{"a": true, "b": true, "c": false}
+	setB := StringSet{"a": true, "c": false}
+
+	expected := StringSet{"b": true}
+	actual := setA.Difference(setB)
+
+	if !actual.Contains(expected) {
+		t.Errorf("Expected difference to be %v, but instead received: %v", expected, actual)
+	}
+}

--- a/main/main.go
+++ b/main/main.go
@@ -48,9 +48,12 @@ func main() {
 		log.Fatalf("err %v", err)
 	}
 	if _, set := os.LookupEnv("FF_STATE_PROVIDER"); !set {
+		log.Println("FF_STATE_PROVIDER not set, defaulting to memory")
 		if err := os.Setenv("FF_STATE_PROVIDER", "memory"); err != nil {
 			log.Fatalf("err %v", err)
 		}
+	} else {
+		log.Println("FF_STATE_PROVIDER set to", os.Getenv("FF_STATE_PROVIDER"))
 	}
 	apiPort := help.GetEnv("API_PORT", "7878")
 	metadataHost := help.GetEnv("METADATA_HOST", "localhost")

--- a/provider/correctness_test.go
+++ b/provider/correctness_test.go
@@ -719,16 +719,16 @@ func getTrainingSetDatasetTS(storeType pt.Type, storeConfig pc.SerializedConfig)
 				ProviderType:        storeType,
 				ProviderConfig:      storeConfig,
 				TimestampColumnName: "OBSERVED_ON",
-				Location:            nil,
+				Location:            labelLoc,
 				EntityMappings: &metadata.EntityMappings{
 					Mappings: []metadata.EntityMapping{
 						{
 							Name:         "Location",
-							EntityColumn: "ENTITY_LOCATION",
+							EntityColumn: "LOCATION_ID",
 						},
 					},
-					ValueColumn:     "VALUE",
-					TimestampColumn: "TS",
+					ValueColumn:     "WAVE_HEIGHT_FT",
+					TimestampColumn: "OBSERVED_ON",
 				},
 			},
 			Features: featureIDs,
@@ -812,8 +812,8 @@ func getTrainingSetFeaturesTSLabelsNoTS(storeType pt.Type, storeConfig pc.Serial
 			LabelSourceMapping: SourceMapping{
 				ProviderType:   storeType,
 				ProviderConfig: storeConfig,
-				Location:       nil,
-				EntityMappings: &metadata.EntityMappings{Mappings: []metadata.EntityMapping{{Name: "Location", EntityColumn: "ENTITY_LOCATION"}}, ValueColumn: "VALUE"},
+				Location:       labelLoc,
+				EntityMappings: &metadata.EntityMappings{Mappings: []metadata.EntityMapping{{Name: "Location", EntityColumn: "LOCATION_ID"}}, ValueColumn: "LEVEL"},
 			},
 			Features: featureIDs,
 			FeatureSourceMappings: []SourceMapping{
@@ -904,10 +904,10 @@ func getTrainingSetDatasetFeaturesNoTSLabelTS(storeType pt.Type, storeConfig pc.
 				Location:            labelLoc,
 				EntityMappings: &metadata.EntityMappings{
 					Mappings: []metadata.EntityMapping{
-						{Name: "surfer", EntityColumn: "ENTITY_SURFER"},
+						{Name: "surfer", EntityColumn: "SURFER_ID"},
 					},
-					ValueColumn:     "VALUE",
-					TimestampColumn: "TS",
+					ValueColumn:     "SUCCESSFUL_RIDES",
+					TimestampColumn: "SESSION_DATE",
 				},
 			},
 			Features: featureIDs,
@@ -989,7 +989,7 @@ func getTrainingSetDatasetNoTS(storeType pt.Type, storeConfig pc.SerializedConfi
 				ProviderType:   storeType,
 				ProviderConfig: storeConfig,
 				Location:       labelLoc,
-				EntityMappings: &metadata.EntityMappings{Mappings: []metadata.EntityMapping{{Name: "surfer", EntityColumn: "ENTITY_SURFER"}}, ValueColumn: "VALUE"},
+				EntityMappings: &metadata.EntityMappings{Mappings: []metadata.EntityMapping{{Name: "surfer", EntityColumn: "SURFER_ID"}}, ValueColumn: "SKILL_LEVEL"},
 			},
 			Features: featureIDs,
 			FeatureSourceMappings: []SourceMapping{

--- a/provider/sql.go
+++ b/provider/sql.go
@@ -78,6 +78,7 @@ type OfflineTableQueries interface {
 	transformationCreate(name string, query string) []string
 	transformationUpdate(db *sql.DB, tableName string, query string) error
 	transformationExists() string // this isn't used anywhere should I still keep it
+	resourceTableColumns(obj pl.FullyQualifiedObject) (string, error)
 }
 
 type sqlOfflineStore struct {
@@ -1953,6 +1954,24 @@ func (q defaultOfflineSQLQueries) transformationUpdate(db *sql.DB, tableName str
 func (q defaultOfflineSQLQueries) transformationExists() string {
 	bind := q.newVariableBindingIterator()
 	return fmt.Sprintf("SELECT DISTINCT (table_name) FROM information_schema.tables WHERE table_name=%s AND table_schema=CURRENT_SCHEMA()", bind.Next())
+}
+
+func (q defaultOfflineSQLQueries) resourceTableColumns(obj pl.FullyQualifiedObject) (string, error) {
+	if obj.Database == "" {
+		return "", fferr.NewInternalErrorf("database required for resource table columns query")
+	}
+	if obj.Table == "" {
+		return "", fferr.NewInternalErrorf("table required for resource table columns query")
+	}
+	if obj.Schema == "" {
+		obj.Schema = "PUBLIC"
+	}
+	var sb strings.Builder
+	sb.WriteString("SELECT COLUMN_NAME FROM ")
+	sb.WriteString(fmt.Sprintf("%s.INFORMATION_SCHEMA.COLUMNS ", obj.Database))
+	sb.WriteString(fmt.Sprintf("WHERE TABLE_SCHEMA = '%s' ", obj.Schema))
+	sb.WriteString(fmt.Sprintf("AND TABLE_NAME = '%s'", obj.Table))
+	return sb.String(), nil
 }
 
 func GetTransformationTableName(id ResourceID) (string, error) {


### PR DESCRIPTION
# Description

This PR removes intermediate, "resource" tables from labels in Snowflake and instead introduces a check on the columns in the source tables to ensure the features/labels are correctly registered.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced utilities for managing collections of strings.
	- Enabled dynamic retrieval and validation of resource table column names for offline SQL operations.
	- Added functionality to convert resource columns into a string set for better management.

- **Refactor**
	- Streamlined resource registration across tasks, resulting in clearer error messages and improved logging.
	- Updated configuration logging to display environment defaults more informatively.

- **Tests**
	- Expanded integration tests to cover robust resource registration scenarios, ensuring reliability across valid and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->