### PR TITLE
Add arm target to Docker images

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -98,6 +98,7 @@ jobs:
         with:
           context: .
           file: ./api/Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: featureformcom/api-server:${{ env.TAG }}
           push: true
           cache-from: type=gha
@@ -133,6 +134,7 @@ jobs:
         with:
           context: .
           file: ./coordinator/Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: featureformcom/coordinator:${{ env.TAG }}
           push: true
           cache-from: type=gha
@@ -168,6 +170,7 @@ jobs:
         with:
           context: .
           file: ./dashboard/Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: featureformcom/dashboard:${{ env.TAG }}
           push: true
           cache-from: type=gha
@@ -203,6 +206,7 @@ jobs:
         with:
           context: .
           file: ./metadata/Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: featureformcom/metadata:${{ env.TAG }}
           push: true
           cache-from: type=gha
@@ -238,6 +242,7 @@ jobs:
         with:
           context: .
           file: ./metadata/dashboard/Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: featureformcom/metadata-dashboard:${{ env.TAG }}
           push: true
           cache-from: type=gha
@@ -273,6 +278,7 @@ jobs:
         with:
           context: .
           file: ./serving/Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: featureformcom/serving:${{ env.TAG }}
           push: true
           cache-from: type=gha
@@ -308,6 +314,7 @@ jobs:
         with:
           context: .
           file: ./runner/Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: featureformcom/worker:${{ env.TAG }}
           push: true
           cache-from: type=gha
@@ -343,6 +350,7 @@ jobs:
         with:
           context: .
           file: ./provider/scripts/k8s/Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: featureformcom/k8s_runner:${{ env.TAG }}
           push: true
           cache-from: type=gha
@@ -378,6 +386,7 @@ jobs:
         with:
           context: .
           file: ./db/Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: featureformcom/db-migration-up:${{ env.TAG }}
           push: true
           cache-from: type=gha
@@ -413,6 +422,7 @@ jobs:
         with:
           context: .
           file: ./streamer/Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: featureformcom/iceberg-streamer:${{ env.TAG }}
           push: true
           cache-from: type=gha
@@ -448,6 +458,7 @@ jobs:
         with:
           context: .
           file: ./streamer_proxy/Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: featureformcom/iceberg-proxy:${{ env.TAG }}
           push: true
           cache-from: type=gha


### PR DESCRIPTION
# Description

Adds arm64 targets to all of our Docker images which didn't have them before.

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Docker image build process to support both AMD64 and ARM64 architectures, ensuring broader compatibility across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->