### PR TITLE
Feature: adds tags to DynamoDB configs to tag tables

### DIFF
--- a/client/src/featureform/client.py
+++ b/client/src/featureform/client.py
@@ -832,26 +832,7 @@ class Client(ResourceClient, ServingClient):
         """
 
         provider = self.__get_provider(name)
-        config = provider.serialized_config
-        deserialized_config = json.loads(config.decode("utf-8"))
-
-        if deserialized_config["Credentials"]["Type"] == AWSStaticCredentials.type():
-            credentials = AWSStaticCredentials(
-                deserialized_config["Credentials"]["AccessKeyId"],
-                deserialized_config["Credentials"]["SecretKey"],
-            )
-        elif (
-            deserialized_config["Credentials"]["Type"]
-            == AWSAssumeRoleCredentials.type()
-        ):
-            credentials = AWSAssumeRoleCredentials()
-        else:
-            raise ValueError("Invalid Credentials Type")
-
-        dynamodb_config = DynamodbConfig(
-            region=deserialized_config["Region"],
-            credentials=credentials,
-        )
+        dynamodb_config = DynamodbConfig.deserialize(provider.serialized_config)
 
         online_provider = self.__create_provider(
             provider.name,

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -3335,7 +3335,7 @@ class Registrar:
         config = DynamodbConfig(
             credentials=credentials,
             region=region,
-            table_tags=table_tags,
+            table_tags=table_tags if table_tags else {},
         )
         provider = Provider(
             name=name,

--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -3300,8 +3300,9 @@ class Registrar:
         region: str,
         description: str = "",
         team: str = "",
-        tags: List[str] = [],
-        properties: dict = {},
+        tags: Optional[List[str]] = None,
+        properties: Optional[dict] = None,
+        table_tags: Optional[dict] = None,
     ):
         """Register a DynamoDB provider.
 
@@ -3312,6 +3313,7 @@ class Registrar:
             description="A Dynamodb deployment we created for the Featureform quickstart",
             credentials=aws_creds,
             region="us-east-1"
+            table_tags={"owner": "featureform"}
         )
         ```
 
@@ -3323,14 +3325,17 @@ class Registrar:
             team (str): (Mutable) Name of team
             tags (List[str]): (Mutable) Optional grouping mechanism for resources
             properties (dict): (Mutable) Optional grouping mechanism for resources
+            table_tags (dict): (Mutable) Tags to be added to the DynamoDB tables
 
         Returns:
             dynamodb (OnlineProvider): Provider
         """
         tags, properties = set_tags_properties(tags, properties)
+
         config = DynamodbConfig(
             credentials=credentials,
             region=region,
+            table_tags=table_tags,
         )
         provider = Provider(
             name=name,

--- a/client/tests/provider_config_test.py
+++ b/client/tests/provider_config_test.py
@@ -188,9 +188,60 @@ def test_dynamodb():
     conf = DynamodbConfig(
         region="region",
         credentials=AWSStaticCredentials(access_key="id", secret_key="key"),
+        table_tags={"owner": "featureform"},
     )
     serialized_config = conf.serialize()
     assert json.loads(serialized_config) == expected_config
+
+
+@pytest.mark.local
+@pytest.mark.parametrize(
+    "table_tags, expected_errors",
+    [
+        (  # Valid case
+            {"ValidKey": "ValidValue"},
+            [],
+        ),
+        (  # Invalid: Key exceeds 128 characters
+            {"K" * 129: "ValidValue"},
+            [
+                "Key '{}' exceeds the maximum length of 128 characters.".format(
+                    "K" * 129
+                )
+            ],
+        ),
+        (  # Invalid: Value exceeds 256 characters
+            {"ValidKey": "V" * 257},
+            ["Value for key 'ValidKey' exceeds the maximum length of 256 characters."],
+        ),
+        (  # Invalid: Key contains disallowed characters
+            {"Invalid!Key": "ValidValue"},
+            ["Key 'Invalid!Key' contains invalid characters."],
+        ),
+        (  # Invalid: Value contains disallowed characters
+            {"ValidKey": "Invalid!Value"},
+            ["Value 'Invalid!Value' contains invalid characters."],
+        ),
+        (  # Invalid: Key starts with 'aws'
+            {"awsRestrictedKey": "ValidValue"},
+            ["Key 'awsRestrictedKey' cannot start with 'aws'."],
+        ),
+        (  # Multiple errors in one case
+            {"awsKey!": "V" * 300},
+            [
+                "Value for key 'awsKey!' exceeds the maximum length of 256 characters.",
+                "Key 'awsKey!' contains invalid characters.",
+                "Key 'awsKey!' cannot start with 'aws'.",
+            ],
+        ),
+    ],
+)
+def test_dynamodb_table_tags(table_tags, expected_errors):
+    dummy_credentials = AWSStaticCredentials(access_key="test", secret_key="test")
+    config = DynamodbConfig(region="us-east-1", credentials=dummy_credentials)
+    errors = config.validate_table_tags(table_tags)
+
+    assert errors == expected_errors, f"Expected {expected_errors}, but got {errors}"
 
 
 @pytest.mark.local

--- a/provider/connection/connection_configs.json
+++ b/provider/connection/connection_configs.json
@@ -77,6 +77,9 @@
       "AccessKeyId": "id",
       "SecretKey": "key",
       "Type": "AWS_STATIC_CREDENTIALS"
+    },
+    "Tags": {
+      "owner": "featureform"
     }
   },
   "MongoDBConfig": {

--- a/provider/direct_materialize_test.go
+++ b/provider/direct_materialize_test.go
@@ -25,7 +25,7 @@ func TestDirectMaterialization(t *testing.T) {
 		"IcebergEMR": GetTestingEMRGlue(t, pc.Iceberg),
 	}
 	onlineStores := map[string]OnlineStore{
-		"Dynamo": GetTestingDynamoDB(t),
+		"Dynamo": GetTestingDynamoDB(t, map[string]string{}),
 	}
 	for offlineName, offlineStore := range offlineStores {
 		t.Logf("Testing offline store: %s", offlineName)

--- a/provider/dynamodb_test_utils.go
+++ b/provider/dynamodb_test_utils.go
@@ -16,7 +16,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-func GetTestingDynamoDB(t *testing.T) OnlineStore {
+func GetTestingDynamoDB(t *testing.T, tags map[string]string) OnlineStore {
 	err := godotenv.Load("../.env")
 	if err != nil {
 		t.Logf("could not open .env file... Checking environment: %s", err)
@@ -39,6 +39,10 @@ func GetTestingDynamoDB(t *testing.T) OnlineStore {
 		Region:             "us-east-1",
 		Endpoint:           endpoint,
 		StronglyConsistent: true,
+	}
+
+	if len(tags) > 0 {
+		dynamoConfig.Tags = tags
 	}
 
 	store, err := GetOnlineStore(pt.DynamoDBOnline, dynamoConfig.Serialized())

--- a/provider/provider_config/dynamo_config.go
+++ b/provider/provider_config/dynamo_config.go
@@ -21,6 +21,7 @@ type DynamodbConfig struct {
 	Credentials        AWSCredentials
 	Endpoint           string
 	StronglyConsistent bool
+	Tags               map[string]string
 }
 
 type dynamodbConfigTemp struct {
@@ -29,6 +30,7 @@ type dynamodbConfigTemp struct {
 	Credentials        json.RawMessage
 	Endpoint           string
 	StronglyConsistent bool
+	Tags               map[string]string
 }
 
 func (d DynamodbConfig) Serialized() SerializedConfig {
@@ -48,6 +50,7 @@ func (d *DynamodbConfig) Deserialize(config []byte) error {
 	d.Prefix = temp.Prefix
 	d.Region = temp.Region
 	d.StronglyConsistent = temp.StronglyConsistent
+	d.Tags = temp.Tags
 
 	creds, err := UnmarshalAWSCredentials(temp.Credentials)
 	if err != nil {
@@ -61,6 +64,7 @@ func (d *DynamodbConfig) Deserialize(config []byte) error {
 func (d DynamodbConfig) MutableFields() ss.StringSet {
 	return ss.StringSet{
 		"Credentials": true,
+		"Tags":        true,
 	}
 }
 

--- a/provider/provider_config/dynamo_config_test.go
+++ b/provider/provider_config/dynamo_config_test.go
@@ -17,6 +17,7 @@ import (
 func TestDynamoConfigMutableFields(t *testing.T) {
 	expected := ss.StringSet{
 		"Credentials": true,
+		"Tags":        true,
 	}
 
 	config := DynamodbConfig{

--- a/runner/materialize_test.go
+++ b/runner/materialize_test.go
@@ -31,7 +31,7 @@ func TestMaterializationRunner(t *testing.T) {
 	// force the factory to exist by calling this directly.
 	ResetFactoryMap()
 	registerFactories()
-	dynamodb := provider.GetTestingDynamoDB(t)
+	dynamodb := provider.GetTestingDynamoDB(t, map[string]string{})
 	dbrix := provider.GetTestingS3Databricks(t)
 	t.Run("dbrix_to_dynamo", func(t *testing.T) {
 		testMaterializationRunner(t, dbrix, dynamodb)


### PR DESCRIPTION
# Description

This PR introduces the ability to tag DynamoDB tables created by Featureform to track usage and spending. See [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html) for tagging details.

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that modifies some code)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- DynamoDB resource registration now accepts custom table tags, allowing for additional metadata during setup.
	- Enhanced tag validation ensures tags adhere to proper naming and formatting rules.
	- Default ownership tagging has been added to streamline resource organization.
	- New field for tags added to DynamoDB configuration for improved metadata management.
- **Bug Fixes**
	- Improved error handling for invalid tag structures during DynamoDB configuration.
- **Tests**
	- Added comprehensive tests for the new tagging functionality in DynamoDB, covering various scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->