### PR TITLE
Add New Dataset interfaces

### DIFF
--- a/fftypes/row.go
+++ b/fftypes/row.go
@@ -1,0 +1,3 @@
+package types
+
+type Row []Value

--- a/fftypes/types.go
+++ b/fftypes/types.go
@@ -1,0 +1,336 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+
+	"github.com/featureform/fferr"
+	pb "github.com/featureform/metadata/proto"
+)
+
+func init() {
+	initProtoToScalar()
+}
+
+const (
+	Int       ScalarType = "int"
+	Int8      ScalarType = "int8"
+	Int16     ScalarType = "int16"
+	Int32     ScalarType = "int32"
+	Int64     ScalarType = "int64"
+	UInt8     ScalarType = "uint8"
+	UInt16    ScalarType = "uint16"
+	UInt32    ScalarType = "uint32"
+	UInt64    ScalarType = "uint64"
+	Float32   ScalarType = "float32"
+	Float64   ScalarType = "float64"
+	String    ScalarType = "string"
+	Bool      ScalarType = "bool"
+	Timestamp ScalarType = "time.Time"
+	Datetime  ScalarType = "datetime"
+)
+
+var ScalarTypes = map[ScalarType]bool{
+	//NilType:   true,
+	Int:       true,
+	Int8:      true,
+	Int16:     true,
+	Int32:     true,
+	Int64:     true,
+	UInt8:     true,
+	UInt16:    true,
+	UInt32:    true,
+	UInt64:    true,
+	Float32:   true,
+	Float64:   true,
+	String:    true,
+	Bool:      true,
+	Timestamp: true,
+	Datetime:  true,
+}
+
+var scalarToProto = map[ScalarType]pb.ScalarType{
+	//NilType: pb.ScalarType_NULL,
+	Int:     pb.ScalarType_INT,
+	Int32:   pb.ScalarType_INT32,
+	Int64:   pb.ScalarType_INT64,
+	Float32: pb.ScalarType_FLOAT32,
+	Float64: pb.ScalarType_FLOAT64,
+	String:  pb.ScalarType_STRING,
+	Bool:    pb.ScalarType_BOOL,
+}
+
+// Created in init() as the inverse of scalarToProto
+var protoToScalar map[pb.ScalarType]ScalarType
+
+func initProtoToScalar() {
+	protoToScalar = make(map[pb.ScalarType]ScalarType, len(scalarToProto))
+	for scalar, proto := range scalarToProto {
+		protoToScalar[proto] = scalar
+	}
+}
+
+type ValueType interface {
+	Scalar() ScalarType
+	IsVector() bool
+	Type() reflect.Type
+	String() string
+	ToProto() *pb.ValueType
+}
+
+type VectorType struct {
+	ScalarType  ScalarType
+	Dimension   int32
+	IsEmbedding bool
+}
+
+func ValueTypeFromProto(protoVal *pb.ValueType) (ValueType, error) {
+	switch casted := protoVal.GetType().(type) {
+	case *pb.ValueType_Scalar:
+		scalar, has := protoToScalar[casted.Scalar]
+		if has {
+			return scalar, nil
+		}
+	case *pb.ValueType_Vector:
+		protoVec := casted.Vector
+		scalar, has := protoToScalar[protoVec.Scalar]
+		if has {
+			return VectorType{
+				ScalarType:  scalar,
+				Dimension:   protoVec.Dimension,
+				IsEmbedding: protoVec.IsEmbedding,
+			}, nil
+		}
+	}
+	protoStr := proto.MarshalTextString(protoVal)
+	return nil, fferr.NewInternalErrorf("Unable to parse value type proto %T %s", protoVal.GetType(), protoStr)
+}
+
+// jsonValueType provides a generic JSON representation of any ValueType.
+type jsonValueType struct {
+	ScalarType  ScalarType
+	Dimension   int32
+	IsEmbedding bool
+	IsVector    bool
+}
+
+func (wrapper *jsonValueType) FromValueType(t ValueType) {
+	switch typed := t.(type) {
+	case ScalarType:
+		*wrapper = jsonValueType{
+			ScalarType: typed,
+			IsVector:   false,
+		}
+	case VectorType:
+		*wrapper = jsonValueType{
+			ScalarType:  typed.ScalarType,
+			Dimension:   typed.Dimension,
+			IsEmbedding: typed.IsEmbedding,
+			IsVector:    true,
+		}
+	}
+}
+
+func (wrapper jsonValueType) ToValueType() ValueType {
+	if wrapper.IsVector {
+		return VectorType{
+			ScalarType:  wrapper.ScalarType,
+			Dimension:   wrapper.Dimension,
+			IsEmbedding: wrapper.IsEmbedding,
+		}
+	} else {
+		return wrapper.ScalarType
+	}
+}
+
+func SerializeType(t ValueType) string {
+	var wrapper jsonValueType
+	wrapper.FromValueType(t)
+	bytes, err := json.Marshal(wrapper)
+	if err != nil {
+		panic(err)
+	}
+	return string(bytes)
+}
+
+func DeserializeType(t string) (ValueType, error) {
+	var wrapper jsonValueType
+	if err := json.Unmarshal([]byte(t), &wrapper); err != nil {
+		return nil, err
+	}
+	return wrapper.ToValueType(), nil
+}
+
+func (t VectorType) Scalar() ScalarType {
+	return t.ScalarType
+}
+
+func (t VectorType) IsVector() bool {
+	return true
+}
+
+func (t VectorType) Type() reflect.Type {
+	scalar := t.Scalar().Type()
+	if scalar.Kind() == reflect.Ptr {
+		scalar = scalar.Elem()
+	}
+	return reflect.SliceOf(scalar)
+}
+
+func (t VectorType) String() string {
+	return fmt.Sprintf("%s[%d](embedding=%v)", t.Scalar().String(), t.Dimension, t.IsEmbedding)
+}
+
+func (t VectorType) ToProto() *pb.ValueType {
+	scalarEnum, err := t.Scalar().ToProtoEnum()
+	if err != nil {
+		panic(err)
+	}
+	return &pb.ValueType{
+		Type: &pb.ValueType_Vector{
+			Vector: &pb.VectorType{
+				Scalar:      scalarEnum,
+				Dimension:   t.Dimension,
+				IsEmbedding: t.IsEmbedding,
+			},
+		},
+	}
+}
+
+type ScalarType string
+
+func (t ScalarType) Scalar() ScalarType {
+	return t
+}
+
+func (t ScalarType) IsVector() bool {
+	return false
+}
+
+func (t ScalarType) String() string {
+	return string(t)
+}
+
+// This method is used in encoding our supported data types to parquet.
+// It returns a pointer type for scalar values to allow for nullability.
+func (t ScalarType) Type() reflect.Type {
+	switch t {
+	case Int:
+		return reflect.PointerTo(reflect.TypeOf(int(0)))
+	case Int8:
+		return reflect.PointerTo(reflect.TypeOf(int8(0)))
+	case Int16:
+		return reflect.PointerTo(reflect.TypeOf(int16(0)))
+	case Int32:
+		return reflect.PointerTo(reflect.TypeOf(int32(0)))
+	case Int64:
+		return reflect.PointerTo(reflect.TypeOf(int64(0)))
+	case UInt8:
+		return reflect.PointerTo(reflect.TypeOf(uint8(0)))
+	case UInt16:
+		return reflect.PointerTo(reflect.TypeOf(uint16(0)))
+	case UInt32:
+		return reflect.PointerTo(reflect.TypeOf(uint32(0)))
+	case UInt64:
+		return reflect.PointerTo(reflect.TypeOf(uint64(0)))
+	case Float32:
+		return reflect.PointerTo(reflect.TypeOf(float32(0)))
+	case Float64:
+		return reflect.PointerTo(reflect.TypeOf(float64(0)))
+	case String:
+		return reflect.PointerTo(reflect.TypeOf(string("")))
+	case Bool:
+		return reflect.PointerTo(reflect.TypeOf(bool(false)))
+	case Timestamp:
+		return reflect.TypeOf(time.Time{})
+	case Datetime:
+		return reflect.TypeOf(time.Time{})
+	default:
+		return nil
+	}
+}
+
+func (t ScalarType) ToProto() *pb.ValueType {
+	protoEnum, err := t.ToProtoEnum()
+	if err != nil {
+		panic(err)
+	}
+	return &pb.ValueType{
+		Type: &pb.ValueType_Scalar{protoEnum},
+	}
+}
+
+func (t ScalarType) ToProtoEnum() (pb.ScalarType, error) {
+	protoVal, mapped := scalarToProto[t]
+	if !mapped {
+		errMsg := "ScalarType not mapped to proto: %s\nMap %v\n"
+		err := fferr.NewInternalErrorf(errMsg, t, scalarToProto)
+		return pb.ScalarType_NULL, err
+	}
+	return protoVal, nil
+}
+
+// TODO(simba) merge this into the serialize/deserialize above
+type ValueTypeJSONWrapper struct {
+	ValueType
+}
+
+func (vt *ValueTypeJSONWrapper) UnmarshalJSON(data []byte) error {
+	v := map[string]VectorType{"ValueType": {}}
+	if err := json.Unmarshal(data, &v); err == nil {
+		vt.ValueType = v["ValueType"]
+		return nil
+	}
+
+	s := map[string]ScalarType{"ValueType": ScalarType("")}
+	if err := json.Unmarshal(data, &s); err == nil {
+		vt.ValueType = s["ValueType"]
+		return nil
+	}
+
+	return fferr.NewInternalError(fmt.Errorf("could not unmarshal value type: %v", data))
+}
+
+func (vt ValueTypeJSONWrapper) MarshalJSON() ([]byte, error) {
+	switch vt.ValueType.(type) {
+	case VectorType:
+		return json.Marshal(map[string]VectorType{"ValueType": vt.ValueType.(VectorType)})
+	case ScalarType:
+		return json.Marshal(map[string]ScalarType{"ValueType": vt.ValueType.(ScalarType)})
+	default:
+		return nil, fferr.NewInternalError(fmt.Errorf("could not marshal value type: %v", vt.ValueType))
+	}
+}
+
+type ColumnSchema struct {
+	Name       ColumnName
+	NativeType NativeType
+	Type       ValueType
+}
+
+type Value struct {
+	NativeType NativeType
+	Type       ValueType
+	Value      any
+}
+
+type NativeType string
+type ColumnName string
+
+type Schema struct {
+	Fields []ColumnSchema
+	// todo: can include more state or behavior, etc.
+}
+
+// ColumnNames returns a slice of all column names in the schema
+func (s Schema) ColumnNames() []string {
+	names := make([]string, len(s.Fields))
+	for i, field := range s.Fields {
+		names[i] = string(field.Name)
+	}
+	return names
+}

--- a/provider/dataset/dataset.go
+++ b/provider/dataset/dataset.go
@@ -65,8 +65,15 @@ type SizedSegmentableDataset interface {
 // chunk iterators of size ChunkSize (last chunk will be
 // <= ChunkSize).
 type ChunkedDatasetAdapter struct {
-	SizedSegmentableDataset
-	ChunkSize int64
+func (adapter *ChunkedDatasetAdapter) getSize() (int64, error) {
+	if adapter.ChunkSize <= 0 {
+		return 0, fferr.NewInternalErrorf("chunk size must be > 0")
+	}
+	adapter.sizeOnce.Do(func() {
+		adapter.size, adapter.sizeErr = adapter.SizedSegmentableDataset.Len()
+	})
+	return adapter.size, adapter.sizeErr
+}
 
 	size     int64
 	sizeErr  error

--- a/provider/dataset/dataset.go
+++ b/provider/dataset/dataset.go
@@ -65,15 +65,8 @@ type SizedSegmentableDataset interface {
 // chunk iterators of size ChunkSize (last chunk will be
 // <= ChunkSize).
 type ChunkedDatasetAdapter struct {
-func (adapter *ChunkedDatasetAdapter) getSize() (int64, error) {
-	if adapter.ChunkSize <= 0 {
-		return 0, fferr.NewInternalErrorf("chunk size must be > 0")
-	}
-	adapter.sizeOnce.Do(func() {
-		adapter.size, adapter.sizeErr = adapter.SizedSegmentableDataset.Len()
-	})
-	return adapter.size, adapter.sizeErr
-}
+	SizedSegmentableDataset
+	ChunkSize int64
 
 	size     int64
 	sizeErr  error
@@ -81,6 +74,9 @@ func (adapter *ChunkedDatasetAdapter) getSize() (int64, error) {
 }
 
 func (adapter *ChunkedDatasetAdapter) getSize() (int64, error) {
+	if adapter.ChunkSize <= 0 {
+		return 0, fferr.NewInternalErrorf("chunk size must be > 0")
+	}
 	adapter.sizeOnce.Do(func() {
 		adapter.size, adapter.sizeErr = adapter.SizedSegmentableDataset.Len()
 	})

--- a/provider/dataset/dataset.go
+++ b/provider/dataset/dataset.go
@@ -1,0 +1,155 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright 2025 FeatureForm Inc.
+//
+
+package dataset
+
+import (
+	. "context"
+	"sync"
+
+	"github.com/featureform/fferr"
+	types "github.com/featureform/fftypes"
+	pl "github.com/featureform/provider/location"
+)
+
+// Dataset is the base interface required by most of the
+// OfflineStore interface. It provides a location, iterator,
+// and schema
+type Dataset interface {
+	Location() pl.Location
+	Iterator(ctx Context) (Iterator, error)
+	Schema() (types.Schema, error)
+}
+
+// WriteableDataset is a Dataset that you can write to. For some datasets,
+// especially file based one, writing single rows is expensive. It's
+// preferable to write as many things as possible in a single batch.
+type WriteableDataset interface {
+	Dataset
+	WriteBatch(Context, []types.Row) error
+}
+
+// SizedDataset is a Dataset where the size can be cheaply calculated.
+type SizedDataset interface {
+	Dataset
+	Len() (int64, error)
+}
+
+// SegmentableDataset allows a user to easily iterate
+// an arbitrary segment of the dataset. Note that it
+// doesn't guarantee the end of the iterator is actually
+// in range of the dataset. You can try casting Iterator
+// to SizedIterator to see if the length is available.
+type SegmentableDataset interface {
+	Dataset
+	IterateSegment(ctx Context, begin, end int64) (Iterator, error)
+}
+
+type ChunkedDataset interface {
+	NumChunks() (int, error)
+	ChunkIterator(ctx Context, idx int) (SizedIterator, error)
+}
+
+type SizedSegmentableDataset interface {
+	SizedDataset
+	SegmentableDataset
+}
+
+// ChunkedDatasetAdapter takes a SizedSegmentableDataset
+// and adapts it to include the ChunkedDataset methods
+// by using Len() and IterateSegment() to create
+// chunk iterators of size ChunkSize (last chunk will be
+// <= ChunkSize).
+type ChunkedDatasetAdapter struct {
+	SizedSegmentableDataset
+	ChunkSize int64
+
+	size     int64
+	sizeErr  error
+	sizeOnce sync.Once
+}
+
+func (adapter *ChunkedDatasetAdapter) getSize() (int64, error) {
+	adapter.sizeOnce.Do(func() {
+		adapter.size, adapter.sizeErr = adapter.SizedSegmentableDataset.Len()
+	})
+	return adapter.size, adapter.sizeErr
+}
+
+func (adapter *ChunkedDatasetAdapter) NumChunks() (int, error) {
+	size, err := adapter.getSize()
+	if err != nil {
+		return -1, err
+	}
+
+	numChunks := size / adapter.ChunkSize
+	if size%adapter.ChunkSize > 0 {
+		numChunks++
+	}
+
+	return int(numChunks), nil
+}
+
+func (adapter *ChunkedDatasetAdapter) ChunkIterator(ctx Context, idx int) (SizedIterator, error) {
+	numChunks, err := adapter.NumChunks()
+	if err != nil {
+		return nil, err
+	}
+
+	if idx < 0 || idx >= numChunks {
+		return nil, fferr.NewInternalErrorf("chunk index out of range")
+	}
+
+	begin := int64(idx) * adapter.ChunkSize
+	end := begin + adapter.ChunkSize
+
+	size, err := adapter.SizedSegmentableDataset.Len()
+	if err != nil {
+		return nil, err
+	}
+
+	if end > size {
+		end = size
+	}
+
+	iter, err := adapter.SizedSegmentableDataset.IterateSegment(ctx, begin, end)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a wrapper that adds the Len method to any iterator
+	return &GenericSizedIterator{
+		Iterator: iter,
+		length:   end - begin,
+	}, nil
+}
+
+// Iterator is the generic interface to loop through any dataset in
+// Featureform.
+type Iterator interface {
+	Next(Context) bool
+	Values() types.Row
+	Schema() (types.Schema, error)
+	Err() error
+	Close() error
+}
+
+// SizedIterator is an Iterator where we can cheaply check
+// the full length.
+type SizedIterator interface {
+	Iterator
+	Len() (int64, error)
+}
+
+type GenericSizedIterator struct {
+	Iterator
+	length int64
+}
+
+func (it *GenericSizedIterator) Len() (int64, error) {
+	return it.length, nil
+}

--- a/provider/dataset/dataset_test.go
+++ b/provider/dataset/dataset_test.go
@@ -1,8 +1,6 @@
 package dataset
 
 import (
-	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,188 +11,226 @@ import (
 	pl "github.com/featureform/provider/location"
 )
 
-type InMemoryDataset struct {
-	data     []types.Row
-	schema   types.Schema
-	location pl.Location
+// DatasetTestCase holds a dataset and expected values for testing
+type DatasetTestCase struct {
+	Dataset        Dataset
+	ExpectedData   []types.Row
+	ExpectedSchema types.Schema
+	Location       pl.Location
+	// DatasetFactory creates a new dataset with the same configuration as Dataset
+	// Used for tests that modify the dataset (e.g., write tests)
+	DatasetFactory func() Dataset
 }
 
-func NewInMemoryDataset(data []types.Row, schema types.Schema, location pl.Location) *InMemoryDataset {
-	return &InMemoryDataset{data: data, schema: schema, location: location}
-}
+// RunDatasetTestSuite runs a suite of tests against a pre-created dataset
+func RunDatasetTestSuite(t *testing.T, tc DatasetTestCase) {
+	t.Run("BasicProperties", func(t *testing.T) {
+		testBasicProperties(t, tc)
+	})
 
-func (ds *InMemoryDataset) Location() pl.Location {
-	return ds.location
-}
+	t.Run("Iterator", func(t *testing.T) {
+		testIterator(t, tc)
+	})
 
-func (ds *InMemoryDataset) Iterator(ctx context.Context) (Iterator, error) {
-	return &InMemoryIterator{data: ds.data, index: -1}, nil
-}
+	t.Run("SegmentIterator", func(t *testing.T) {
+		testSegmentIterator(t, tc)
+	})
 
-func (ds *InMemoryDataset) Schema() (types.Schema, error) {
-	return ds.schema, nil
-}
-
-func (ds *InMemoryDataset) WriteBatch(ctx context.Context, rows []types.Row) error {
-	ds.data = append(ds.data, rows...)
-	return nil
-}
-
-func (ds *InMemoryDataset) Len() (int64, error) {
-	return int64(len(ds.data)), nil
-}
-
-func (ds *InMemoryDataset) IterateSegment(ctx context.Context, begin, end int64) (Iterator, error) {
-	size, err := ds.Len()
-	if err != nil {
-		return nil, err
+	if writeable, ok := tc.Dataset.(WriteableDataset); ok {
+		t.Run("Writeable", func(t *testing.T) {
+			// Use a fresh dataset for write tests if a factory is provided
+			var datasetToTest WriteableDataset
+			if tc.DatasetFactory != nil {
+				freshDataset := tc.DatasetFactory()
+				var ok bool
+				datasetToTest, ok = freshDataset.(WriteableDataset)
+				if !ok {
+					t.Fatalf("Dataset created by factory does not implement WriteableDataset")
+				}
+			} else {
+				// Otherwise, use the original but warn about it
+				t.Log("No dataset factory provided. The original dataset will be modified.")
+				datasetToTest = writeable
+			}
+			testWriteableDataset(t, datasetToTest, tc)
+		})
 	}
-	if begin < 0 || end > size || begin > end {
-		return nil, errors.New("invalid segment range")
+
+	if sized, ok := tc.Dataset.(SizedDataset); ok {
+		t.Run("Sized", func(t *testing.T) {
+			testSizedDataset(t, sized, tc)
+		})
 	}
-	return &InMemoryIterator{data: ds.data[begin:end], index: -1}, nil
-}
 
-type InMemoryIterator struct {
-	data  []types.Row
-	index int
-}
-
-func (it *InMemoryIterator) Next(ctx context.Context) bool {
-	if it.index+1 < len(it.data) {
-		it.index++
-		return true
+	if segmentable, ok := tc.Dataset.(SegmentableDataset); ok {
+		t.Run("InvalidSegment", func(t *testing.T) {
+			testInvalidSegment(t, segmentable)
+		})
 	}
-	return false
+
+	if sizedSegmentable, ok := tc.Dataset.(SizedSegmentableDataset); ok {
+		t.Run("ChunkedAdapter", func(t *testing.T) {
+			testChunkedDatasetAdapter(t, sizedSegmentable, tc)
+		})
+	}
 }
 
-func (it *InMemoryIterator) Values() types.Row {
-	return it.data[it.index]
+func testIteratorSize(t *testing.T, iter Iterator, expectedSize int64) (isSized bool) {
+	sizedIter, ok := iter.(SizedIterator)
+	if !ok {
+		return false
+	}
+
+	t.Logf("Iterator of type %T implements SizedIterator", iter)
+	size, err := sizedIter.Len()
+	require.NoError(t, err)
+	assert.Equal(t, expectedSize, size, "Iterator size doesn't match expected length")
+	return true
 }
 
-func (it *InMemoryIterator) Schema() (types.Schema, error) {
-	return types.Schema{}, nil
+func testBasicProperties(t *testing.T, tc DatasetTestCase) {
+	assert.Equal(t, tc.Location, tc.Dataset.Location())
+	schema, err := tc.Dataset.Schema()
+	require.NoError(t, err)
+	assert.Equal(t, tc.ExpectedSchema, schema)
 }
 
-func (it *InMemoryIterator) Err() error {
-	return nil
-}
-
-func (it *InMemoryIterator) Close() error {
-	return nil
-}
-
-type SizedInMemoryIterator struct {
-	InMemoryIterator
-}
-
-func (it *SizedInMemoryIterator) Len() (int64, error) {
-	return int64(len(it.data)), nil
-}
-
-func TestNewDataset(t *testing.T) {
+func testIterator(t *testing.T, tc DatasetTestCase) {
 	ctx := logging.NewTestContext(t)
 
-	data := []types.Row{
-		{types.Value{NativeType: "int", Type: types.Int, Value: 1}},
-		{types.Value{NativeType: "int", Type: types.Int, Value: 2}},
-		{types.Value{NativeType: "int", Type: types.Int, Value: 3}}}
-	schema := types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}
-	location, err := pl.NewFileLocationFromURI("file://test")
-	require.NoError(t, err)
-	ds := NewInMemoryDataset(data, schema, location)
-
-	assert.Equal(t, location, ds.Location())
-	sch, err := ds.Schema()
-	require.NoError(t, err)
-	assert.Equal(t, schema, sch)
-
-	iter, err := ds.Iterator(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, iter)
-}
-
-func TestWriteableDataset(t *testing.T) {
-	ctx := logging.NewTestContext(t)
-
-	location, err := pl.NewFileLocationFromURI("file://test")
-	require.NoError(t, err)
-	ds := NewInMemoryDataset([]types.Row{}, types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}, location)
-	rows := []types.Row{
-		{types.Value{NativeType: "int", Type: types.Int, Value: 4}},
-		{types.Value{NativeType: "int", Type: types.Int, Value: 5}},
-	}
-	err = ds.WriteBatch(ctx, rows)
-	require.NoError(t, err)
-	length, err := ds.Len()
-	require.NoError(t, err)
-	assert.Equal(t, int64(2), length)
-}
-
-func TestSizedDataset(t *testing.T) {
-	data := []types.Row{
-		{types.Value{NativeType: "int", Type: types.Int, Value: 1}},
-		{types.Value{NativeType: "int", Type: types.Int, Value: 2}},
-	}
-	schema := types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}
-	location, err := pl.NewFileLocationFromURI("file://test")
-	require.NoError(t, err)
-	ds := NewInMemoryDataset(data, schema, location)
-
-	size, err := ds.Len()
-	require.NoError(t, err)
-	assert.Equal(t, int64(2), size)
-}
-
-func TestSegmentableDataset(t *testing.T) {
-	ctx := logging.NewTestContext(t)
-
-	location, err := pl.NewFileLocationFromURI("file://test")
-	require.NoError(t, err)
-	ds := NewInMemoryDataset([]types.Row{
-		{types.Value{NativeType: "int", Type: types.Int, Value: 1}},
-		{types.Value{NativeType: "int", Type: types.Int, Value: 2}},
-		{types.Value{NativeType: "int", Type: types.Int, Value: 3}},
-	}, types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}, location)
-
-	iter, err := ds.IterateSegment(ctx, 1, 3)
+	iter, err := tc.Dataset.Iterator(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, iter)
 
-	require.True(t, iter.Next(ctx))
-	assert.Equal(t, types.Row{types.Value{NativeType: "int", Type: types.Int, Value: 2}}, iter.Values())
-	require.True(t, iter.Next(ctx))
-	assert.Equal(t, types.Row{types.Value{NativeType: "int", Type: types.Int, Value: 3}}, iter.Values())
-	assert.False(t, iter.Next(ctx))
+	// Check if the iterator implements SizedIterator
+	if isSized := testIteratorSize(t, iter, int64(len(tc.ExpectedData))); isSized {
+		// Get a fresh iterator since we might have consumed it
+		iter, err = tc.Dataset.Iterator(ctx)
+		require.NoError(t, err)
+	}
+
+	i := 0
+	for iter.Next(ctx) {
+		require.Less(t, i, len(tc.ExpectedData), "Iterator returned more rows than expected")
+		assert.Equal(t, tc.ExpectedData[i], iter.Values())
+		i++
+	}
+	assert.Equal(t, len(tc.ExpectedData), i, "Iterator did not return all expected rows")
 }
 
-func TestInvalidSegmentableDataset(t *testing.T) {
+func testSegmentIterator(t *testing.T, tc DatasetTestCase) {
 	ctx := logging.NewTestContext(t)
 
-	location, err := pl.NewFileLocationFromURI("file://test")
-	require.NoError(t, err)
-	ds := NewInMemoryDataset([]types.Row{
-		{types.Value{NativeType: "int", Type: types.Int, Value: 1}},
-		{types.Value{NativeType: "int", Type: types.Int, Value: 2}},
-	}, types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}, location)
+	// Skip test if not enough data
+	if len(tc.ExpectedData) < 2 {
+		t.Skip("Not enough data for segment test")
+		return
+	}
 
+	// Test segment from 1 to end
+	segmentable, ok := tc.Dataset.(SegmentableDataset)
+	if !ok {
+		t.Skip("Dataset is not segmentable")
+		return
+	}
+
+	start := int64(1)
+	end := int64(len(tc.ExpectedData))
+	expectedSize := end - start
+
+	iter, err := segmentable.IterateSegment(ctx, start, end)
+	require.NoError(t, err)
+	require.NotNil(t, iter)
+
+	// Check if the segment iterator implements SizedIterator
+	if isSized := testIteratorSize(t, iter, expectedSize); isSized {
+		// Get a fresh iterator since we might have consumed it
+		iter, err = segmentable.IterateSegment(ctx, start, end)
+		require.NoError(t, err)
+	}
+
+	// Verify iterator returns expected segment
+	for i := start; i < end; i++ {
+		require.True(t, iter.Next(ctx), "Iterator ended prematurely")
+		assert.Equal(t, tc.ExpectedData[i], iter.Values())
+	}
+	assert.False(t, iter.Next(ctx), "Iterator did not end as expected")
+}
+
+func testWriteableDataset(t *testing.T, ds WriteableDataset, tc DatasetTestCase) {
+	// This test will modify the dataset by writing new rows to it
+	t.Run("WriteBatch", func(t *testing.T) {
+		ctx := logging.NewTestContext(t)
+
+		// Note: This test modifies the original dataset by adding rows.
+		// If you need to keep the original dataset unchanged, you would need to
+		// create a new dataset with the same properties before running this test.
+
+		// Create new rows to write
+		newRows := []types.Row{
+			{types.Value{NativeType: "int", Type: types.Int, Value: 100}},
+			{types.Value{NativeType: "int", Type: types.Int, Value: 101}},
+		}
+
+		// Get initial length
+		var initialLen int64
+		if sized, ok := ds.(SizedDataset); ok {
+			var err error
+			initialLen, err = sized.Len()
+			require.NoError(t, err)
+		}
+
+		// Keep track of expected data after write
+		expectedDataAfterWrite := append([]types.Row{}, tc.ExpectedData...)
+		expectedDataAfterWrite = append(expectedDataAfterWrite, newRows...)
+
+		// Write batch
+		err := ds.WriteBatch(ctx, newRows)
+		require.NoError(t, err)
+
+		// Verify length increased if possible
+		if sized, ok := ds.(SizedDataset); ok {
+			newLen, err := sized.Len()
+			require.NoError(t, err)
+			assert.Equal(t, initialLen+int64(len(newRows)), newLen)
+		}
+
+		// Verify all rows (original + new) are available through iteration
+		iter, err := ds.Iterator(ctx)
+		require.NoError(t, err)
+
+		rowIdx := 0
+		for iter.Next(ctx) {
+			if rowIdx < len(expectedDataAfterWrite) {
+				assert.Equal(t, expectedDataAfterWrite[rowIdx], iter.Values())
+			} else {
+				t.Errorf("Iterator returned more rows than expected")
+			}
+			rowIdx++
+		}
+
+		assert.Equal(t, len(expectedDataAfterWrite), rowIdx,
+			"Iterator did not return all expected rows")
+	})
+}
+
+func testSizedDataset(t *testing.T, ds SizedDataset, tc DatasetTestCase) {
+	size, err := ds.Len()
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(tc.ExpectedData)), size)
+}
+
+func testInvalidSegment(t *testing.T, ds SegmentableDataset) {
+	ctx := logging.NewTestContext(t)
+
+	// Try an invalid segment range
 	iter, err := ds.IterateSegment(ctx, -1, 3)
 	assert.Error(t, err)
 	assert.Nil(t, iter)
 }
 
-func TestChunkedDatasetAdapter(t *testing.T) {
+func testChunkedDatasetAdapter(t *testing.T, ds SizedSegmentableDataset, tc DatasetTestCase) {
 	ctx := logging.NewTestContext(t)
-
-	// Setup: Create a dataset with 10 rows
-	data := make([]types.Row, 10)
-	for i := 0; i < 10; i++ {
-		data[i] = types.Row{types.Value{NativeType: "int", Type: types.Int, Value: i + 1}}
-	}
-	schema := types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}
-	location, err := pl.NewFileLocationFromURI("file://test")
-	require.NoError(t, err)
-	ds := NewInMemoryDataset(data, schema, location)
 
 	// Create adapter with chunk size of 3
 	adapter := ChunkedDatasetAdapter{
@@ -202,86 +238,85 @@ func TestChunkedDatasetAdapter(t *testing.T) {
 		ChunkSize:               3,
 	}
 
+	// Calculate expected number of chunks
+	totalRows := int64(len(tc.ExpectedData))
+	expectedChunks := (totalRows + adapter.ChunkSize - 1) / adapter.ChunkSize
+
 	// Test 1: Verify correct number of chunks
 	t.Run("NumChunks", func(t *testing.T) {
 		numChunks, err := adapter.NumChunks()
 		require.NoError(t, err)
-		// 10 rows with chunk size 3 should give 4 chunks (3,3,3,1)
-		assert.Equal(t, 4, numChunks)
+		assert.Equal(t, int(expectedChunks), numChunks)
 	})
 
-	// Test 2: Verify first chunk (should have 3 elements)
-	t.Run("FirstChunk", func(t *testing.T) {
-		// Create test context for this subtest
-		iter, err := adapter.ChunkIterator(ctx, 0)
-		require.NoError(t, err)
-		require.NotNil(t, iter)
+	// Test 2: Verify first chunk (should have up to ChunkSize elements)
+	if totalRows > 0 {
+		t.Run("FirstChunk", func(t *testing.T) {
+			// Create test context for this subtest
+			iter, err := adapter.ChunkIterator(ctx, 0)
+			require.NoError(t, err)
+			require.NotNil(t, iter)
 
-		// Verify chunk size
-		size, err := iter.Len()
-		require.NoError(t, err)
-		assert.Equal(t, int64(3), size)
+			// Calculate expected size for first chunk
+			expectedSize := adapter.ChunkSize
+			if totalRows < expectedSize {
+				expectedSize = totalRows
+			}
 
-		// Verify chunk contents
-		expectedValues := []int{1, 2, 3}
-		i := 0
-		// Pass context to Next
-		for iter.Next(ctx) {
-			val := iter.Values()
-			assert.Equal(t, expectedValues[i], val[0].Value)
-			i++
-		}
-		assert.Equal(t, 3, i, "Should have iterated through 3 elements")
-	})
+			// We expect chunk iterators to always be sized
+			isSized := testIteratorSize(t, iter, expectedSize)
+			require.True(t, isSized, "Chunk iterator should implement SizedIterator")
 
-	// Test 3: Verify last chunk (should have only 1 element)
-	t.Run("LastChunk", func(t *testing.T) {
-		iter, err := adapter.ChunkIterator(ctx, 3)
-		require.NoError(t, err)
-		require.NotNil(t, iter)
+			// Get a fresh iterator since we might have consumed it
+			iter, err = adapter.ChunkIterator(ctx, 0)
+			require.NoError(t, err)
 
-		// Verify chunk size
-		size, err := iter.Len()
-		require.NoError(t, err)
-		assert.Equal(t, int64(1), size)
+			// Verify chunk contents
+			i := 0
+			for iter.Next(ctx) {
+				val := iter.Values()
+				assert.Equal(t, tc.ExpectedData[i], val)
+				i++
+			}
+			assert.Equal(t, int(expectedSize), i, "Should have iterated through all elements")
+		})
+	}
 
-		// Verify chunk contents
-		require.True(t, iter.Next(ctx))
-		val := iter.Values()
-		assert.Equal(t, 10, val[0].Value)
-		assert.False(t, iter.Next(ctx), "Should have only one element")
-	})
+	// Test 3: Verify last chunk if there are multiple chunks
+	if int(expectedChunks) > 1 {
+		t.Run("LastChunk", func(t *testing.T) {
+			lastChunkIndex := int(expectedChunks) - 1
+			iter, err := adapter.ChunkIterator(ctx, lastChunkIndex)
+			require.NoError(t, err)
+			require.NotNil(t, iter)
+
+			// Calculate expected size for last chunk
+			lastChunkSize := int(totalRows) - (lastChunkIndex * int(adapter.ChunkSize))
+
+			// We expect chunk iterators to always be sized
+			isSized := testIteratorSize(t, iter, int64(lastChunkSize))
+			require.True(t, isSized, "Chunk iterator should implement SizedIterator")
+
+			// Get a fresh iterator since we might have consumed it
+			iter, err = adapter.ChunkIterator(ctx, lastChunkIndex)
+			require.NoError(t, err)
+
+			// Verify chunk contents
+			startIdx := lastChunkIndex * int(adapter.ChunkSize)
+			i := 0
+			for iter.Next(ctx) {
+				val := iter.Values()
+				assert.Equal(t, tc.ExpectedData[startIdx+i], val)
+				i++
+			}
+			assert.Equal(t, lastChunkSize, i, "Should have iterated through all elements")
+		})
+	}
 
 	// Test 4: Verify error handling for out-of-bounds chunk
 	t.Run("OutOfBoundsChunk", func(t *testing.T) {
-		iter, err := adapter.ChunkIterator(ctx, 4)
+		iter, err := adapter.ChunkIterator(ctx, int(expectedChunks))
 		assert.Error(t, err)
 		assert.Nil(t, iter)
 	})
-}
-
-func TestSizedIterator(t *testing.T) {
-	ctx := logging.NewTestContext(t)
-
-	data := []types.Row{
-		{types.Value{NativeType: "int", Type: types.Int, Value: 1}},
-		{types.Value{NativeType: "int", Type: types.Int, Value: 2}},
-		{types.Value{NativeType: "int", Type: types.Int, Value: 3}},
-	}
-
-	iter := &SizedInMemoryIterator{
-		InMemoryIterator: InMemoryIterator{data: data, index: -1},
-	}
-
-	length, err := iter.Len()
-	require.NoError(t, err)
-	assert.Equal(t, int64(3), length)
-
-	count := 0
-	for iter.Next(ctx) {
-		count++
-		val := iter.Values()
-		assert.Equal(t, count, val[0].Value)
-	}
-	assert.Equal(t, 3, count)
 }

--- a/provider/dataset/dataset_test.go
+++ b/provider/dataset/dataset_test.go
@@ -1,0 +1,287 @@
+package dataset
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	types "github.com/featureform/fftypes"
+	"github.com/featureform/logging"
+	pl "github.com/featureform/provider/location"
+)
+
+type InMemoryDataset struct {
+	data     []types.Row
+	schema   types.Schema
+	location pl.Location
+}
+
+func NewInMemoryDataset(data []types.Row, schema types.Schema, location pl.Location) *InMemoryDataset {
+	return &InMemoryDataset{data: data, schema: schema, location: location}
+}
+
+func (ds *InMemoryDataset) Location() pl.Location {
+	return ds.location
+}
+
+func (ds *InMemoryDataset) Iterator(ctx context.Context) (Iterator, error) {
+	return &InMemoryIterator{data: ds.data, index: -1}, nil
+}
+
+func (ds *InMemoryDataset) Schema() (types.Schema, error) {
+	return ds.schema, nil
+}
+
+func (ds *InMemoryDataset) WriteBatch(ctx context.Context, rows []types.Row) error {
+	ds.data = append(ds.data, rows...)
+	return nil
+}
+
+func (ds *InMemoryDataset) Len() (int64, error) {
+	return int64(len(ds.data)), nil
+}
+
+func (ds *InMemoryDataset) IterateSegment(ctx context.Context, begin, end int64) (Iterator, error) {
+	size, err := ds.Len()
+	if err != nil {
+		return nil, err
+	}
+	if begin < 0 || end > size || begin > end {
+		return nil, errors.New("invalid segment range")
+	}
+	return &InMemoryIterator{data: ds.data[begin:end], index: -1}, nil
+}
+
+type InMemoryIterator struct {
+	data  []types.Row
+	index int
+}
+
+func (it *InMemoryIterator) Next(ctx context.Context) bool {
+	if it.index+1 < len(it.data) {
+		it.index++
+		return true
+	}
+	return false
+}
+
+func (it *InMemoryIterator) Values() types.Row {
+	return it.data[it.index]
+}
+
+func (it *InMemoryIterator) Schema() (types.Schema, error) {
+	return types.Schema{}, nil
+}
+
+func (it *InMemoryIterator) Err() error {
+	return nil
+}
+
+func (it *InMemoryIterator) Close() error {
+	return nil
+}
+
+type SizedInMemoryIterator struct {
+	InMemoryIterator
+}
+
+func (it *SizedInMemoryIterator) Len() (int64, error) {
+	return int64(len(it.data)), nil
+}
+
+func TestNewDataset(t *testing.T) {
+	ctx := logging.NewTestContext(t)
+
+	data := []types.Row{
+		{types.Value{NativeType: "int", Type: types.Int, Value: 1}},
+		{types.Value{NativeType: "int", Type: types.Int, Value: 2}},
+		{types.Value{NativeType: "int", Type: types.Int, Value: 3}}}
+	schema := types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}
+	location, err := pl.NewFileLocationFromURI("file://test")
+	require.NoError(t, err)
+	ds := NewInMemoryDataset(data, schema, location)
+
+	assert.Equal(t, location, ds.Location())
+	sch, err := ds.Schema()
+	require.NoError(t, err)
+	assert.Equal(t, schema, sch)
+
+	iter, err := ds.Iterator(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, iter)
+}
+
+func TestWriteableDataset(t *testing.T) {
+	ctx := logging.NewTestContext(t)
+
+	location, err := pl.NewFileLocationFromURI("file://test")
+	require.NoError(t, err)
+	ds := NewInMemoryDataset([]types.Row{}, types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}, location)
+	rows := []types.Row{
+		{types.Value{NativeType: "int", Type: types.Int, Value: 4}},
+		{types.Value{NativeType: "int", Type: types.Int, Value: 5}},
+	}
+	err = ds.WriteBatch(ctx, rows)
+	require.NoError(t, err)
+	length, err := ds.Len()
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), length)
+}
+
+func TestSizedDataset(t *testing.T) {
+	data := []types.Row{
+		{types.Value{NativeType: "int", Type: types.Int, Value: 1}},
+		{types.Value{NativeType: "int", Type: types.Int, Value: 2}},
+	}
+	schema := types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}
+	location, err := pl.NewFileLocationFromURI("file://test")
+	require.NoError(t, err)
+	ds := NewInMemoryDataset(data, schema, location)
+
+	size, err := ds.Len()
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), size)
+}
+
+func TestSegmentableDataset(t *testing.T) {
+	ctx := logging.NewTestContext(t)
+
+	location, err := pl.NewFileLocationFromURI("file://test")
+	require.NoError(t, err)
+	ds := NewInMemoryDataset([]types.Row{
+		{types.Value{NativeType: "int", Type: types.Int, Value: 1}},
+		{types.Value{NativeType: "int", Type: types.Int, Value: 2}},
+		{types.Value{NativeType: "int", Type: types.Int, Value: 3}},
+	}, types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}, location)
+
+	iter, err := ds.IterateSegment(ctx, 1, 3)
+	require.NoError(t, err)
+	require.NotNil(t, iter)
+
+	require.True(t, iter.Next(ctx))
+	assert.Equal(t, types.Row{types.Value{NativeType: "int", Type: types.Int, Value: 2}}, iter.Values())
+	require.True(t, iter.Next(ctx))
+	assert.Equal(t, types.Row{types.Value{NativeType: "int", Type: types.Int, Value: 3}}, iter.Values())
+	assert.False(t, iter.Next(ctx))
+}
+
+func TestInvalidSegmentableDataset(t *testing.T) {
+	ctx := logging.NewTestContext(t)
+
+	location, err := pl.NewFileLocationFromURI("file://test")
+	require.NoError(t, err)
+	ds := NewInMemoryDataset([]types.Row{
+		{types.Value{NativeType: "int", Type: types.Int, Value: 1}},
+		{types.Value{NativeType: "int", Type: types.Int, Value: 2}},
+	}, types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}, location)
+
+	iter, err := ds.IterateSegment(ctx, -1, 3)
+	assert.Error(t, err)
+	assert.Nil(t, iter)
+}
+
+func TestChunkedDatasetAdapter(t *testing.T) {
+	ctx := logging.NewTestContext(t)
+
+	// Setup: Create a dataset with 10 rows
+	data := make([]types.Row, 10)
+	for i := 0; i < 10; i++ {
+		data[i] = types.Row{types.Value{NativeType: "int", Type: types.Int, Value: i + 1}}
+	}
+	schema := types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}
+	location, err := pl.NewFileLocationFromURI("file://test")
+	require.NoError(t, err)
+	ds := NewInMemoryDataset(data, schema, location)
+
+	// Create adapter with chunk size of 3
+	adapter := ChunkedDatasetAdapter{
+		SizedSegmentableDataset: ds,
+		ChunkSize:               3,
+	}
+
+	// Test 1: Verify correct number of chunks
+	t.Run("NumChunks", func(t *testing.T) {
+		numChunks, err := adapter.NumChunks()
+		require.NoError(t, err)
+		// 10 rows with chunk size 3 should give 4 chunks (3,3,3,1)
+		assert.Equal(t, 4, numChunks)
+	})
+
+	// Test 2: Verify first chunk (should have 3 elements)
+	t.Run("FirstChunk", func(t *testing.T) {
+		// Create test context for this subtest
+		iter, err := adapter.ChunkIterator(ctx, 0)
+		require.NoError(t, err)
+		require.NotNil(t, iter)
+
+		// Verify chunk size
+		size, err := iter.Len()
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), size)
+
+		// Verify chunk contents
+		expectedValues := []int{1, 2, 3}
+		i := 0
+		// Pass context to Next
+		for iter.Next(ctx) {
+			val := iter.Values()
+			assert.Equal(t, expectedValues[i], val[0].Value)
+			i++
+		}
+		assert.Equal(t, 3, i, "Should have iterated through 3 elements")
+	})
+
+	// Test 3: Verify last chunk (should have only 1 element)
+	t.Run("LastChunk", func(t *testing.T) {
+		iter, err := adapter.ChunkIterator(ctx, 3)
+		require.NoError(t, err)
+		require.NotNil(t, iter)
+
+		// Verify chunk size
+		size, err := iter.Len()
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), size)
+
+		// Verify chunk contents
+		require.True(t, iter.Next(ctx))
+		val := iter.Values()
+		assert.Equal(t, 10, val[0].Value)
+		assert.False(t, iter.Next(ctx), "Should have only one element")
+	})
+
+	// Test 4: Verify error handling for out-of-bounds chunk
+	t.Run("OutOfBoundsChunk", func(t *testing.T) {
+		iter, err := adapter.ChunkIterator(ctx, 4)
+		assert.Error(t, err)
+		assert.Nil(t, iter)
+	})
+}
+
+func TestSizedIterator(t *testing.T) {
+	ctx := logging.NewTestContext(t)
+
+	data := []types.Row{
+		{types.Value{NativeType: "int", Type: types.Int, Value: 1}},
+		{types.Value{NativeType: "int", Type: types.Int, Value: 2}},
+		{types.Value{NativeType: "int", Type: types.Int, Value: 3}},
+	}
+
+	iter := &SizedInMemoryIterator{
+		InMemoryIterator: InMemoryIterator{data: data, index: -1},
+	}
+
+	length, err := iter.Len()
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), length)
+
+	count := 0
+	for iter.Next(ctx) {
+		count++
+		val := iter.Values()
+		assert.Equal(t, count, val[0].Value)
+	}
+	assert.Equal(t, 3, count)
+}

--- a/provider/dataset/dataset_test.go
+++ b/provider/dataset/dataset_test.go
@@ -11,12 +11,12 @@ import (
 	pl "github.com/featureform/provider/location"
 )
 
-// DatasetTestCase holds a dataset and expected values for testing
 type DatasetTestCase struct {
 	Dataset        Dataset
 	ExpectedData   []types.Row
 	ExpectedSchema types.Schema
 	Location       pl.Location
+
 	// DatasetFactory creates a new dataset with the same configuration as Dataset
 	// Used for tests that modify the dataset (e.g., write tests)
 	DatasetFactory func() Dataset
@@ -161,10 +161,6 @@ func testWriteableDataset(t *testing.T, ds WriteableDataset, tc DatasetTestCase)
 	// This test will modify the dataset by writing new rows to it
 	t.Run("WriteBatch", func(t *testing.T) {
 		ctx := logging.NewTestContext(t)
-
-		// Note: This test modifies the original dataset by adding rows.
-		// If you need to keep the original dataset unchanged, you would need to
-		// create a new dataset with the same properties before running this test.
 
 		// Create new rows to write
 		newRows := []types.Row{

--- a/provider/dataset/in_memory_dataset.go
+++ b/provider/dataset/in_memory_dataset.go
@@ -1,0 +1,89 @@
+package dataset
+
+import (
+	"context"
+	"errors"
+
+	types "github.com/featureform/fftypes"
+	pl "github.com/featureform/provider/location"
+)
+
+type InMemoryDataset struct {
+	data     []types.Row
+	schema   types.Schema
+	location pl.Location
+}
+
+func NewInMemoryDataset(data []types.Row, schema types.Schema, location pl.Location) *InMemoryDataset {
+	return &InMemoryDataset{data: data, schema: schema, location: location}
+}
+
+func (ds *InMemoryDataset) Location() pl.Location {
+	return ds.location
+}
+
+func (ds *InMemoryDataset) Iterator(ctx context.Context) (Iterator, error) {
+	return &InMemoryIterator{data: ds.data, index: -1}, nil
+}
+
+func (ds *InMemoryDataset) Schema() (types.Schema, error) {
+	return ds.schema, nil
+}
+
+func (ds *InMemoryDataset) WriteBatch(ctx context.Context, rows []types.Row) error {
+	ds.data = append(ds.data, rows...)
+	return nil
+}
+
+func (ds *InMemoryDataset) Len() (int64, error) {
+	return int64(len(ds.data)), nil
+}
+
+func (ds *InMemoryDataset) IterateSegment(ctx context.Context, begin, end int64) (Iterator, error) {
+	size, err := ds.Len()
+	if err != nil {
+		return nil, err
+	}
+	if begin < 0 || end > size || begin > end {
+		return nil, errors.New("invalid segment range")
+	}
+	it := InMemoryIterator{data: ds.data[begin:end], index: -1}
+	return &SizedInMemoryIterator{it}, nil
+}
+
+type InMemoryIterator struct {
+	data  []types.Row
+	index int
+}
+
+func (it *InMemoryIterator) Next(ctx context.Context) bool {
+	if it.index+1 < len(it.data) {
+		it.index++
+		return true
+	}
+	return false
+}
+
+func (it *InMemoryIterator) Values() types.Row {
+	return it.data[it.index]
+}
+
+func (it *InMemoryIterator) Schema() (types.Schema, error) {
+	return types.Schema{}, nil
+}
+
+func (it *InMemoryIterator) Err() error {
+	return nil
+}
+
+func (it *InMemoryIterator) Close() error {
+	return nil
+}
+
+type SizedInMemoryIterator struct {
+	InMemoryIterator
+}
+
+func (it *SizedInMemoryIterator) Len() (int64, error) {
+	return int64(len(it.data)), nil
+}

--- a/provider/dataset/in_memory_dataset_test.go
+++ b/provider/dataset/in_memory_dataset_test.go
@@ -1,0 +1,40 @@
+package dataset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	types "github.com/featureform/fftypes"
+	pl "github.com/featureform/provider/location"
+)
+
+func TestInMemoryDataset(t *testing.T) {
+	// Create test data
+	data := []types.Row{
+		{types.Value{NativeType: "int", Type: types.Int, Value: 1}},
+		{types.Value{NativeType: "int", Type: types.Int, Value: 2}},
+		{types.Value{NativeType: "int", Type: types.Int, Value: 3}},
+	}
+	schema := types.Schema{Fields: []types.ColumnSchema{{Name: "id", NativeType: "int"}}}
+	location, err := pl.NewFileLocationFromURI("file://test")
+	require.NoError(t, err)
+
+	// Create dataset
+	ds := NewInMemoryDataset(data, schema, location)
+
+	// Create test case with factory for creating fresh datasets
+	tc := DatasetTestCase{
+		Dataset:        ds,
+		ExpectedData:   data,
+		ExpectedSchema: schema,
+		Location:       location,
+		DatasetFactory: func() Dataset {
+			// Create a fresh copy of the dataset for tests that modify it
+			return NewInMemoryDataset(data, schema, location)
+		},
+	}
+
+	// Run the generic test suite
+	RunDatasetTestSuite(t, tc)
+}

--- a/provider/location/location.go
+++ b/provider/location/location.go
@@ -204,6 +204,14 @@ func NewFileLocation(path filestore.Filepath) Location {
 	return &FileStoreLocation{path: path}
 }
 
+func NewFileLocationFromURI(uri string) (Location, error) {
+	fp := filestore.FilePath{}
+	if err := fp.ParseFilePath(uri); err != nil {
+		return nil, fferr.NewInternalErrorf("invalid filestore path: %v", err)
+	}
+	return NewFileLocation(&fp), nil
+}
+
 type FileStoreLocation struct {
 	path filestore.Filepath
 }


### PR DESCRIPTION
# Description

Adds dataset interfaces to be used for types

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a comprehensive dataset management framework with support for segmented, chunked, and iterative data processing, including in-memory datasets. This framework enhances data handling by enabling efficient batch operations and robust error checking.
  - Added a new method to create a `Location` from a URI string, improving location handling capabilities.

- **Tests**
  - Added an extensive testing suite to validate core dataset functionalities, including data creation, writing, segmented iteration, and error handling to ensure reliable performance across various scenarios.
  - Implemented tests specifically for the `InMemoryDataset` to verify its functionality and integration with the dataset management framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->