### PR TITLE
Enterprise port: Re-enable jest tests for github

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Setup Node"
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: "npm"
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run Jest
         run: npm test
-        
+
   go-tests:
     if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || (github.event.inputs.run_job == 'go-tests') }}
     name: Run Go Tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,6 +29,31 @@ env:
   FIRESTORE_CREDENTIALS: ${{ secrets.FIRESTORE_CREDENTIALS_FILE }}
 
 jobs:
+  jest-tests:
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || (github.event.inputs.run_job == 'jest-tests') }}
+    name: Run Jest Tests
+    defaults:
+      run:
+        working-directory: ./dashboard/
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: "Setup Node"
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "npm"
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Run Jest
+        run: npm test
+        
   go-tests:
     if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || (github.event.inputs.run_job == 'go-tests') }}
     name: Run Go Tests

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -49,7 +49,7 @@
     "start-empty:nix": "REACT_APP_EMPTY_RESOURCE_VIEW=true PORT=3000 next start",
     "format": "prettier --write \"./**/*.{js,jsx,json}\"",
     "lint": "eslint .",
-    "test": "jest --coverage",
+    "test": "jest --silent --coverage",
     "snapshot": "jest --updateSnapshot",
     "prepare": "cd .. && husky install dashboard/.husky"
   },

--- a/dashboard/src/components/resource-list/ProviderTable/ProviderTable.test.js
+++ b/dashboard/src/components/resource-list/ProviderTable/ProviderTable.test.js
@@ -29,12 +29,12 @@ describe('ProviderTable', () => {
     expect(foundRedis).toBeInTheDocument();
   });
 
-  test.skip('renders the status correctly', async () => {
+  test('renders the status correctly', async () => {
     render(<ProviderTable />);
 
     const statuses = await screen.findAllByText('Status: Connected');
     const expectedConnected = providerList.data.filter(
-      (p) => p.status === 'Connected'
+      (p) => p.status === 'READY' || p.status == 'CREATED'
     ).length;
     expect(statuses).toHaveLength(expectedConnected);
   });


### PR DESCRIPTION
# Description

We disabled the build workflow (which ran the jest tests) a while back. This PR re-enables them to ensure all of them pass before merging any new UX feature. 

`jest run`
<img width="594" alt="image" src="https://github.com/user-attachments/assets/e17c04c1-0c35-4b58-b60e-3954db43a4ea" />


<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Introduced a new automated testing job in the CI workflow for enhanced quality assurance.
  - Updated the test execution command to suppress console output while retaining coverage reporting.
  - Reactivated and refined component test cases to ensure broader status validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->