### PR TITLE
Enterprise port: register_training_set() missing default param && type validation

### DIFF
--- a/client/src/featureform/register.py
+++ b/client/src/featureform/register.py
@@ -659,6 +659,7 @@ class OfflineSparkProvider(OfflineProvider):
         schedule: str = "",
         tags: List[str] = [],
         properties: dict = {},
+        type: TrainingSetType = TrainingSetType.DYNAMIC,
     ):
         """Register a training set on the Spark provider.
 
@@ -698,6 +699,7 @@ class OfflineSparkProvider(OfflineProvider):
             tags=tags,
             properties=properties,
             provider=self.name(),
+            type=type,
         )
 
     def __eq__(self, __value: object) -> bool:
@@ -4828,6 +4830,8 @@ class Registrar:
             if isinstance(feature, tuple) and feature[1] == "":
                 feature = (feature[0], self.__run)
             processed_features.append(feature)
+        if not isinstance(type, TrainingSetType):
+            raise TypeError("Expected Training Set \"type\" to be TrainingSetType.DYNAMIC|STATIC|VIEW")
         resource = TrainingSetVariant(
             created=None,
             name=name,


### PR DESCRIPTION
# Description

This PR fixes an issue where registering a training set throws a server panic due to an incorrect type value that the client allowed to pass through. Avoids polluting the backend state as well since incorrect types still allow resources to get saved.

new validation check
<img width="1236" alt="Screenshot 2025-04-07 at 12 08 50 PM" src="https://github.com/user-attachments/assets/eadb235c-5f19-4b4c-9a4f-769dcd7ff72a" />

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the training set registration process by allowing users to specify a training set category. This improvement includes robust validation to ensure a proper configuration is used, providing greater flexibility and error feedback when an invalid choice is made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->