### PR TITLE
SqlDataset: Add sanitizer to location and Schema

### DIFF
--- a/coordinator/tasks/source.go
+++ b/coordinator/tasks/source.go
@@ -659,7 +659,7 @@ func getReplacementString(offlineStore provider.OfflineStore, tableMapping table
 		if !isSqlLocation {
 			return "", fferr.NewInvalidArgumentError(fmt.Errorf("expected SQLLocation for Postgres; got: %T", tableMapping.location))
 		}
-		return pl.SanitizeSqlLocation(*sqlLocation), nil
+		return sqlLocation.Sanitized(), nil
 	case pt.SparkOffline:
 		return sanitize(tableMapping.name), nil
 	default:

--- a/coordinator/tasks/source.go
+++ b/coordinator/tasks/source.go
@@ -659,7 +659,7 @@ func getReplacementString(offlineStore provider.OfflineStore, tableMapping table
 		if !isSqlLocation {
 			return "", fferr.NewInvalidArgumentError(fmt.Errorf("expected SQLLocation for Postgres; got: %T", tableMapping.location))
 		}
-		return provider.SanitizeSqlLocation(sqlLocation.TableLocation()), nil
+		return pl.SanitizeSqlLocation(*sqlLocation), nil
 	case pt.SparkOffline:
 		return sanitize(tableMapping.name), nil
 	default:

--- a/fftypes/types.go
+++ b/fftypes/types.go
@@ -311,8 +311,6 @@ type ColumnSchema struct {
 	Name       ColumnName
 	NativeType NativeType
 	Type       ValueType
-	
-	sanitizer func(string) string // function to sanitize column names that differs between databases
 }
 
 type Value struct {
@@ -333,6 +331,8 @@ type TypeConverterMapping map[string]TypeConverter
 type Schema struct {
 	Fields []ColumnSchema
 	// todo: can include more state or behavior, etc.
+
+	columnSanitizer func(string) string
 }
 
 // ColumnNames returns a slice of all column names in the schema
@@ -347,10 +347,10 @@ func (s Schema) ColumnNames() []string {
 func (s Schema) SanitizedColumnNames() []string {
 	names := make([]string, len(s.Fields))
 	for i, field := range s.Fields {
-		if field.sanitizer == nil {
+		if s.columnSanitizer == nil {
 			names[i] = sanitizeColumnName(string(field.Name))
 		} else {
-			names[i] = field.sanitizer(string(field.Name))
+			names[i] = s.columnSanitizer(string(field.Name))
 
 		}
 	}

--- a/helpers/postgres/postgres.go
+++ b/helpers/postgres/postgres.go
@@ -16,14 +16,13 @@ import (
 
 	"github.com/jackc/pgx/v4/stdlib"
 
-	"github.com/featureform/fferr"
-	"github.com/featureform/logging"
-	"github.com/featureform/logging/redacted"
-	pl "github.com/featureform/provider/location"
-
 	"github.com/avast/retry-go/v4"
 	psql "github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
+
+	"github.com/featureform/fferr"
+	"github.com/featureform/logging"
+	"github.com/featureform/logging/redacted"
 )
 
 type Pool struct {
@@ -185,14 +184,4 @@ func (c Config) ConnectionString() string {
 
 func Sanitize(ident string) string {
 	return psql.Identifier{ident}.Sanitize()
-}
-
-func SanitizeLocation(obj pl.SQLLocation) string {
-	var parts []string
-	if obj.GetDatabase() != "" && obj.GetSchema() != "" {
-		parts = append(parts, obj.GetDatabase())
-		parts = append(parts, obj.GetSchema())
-	}
-	parts = append(parts, obj.GetTable())
-	return psql.Identifier(parts).Sanitize()
 }

--- a/provider/bigquery/types_test.go
+++ b/provider/bigquery/types_test.go
@@ -146,7 +146,7 @@ func TestBigQueryTypeConversions(t *testing.T) {
 		// Create dataset with the schema and converter
 		ds, err := dataset.NewSqlDataset(
 			db,
-			*location,
+			location,
 			schema,
 			bqConverter,
 			1, // Limit to 1 row

--- a/provider/clickhouse_test.go
+++ b/provider/clickhouse_test.go
@@ -57,6 +57,7 @@ func (ch *clickHouseOfflineStoreTester) CreateTable(loc pl.Location, schema Tabl
 	logger := ch.logger.With("location", loc, "schema", schema)
 
 	sqlLocation, ok := loc.(*pl.SQLLocation)
+	sqlLocation.SetSanitizer(sanitizeClickHouseTableName)
 	if !ok {
 		errMsg := fmt.Sprintf("invalid location type, expected SQLLocation, got %T", loc)
 		logger.Errorw(errMsg)

--- a/provider/correctness_test.go
+++ b/provider/correctness_test.go
@@ -513,7 +513,7 @@ func newTestSQLTransformationData(test offlineSqlTest, transformationQuery strin
 			Query:         fmt.Sprintf(queryFmt, test.testConfig.sanitizeTableName(tableLoc)),
 			SourceMapping: []SourceMapping{
 				{
-					Template:       pl.SanitizeFullyQualifiedObject(tableLoc),
+					Template:       sqlLoc.Sanitized(),
 					Source:         tableLoc.String(),
 					ProviderType:   test.storeTester.Type(),
 					ProviderConfig: test.storeTester.Config(),

--- a/provider/correctness_test.go
+++ b/provider/correctness_test.go
@@ -513,7 +513,7 @@ func newTestSQLTransformationData(test offlineSqlTest, transformationQuery strin
 			Query:         fmt.Sprintf(queryFmt, test.testConfig.sanitizeTableName(tableLoc)),
 			SourceMapping: []SourceMapping{
 				{
-					Template:       SanitizeSqlLocation(tableLoc),
+					Template:       pl.SanitizeFullyQualifiedObject(tableLoc),
 					Source:         tableLoc.String(),
 					ProviderType:   test.storeTester.Type(),
 					ProviderConfig: test.storeTester.Config(),

--- a/provider/dataset/dataset.go
+++ b/provider/dataset/dataset.go
@@ -22,7 +22,7 @@ import (
 type Dataset interface {
 	Location() pl.Location
 	Iterator(ctx Context) (Iterator, error)
-	Schema() (types.Schema, error)
+	Schema() types.Schema
 }
 
 // WriteableDataset is a Dataset that you can write to. For some datasets,

--- a/provider/dataset/dataset_test.go
+++ b/provider/dataset/dataset_test.go
@@ -97,8 +97,7 @@ func testIteratorSize(t *testing.T, iter Iterator, expectedSize int64) (isSized 
 
 func testBasicProperties(t *testing.T, tc DatasetTestCase) {
 	assert.Equal(t, tc.Location, tc.Dataset.Location())
-	schema, err := tc.Dataset.Schema()
-	require.NoError(t, err)
+	schema := tc.Dataset.Schema()
 	assert.Equal(t, tc.ExpectedSchema, schema)
 }
 

--- a/provider/dataset/in_memory_dataset.go
+++ b/provider/dataset/in_memory_dataset.go
@@ -33,8 +33,8 @@ func (ds *InMemoryDataset) Iterator(ctx context.Context) (Iterator, error) {
 	return &InMemoryIterator{data: ds.data, schema: ds.schema, index: -1}, nil
 }
 
-func (ds *InMemoryDataset) Schema() (types.Schema, error) {
-	return ds.schema, nil
+func (ds *InMemoryDataset) Schema() types.Schema {
+	return ds.schema
 }
 
 func (ds *InMemoryDataset) WriteBatch(ctx context.Context, rows []types.Row) error {

--- a/provider/dataset/sql_dataset.go
+++ b/provider/dataset/sql_dataset.go
@@ -13,8 +13,6 @@ import (
 	"fmt"
 	"strings"
 
-	db "github.com/jackc/pgx/v4"
-
 	"github.com/featureform/fferr"
 	types "github.com/featureform/fftypes"
 	"github.com/featureform/logging"
@@ -134,10 +132,7 @@ func (ds SqlDataset) Location() location.Location {
 
 func (ds SqlDataset) Iterator(ctx context.Context) (Iterator, error) {
 	logger := logging.GetLoggerFromContext(ctx)
-	columnNames := make([]string, 0)
-	for _, col := range ds.schema.ColumnNames() {
-		columnNames = append(columnNames, sanitizeCol(col))
-	}
+	columnNames := ds.Schema().SanitizedColumnNames()
 	cols := strings.Join(columnNames, ", ")
 	loc := ds.location.Sanitized()
 	var query string
@@ -268,8 +263,4 @@ func (it *SqlIterator) Next() bool {
 
 	it.currentValues = it.rowBuffer
 	return true
-}
-
-func sanitizeCol(ident string) string {
-	return db.Identifier{ident}.Sanitize()
 }

--- a/provider/dataset/sql_dataset_test.go
+++ b/provider/dataset/sql_dataset_test.go
@@ -71,7 +71,7 @@ func TestSqlDatasetQueryConstruction(t *testing.T) {
 			tc.setupMockFn(mock)
 
 			// Create dataset
-			ds, err := NewSqlDataset(db, *loc, testSchema, mockConverter, tc.limit)
+			ds, err := NewSqlDataset(db, loc, testSchema, mockConverter, tc.limit)
 			require.NoError(t, err)
 
 			// Call the method that builds and executes the query

--- a/provider/dataset/sql_dataset_test.go
+++ b/provider/dataset/sql_dataset_test.go
@@ -1,0 +1,109 @@
+package dataset
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	types "github.com/featureform/fftypes"
+	"github.com/featureform/provider/location"
+)
+
+func TestSqlDatasetQueryConstruction(t *testing.T) {
+	// Create a mock database connection
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Setup test data
+	testSchema := types.Schema{
+		Fields: []types.ColumnSchema{
+			{Name: "id", NativeType: "integer", Type: types.Int},
+			{Name: "name", NativeType: "varchar", Type: types.String},
+			{Name: "special; column--", NativeType: "varchar", Type: types.String}, // Test sanitization
+		},
+	}
+
+	// Mock converter - can be replaced with actual implementation or a more detailed mock
+	mockConverter := &mockIntegerValueConverter{}
+
+	testCases := []struct {
+		name           string
+		limit          int
+		expectedQuery  string
+		setupMockFn    func(mock sqlmock.Sqlmock)
+		locationSchema string
+		locationTable  string
+	}{
+		{
+			name:           "No Limit Query",
+			limit:          -1,
+			locationSchema: "test_schema",
+			locationTable:  "test_table",
+			setupMockFn: func(mock sqlmock.Sqlmock) {
+				columns := []string{"id", "name", "special; column--"}
+				mock.ExpectQuery(`SELECT "id", "name", "special; column--" FROM "test_schema"."test_table"`).
+					WillReturnRows(sqlmock.NewRows(columns))
+			},
+		},
+		{
+			name:           "With Limit Query",
+			limit:          10,
+			locationSchema: "test_schema",
+			locationTable:  "test_table",
+			setupMockFn: func(mock sqlmock.Sqlmock) {
+				columns := []string{"id", "name", "special; column--"}
+				mock.ExpectQuery(`SELECT "id", "name", "special; column--" FROM "test_schema"."test_table" LIMIT 10`).
+					WillReturnRows(sqlmock.NewRows(columns))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup location
+			loc := location.NewSQLLocationFromParts("", tc.locationSchema, tc.locationTable)
+
+			// Setup mock expectations
+			tc.setupMockFn(mock)
+
+			// Create dataset
+			ds, err := NewSqlDataset(db, *loc, testSchema, mockConverter, tc.limit)
+			require.NoError(t, err)
+
+			// Call the method that builds and executes the query
+			ctx := context.Background()
+			iterator, err := ds.Iterator(ctx)
+
+			// Verify results
+			assert.NoError(t, err)
+			assert.NotNil(t, iterator)
+
+			// Verify all expectations were met
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+// Simple mock converter
+type mockIntegerValueConverter struct{}
+
+func (m *mockIntegerValueConverter) ConvertValue(nativeType types.NativeType, value any) (types.Value, error) {
+	return types.Value{
+		NativeType: nativeType,
+		Type:       types.Int,
+		Value:      value,
+	}, nil
+}
+
+func (m *mockIntegerValueConverter) GetType(nativeType types.NativeType) (types.ValueType, error) {
+	switch nativeType {
+	case "integer":
+		return types.Int, nil
+	default:
+		return types.String, nil
+	}
+}

--- a/provider/location/location.go
+++ b/provider/location/location.go
@@ -105,6 +105,7 @@ func (f FullyQualifiedObject) String() string {
 	return strings.Join(parts, ".")
 }
 
+// This is a helper function to sanitize a fully qualified object for use in most SQL queries (postgres, snowflake, etc.)
 func SanitizeFullyQualifiedObject(obj FullyQualifiedObject) string {
 	ident := psql.Identifier{}
 

--- a/provider/location/location.go
+++ b/provider/location/location.go
@@ -125,6 +125,8 @@ type SQLLocation struct {
 	database string
 	schema   string
 	table    string
+
+	sanitizer func(obj FullyQualifiedObject) string
 }
 
 func (l *SQLLocation) GetDatabase() string {
@@ -149,6 +151,10 @@ func (l *SQLLocation) IsAbsolute() bool {
 
 func (l *SQLLocation) IsRelative() bool {
 	return !l.IsAbsolute()
+}
+
+func (l *SQLLocation) SetSanitizer(sanitizer func(obj FullyQualifiedObject) string) {
+	l.sanitizer = sanitizer
 }
 
 // GetTableFromRoot return table if it's an absolute position.
@@ -218,8 +224,12 @@ func (l *SQLLocation) Proto() *pb.Location {
 	}
 }
 
-func SanitizeSqlLocation(loc SQLLocation) string {
-	return SanitizeFullyQualifiedObject(loc.TableLocation())
+func (l *SQLLocation) Sanitized() string {
+	if l.sanitizer == nil {
+		return SanitizeFullyQualifiedObject(l.TableLocation())
+	} else {
+		return l.sanitizer(l.TableLocation())
+	}
 }
 
 func NewFileLocation(path filestore.Filepath) Location {

--- a/provider/location/location_test.go
+++ b/provider/location/location_test.go
@@ -9,6 +9,8 @@ package location
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSQLLocation_TableLocation(t *testing.T) {
@@ -230,10 +232,7 @@ func TestSQLLocation_GetTableFromRoot(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.root.GetTableFromRoot(&tt.table)
-
-			if *result != tt.expected {
-				t.Errorf("Root %v, Table %v, GetTableFromRoot() = %v, want %v", tt.root, tt.table, result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, *result)
 		})
 	}
 }

--- a/provider/postgres.go
+++ b/provider/postgres.go
@@ -14,15 +14,15 @@ import (
 	"text/template"
 	"time"
 
+	_ "github.com/lib/pq"
+
 	"github.com/featureform/fferr"
-	helper "github.com/featureform/helpers/postgres"
 	"github.com/featureform/logging"
 	pl "github.com/featureform/provider/location"
 	pc "github.com/featureform/provider/provider_config"
 	pt "github.com/featureform/provider/provider_type"
 	tsq "github.com/featureform/provider/tsquery"
 	"github.com/featureform/provider/types"
-	_ "github.com/lib/pq"
 )
 
 type postgresColumnType string
@@ -142,7 +142,7 @@ WHERE rn = 1
 		"tsSelectStatement":  tsSelectStatement,
 		"tsOrderByStatement": tsOrderByStatement,
 		// TODO: Error checking for SQLLocation
-		"sourceLocation": helper.SanitizeLocation(*schema.SourceTable.(*pl.SQLLocation)),
+		"sourceLocation": pl.SanitizeSqlLocation(*schema.SourceTable.(*pl.SQLLocation)),
 	}
 
 	var sb strings.Builder
@@ -220,7 +220,7 @@ func (q postgresSQLQueries) adaptTsDefToBuilderParams(def TrainingSetDef) (tsq.B
 		if !isSQLLocation {
 			return "", fferr.NewInternalErrorf("label location is not an SQL location, actual %T. %v", lblLoc, lblLoc)
 		}
-		return helper.SanitizeLocation(*lblLoc), nil
+		return pl.SanitizeSqlLocation(*lblLoc), nil
 	}
 
 	// TODO: Create and pass in actual logger

--- a/provider/postgres.go
+++ b/provider/postgres.go
@@ -135,6 +135,8 @@ WHERE rn = 1
 		tsOrderByStatement = ""
 	}
 
+	sqlLoc := schema.SourceTable.(*pl.SQLLocation)
+
 	values := map[string]any{
 		"tableName":          sanitize(tableName),
 		"entity":             schema.Entity,
@@ -142,7 +144,7 @@ WHERE rn = 1
 		"tsSelectStatement":  tsSelectStatement,
 		"tsOrderByStatement": tsOrderByStatement,
 		// TODO: Error checking for SQLLocation
-		"sourceLocation": pl.SanitizeSqlLocation(*schema.SourceTable.(*pl.SQLLocation)),
+		"sourceLocation": sqlLoc.Sanitized(),
 	}
 
 	var sb strings.Builder
@@ -220,7 +222,7 @@ func (q postgresSQLQueries) adaptTsDefToBuilderParams(def TrainingSetDef) (tsq.B
 		if !isSQLLocation {
 			return "", fferr.NewInternalErrorf("label location is not an SQL location, actual %T. %v", lblLoc, lblLoc)
 		}
-		return pl.SanitizeSqlLocation(*lblLoc), nil
+		return lblLoc.Sanitized(), nil
 	}
 
 	// TODO: Create and pass in actual logger

--- a/provider/postgres_test.go
+++ b/provider/postgres_test.go
@@ -66,7 +66,7 @@ func getConfiguredPostgresTester(t *testing.T) offlineSqlTest {
 
 	sanitizeTableName := func(obj pl.FullyQualifiedObject) string {
 		loc := pl.NewSQLLocationFromParts(obj.Database, obj.Schema, obj.Table)
-		return pl.SanitizeSqlLocation(*loc)
+		return loc.Sanitized()
 	}
 
 	return offlineSqlTest{

--- a/provider/postgres_test.go
+++ b/provider/postgres_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	helper "github.com/featureform/helpers/postgres"
 	pl "github.com/featureform/provider/location"
 	pt "github.com/featureform/provider/provider_type"
 )
@@ -67,7 +66,7 @@ func getConfiguredPostgresTester(t *testing.T) offlineSqlTest {
 
 	sanitizeTableName := func(obj pl.FullyQualifiedObject) string {
 		loc := pl.NewSQLLocationFromParts(obj.Database, obj.Schema, obj.Table)
-		return helper.SanitizeLocation(*loc)
+		return pl.SanitizeSqlLocation(*loc)
 	}
 
 	return offlineSqlTest{

--- a/provider/postgres_tester_test.go
+++ b/provider/postgres_tester_test.go
@@ -116,7 +116,7 @@ func (p *postgresOfflineStoreTester) CreateTable(loc location.Location, schema T
 	}
 
 	var queryBuilder strings.Builder
-	queryBuilder.WriteString(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (", location.SanitizeFullyQualifiedObject(sqlLocation.TableLocation())))
+	queryBuilder.WriteString(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (", sqlLocation.Sanitized()))
 	for i, column := range schema.Columns {
 		if i > 0 {
 			queryBuilder.WriteString(", ")

--- a/provider/postgres_tester_test.go
+++ b/provider/postgres_tester_test.go
@@ -116,7 +116,7 @@ func (p *postgresOfflineStoreTester) CreateTable(loc location.Location, schema T
 	}
 
 	var queryBuilder strings.Builder
-	queryBuilder.WriteString(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (", SanitizeSqlLocation(sqlLocation.TableLocation())))
+	queryBuilder.WriteString(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (", location.SanitizeFullyQualifiedObject(sqlLocation.TableLocation())))
 	for i, column := range schema.Columns {
 		if i > 0 {
 			queryBuilder.WriteString(", ")

--- a/provider/snowflake.go
+++ b/provider/snowflake.go
@@ -272,7 +272,7 @@ func (sf *snowflakeOfflineStore) CreateMaterialization(id ResourceID, opts Mater
 		logger.Errorw("Source table is not an SQL location", "location_type", fmt.Sprintf("%T", opts.Schema.SourceTable))
 		return nil, fferr.NewInvalidArgumentErrorf("source table is not an SQL location")
 	}
-	materializationAsQuery := sf.sfQueries.materializationCreateAsQuery(opts.Schema.Entity, opts.Schema.Value, opts.Schema.TS, pl.SanitizeFullyQualifiedObject(sqlLoc.TableLocation()))
+	materializationAsQuery := sf.sfQueries.materializationCreateAsQuery(opts.Schema.Entity, opts.Schema.Value, opts.Schema.TS, sqlLoc.Sanitized())
 	if err := resConfig.Validate(); err != nil {
 		logger.Errorw("Failed to validate dynamic table config", "error", err)
 		return nil, err

--- a/provider/snowflake.go
+++ b/provider/snowflake.go
@@ -272,7 +272,7 @@ func (sf *snowflakeOfflineStore) CreateMaterialization(id ResourceID, opts Mater
 		logger.Errorw("Source table is not an SQL location", "location_type", fmt.Sprintf("%T", opts.Schema.SourceTable))
 		return nil, fferr.NewInvalidArgumentErrorf("source table is not an SQL location")
 	}
-	materializationAsQuery := sf.sfQueries.materializationCreateAsQuery(opts.Schema.Entity, opts.Schema.Value, opts.Schema.TS, SanitizeSqlLocation(sqlLoc.TableLocation()))
+	materializationAsQuery := sf.sfQueries.materializationCreateAsQuery(opts.Schema.Entity, opts.Schema.Value, opts.Schema.TS, pl.SanitizeFullyQualifiedObject(sqlLoc.TableLocation()))
 	if err := resConfig.Validate(); err != nil {
 		logger.Errorw("Failed to validate dynamic table config", "error", err)
 		return nil, err

--- a/provider/snowflake/types_test.go
+++ b/provider/snowflake/types_test.go
@@ -96,7 +96,7 @@ func TestSnowflakeTypeConversions(t *testing.T) {
 		location := pl.NewSQLLocation("test_table")
 
 		// Create the dataset with schema and SfConverter (not TypeMap)
-		return dataset.NewSqlDataset(db, *location, schema, SfConverter, 1)
+		return dataset.NewSqlDataset(db, location, schema, SfConverter, 1)
 	}
 
 	// Create a type map for the test harness
@@ -170,7 +170,7 @@ func TestTimestampTypeHandling(t *testing.T) {
 			// Create dataset
 			ds, err := dataset.NewSqlDataset(
 				db,
-				*location,
+				location,
 				schema,
 				SfConverter,
 				1,

--- a/provider/snowflake_queries.go
+++ b/provider/snowflake_queries.go
@@ -118,13 +118,11 @@ func (q snowflakeSQLQueries) materializationCreateAsQuery(entity, value, ts, tab
 }
 
 func (q snowflakeSQLQueries) dropTableQuery(loc pl.SQLLocation) string {
-	obj := loc.TableLocation()
-	return fmt.Sprintf("DROP TABLE %s", pl.SanitizeFullyQualifiedObject(obj))
+	return fmt.Sprintf("DROP TABLE %s", loc.Sanitized())
 }
 
 func (q snowflakeSQLQueries) dropViewQuery(loc pl.SQLLocation) string {
-	obj := loc.TableLocation()
-	return fmt.Sprintf("DROP VIEW %s", pl.SanitizeFullyQualifiedObject(obj))
+	return fmt.Sprintf("DROP VIEW %s", loc.Sanitized())
 }
 
 func SanitizeSnowflakeIdentifier(obj pl.FullyQualifiedObject) string {

--- a/provider/snowflake_queries.go
+++ b/provider/snowflake_queries.go
@@ -12,9 +12,10 @@ import (
 	"strings"
 	"time"
 
+	db "github.com/jackc/pgx/v4"
+
 	"github.com/featureform/metadata"
 	pl "github.com/featureform/provider/location"
-	db "github.com/jackc/pgx/v4"
 )
 
 const CATALOG_CLAUSE = "CATALOG = 'SNOWFLAKE' "
@@ -118,12 +119,12 @@ func (q snowflakeSQLQueries) materializationCreateAsQuery(entity, value, ts, tab
 
 func (q snowflakeSQLQueries) dropTableQuery(loc pl.SQLLocation) string {
 	obj := loc.TableLocation()
-	return fmt.Sprintf("DROP TABLE %s", SanitizeSqlLocation(obj))
+	return fmt.Sprintf("DROP TABLE %s", pl.SanitizeFullyQualifiedObject(obj))
 }
 
 func (q snowflakeSQLQueries) dropViewQuery(loc pl.SQLLocation) string {
 	obj := loc.TableLocation()
-	return fmt.Sprintf("DROP VIEW %s", SanitizeSqlLocation(obj))
+	return fmt.Sprintf("DROP VIEW %s", pl.SanitizeFullyQualifiedObject(obj))
 }
 
 func SanitizeSnowflakeIdentifier(obj pl.FullyQualifiedObject) string {

--- a/provider/snowflake_types_test.go
+++ b/provider/snowflake_types_test.go
@@ -371,7 +371,7 @@ func TestSnowflakeTypeConversions(t *testing.T) {
 	// Create a test table with all supported Snowflake types
 	tableName := fmt.Sprintf("test_types_%s", strings.ToLower(uuid.NewString()[:8]))
 	location := pl.NewSQLLocationFromParts(snowflakeConfig.Database, "test_types", tableName)
-	sqlLocation := SanitizeSqlLocation(location.TableLocation())
+	sqlLocation := pl.SanitizeSqlLocation(*location)
 
 	// Generate the create table SQL from our test data structure
 	createTableQuery := testData.GenerateCreateTableSQL(sqlLocation)

--- a/provider/snowflake_types_test.go
+++ b/provider/snowflake_types_test.go
@@ -371,7 +371,7 @@ func TestSnowflakeTypeConversions(t *testing.T) {
 	// Create a test table with all supported Snowflake types
 	tableName := fmt.Sprintf("test_types_%s", strings.ToLower(uuid.NewString()[:8]))
 	location := pl.NewSQLLocationFromParts(snowflakeConfig.Database, "test_types", tableName)
-	sqlLocation := pl.SanitizeSqlLocation(*location)
+	sqlLocation := location.Sanitized()
 
 	// Generate the create table SQL from our test data structure
 	createTableQuery := testData.GenerateCreateTableSQL(sqlLocation)
@@ -386,7 +386,7 @@ func TestSnowflakeTypeConversions(t *testing.T) {
 	// Connect to the table using our converter
 	ds, err := dataset.NewSqlDatasetWithAutoSchema(
 		offlineStoreTester.db,
-		*location,
+		location,
 		snowflake.SfConverter,
 		1, // Limit to the one row we inserted
 	)

--- a/provider/sql.go
+++ b/provider/sql.go
@@ -2071,19 +2071,3 @@ func GetTransformationTableName(id ResourceID) (string, error) {
 	}
 	return ps.ResourceToTableName("Transformation", id.Name, id.Variant)
 }
-
-func SanitizeSqlLocation(obj pl.FullyQualifiedObject) string {
-	ident := db.Identifier{}
-
-	if obj.Database != "" && obj.Schema != "" {
-		ident = append(ident, obj.Database)
-	}
-
-	if obj.Schema != "" {
-		ident = append(ident, obj.Schema)
-	}
-
-	ident = append(ident, obj.Table)
-
-	return ident.Sanitize()
-}

--- a/provider/sql.go
+++ b/provider/sql.go
@@ -1288,7 +1288,7 @@ func (table *SqlPrimaryTable) ToDataset() (dataset.SqlDataset, error) {
 	}
 	return dataset.NewSqlDatasetWithAutoSchema(
 		table.db,
-		*table.sqlLocation,
+		table.sqlLocation,
 		conv,
 		-1,
 	)


### PR DESCRIPTION
# Description

Also seeing that we have two different sql location sanitizations so consolidating the 2

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the process for formatting and sanitizing SQL identifiers across supported database integrations, ensuring more consistent query construction.
  - Updated sanitization methods for SQL locations and identifiers, enhancing clarity and code reuse.
  - Simplified return types for schema retrieval methods, removing error handling for a more straightforward interface.
  
- **Tests**
  - Added unit tests to verify proper SQL query formation and reinforce overall reliability.
  - Updated existing tests to reflect changes in sanitization methods and schema retrieval.

- **Chore**
  - Removed outdated sanitization routines and eliminated redundant dependencies to simplify maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->