### PR TITLE
Remove auth mention from charts

### DIFF
--- a/charts/featureform/templates/api-server/deployment.yaml
+++ b/charts/featureform/templates/api-server/deployment.yaml
@@ -50,10 +50,6 @@ spec:
               value: {{ .Values.serving.host }}
             - name: SERVING_PORT
               value: {{ .Values.serving.port | quote }}
-            - name: FF_AUTH_PROVIDER
-              value: {{ .Values.auth.provider | quote }}
-            - name: FF_RBAC_ENABLED
-              value: {{ .Values.auth.rbacEnabled | quote }}
             - name: FF_STATE_PROVIDER
               value: {{ .Values.stateProvider | quote }}
             - name: POD_IP

--- a/charts/featureform/templates/dashboard-metadata/deployment.yaml
+++ b/charts/featureform/templates/dashboard-metadata/deployment.yaml
@@ -51,10 +51,6 @@ spec:
               value: {{ .Values.debug | quote }}
             - name: FEATUREFORM_VERSION
               value: {{ .Values.versionOverride | default .Chart.AppVersion}}
-            - name: FF_AUTH_PROVIDER
-              value: {{ .Values.auth.provider | quote }}
-            - name: FF_RBAC_ENABLED
-              value: {{ .Values.auth.rbacEnabled | quote }}
             - name: FF_STATE_PROVIDER
               value: {{ .Values.stateProvider | quote }}
             - name: PSQL_HOST

--- a/charts/featureform/templates/metadata/deployment.yaml
+++ b/charts/featureform/templates/metadata/deployment.yaml
@@ -48,10 +48,6 @@ spec:
               value: {{ .Values.meilisearch.host }}
             - name: MEILISEARCH_APIKEY
               value: {{ .Values.meilisearch.apikey | quote }}
-            - name: FF_AUTH_PROVIDER
-              value: {{ .Values.auth.provider | quote }}
-            - name: FF_RBAC_ENABLED
-              value: {{ .Values.auth.rbacEnabled | quote }}
             - name: FF_STATE_PROVIDER
               value: {{ .Values.stateProvider | quote }}
             - name: FEATUREFORM_DEBUG_LOGGING


### PR DESCRIPTION
# Description

Removes injecting of environment variables `FF_AUTH_PROVIDER` and `FF_RBAC_ENABLED` in the K8s deployments manifests (which doesn't exist in OSS).

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined service configurations by removing redundant authentication and access control settings across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->