### PR TITLE
Fix float conversion for Postgres

### DIFF
--- a/provider/postgres.go
+++ b/provider/postgres.go
@@ -10,6 +10,7 @@ package provider
 import (
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -268,6 +269,18 @@ func (q postgresSQLQueries) castTableItemType(v interface{}, t interface{}) inte
 	case pgBigInt:
 		return int(v.(int64))
 	case pgFloat:
+		// If the column type is NUMERIC, the SQL interface will return the value as
+		// a []uint8 type. This is the ASCII-formatted value of the float, and is
+		// done because the NUMERIC type has arbitrary precision.
+		if byteArray, ok := v.([]uint8); ok {
+			floatVal, err := strconv.ParseFloat(string(byteArray), 64)
+			if err != nil {
+				return nil
+			}
+			return floatVal
+		}
+
+		// Fall back to the original case for actual float64 values
 		return v.(float64)
 	case pgString:
 		return v.(string)

--- a/provider/postgres.go
+++ b/provider/postgres.go
@@ -32,6 +32,7 @@ const (
 	pgInt       postgresColumnType = "integer"
 	pgBigInt    postgresColumnType = "bigint"
 	pgFloat     postgresColumnType = "float8"
+	pgNumeric   postgresColumnType = "numeric"
 	pgString    postgresColumnType = "varchar"
 	pgBool      postgresColumnType = "boolean"
 	pgTimestamp postgresColumnType = "timestamp with time zone"
@@ -269,19 +270,17 @@ func (q postgresSQLQueries) castTableItemType(v interface{}, t interface{}) inte
 	case pgBigInt:
 		return int(v.(int64))
 	case pgFloat:
+		return v.(float64)
+	case pgNumeric:
 		// If the column type is NUMERIC, the SQL interface will return the value as
 		// a []uint8 type. This is the ASCII-formatted value of the float, and is
 		// done because the NUMERIC type has arbitrary precision.
-		if byteArray, ok := v.([]uint8); ok {
-			floatVal, err := strconv.ParseFloat(string(byteArray), 64)
-			if err != nil {
-				return nil
-			}
-			return floatVal
+		byteArray := v.([]uint8)
+		floatVal, err := strconv.ParseFloat(string(byteArray), 64)
+		if err != nil {
+			return nil
 		}
-
-		// Fall back to the original case for actual float64 values
-		return v.(float64)
+		return floatVal
 	case pgString:
 		return v.(string)
 	case pgBool:
@@ -301,8 +300,10 @@ func (q postgresSQLQueries) getValueColumnType(t *sql.ColumnType) interface{} {
 		return pgBigInt
 	case "int64":
 		return pgBigInt
-	case "float32", "float64", "interface {}":
+	case "float32", "float64":
 		return pgFloat
+	case "interface {}":
+		return pgNumeric
 	case "bool":
 		return pgBool
 	case "time.Time":

--- a/provider/postgres_test.go
+++ b/provider/postgres_test.go
@@ -113,9 +113,9 @@ func TestPostgresCastTableItemType(t *testing.T) {
 			expected: 3.14,
 		},
 		{
-			name:     "pgNumeric conversion",
+			name:     "Numeric column type",
 			input:    []uint8{49, 57, 49, 46, 56, 51},
-			typeSpec: pgNumeric,
+			typeSpec: pgFloat,
 			expected: 191.83,
 		},
 		{

--- a/provider/postgres_test.go
+++ b/provider/postgres_test.go
@@ -113,9 +113,9 @@ func TestPostgresCastTableItemType(t *testing.T) {
 			expected: 3.14,
 		},
 		{
-			name:     "Numeric column type",
+			name:     "pgNumeric conversion",
 			input:    []uint8{49, 57, 49, 46, 56, 51},
-			typeSpec: pgFloat,
+			typeSpec: pgNumeric,
 			expected: 191.83,
 		},
 		{

--- a/provider/postgres_test.go
+++ b/provider/postgres_test.go
@@ -113,6 +113,12 @@ func TestPostgresCastTableItemType(t *testing.T) {
 			expected: 3.14,
 		},
 		{
+			name:     "Numeric column type",
+			input:    []uint8{49, 57, 49, 46, 56, 51},
+			typeSpec: pgFloat,
+			expected: 191.83,
+		},
+		{
 			name:     "pgString conversion",
 			input:    "hello",
 			typeSpec: pgString,

--- a/provider/postgres_test.go
+++ b/provider/postgres_test.go
@@ -113,7 +113,7 @@ func TestPostgresCastTableItemType(t *testing.T) {
 			expected: 3.14,
 		},
 		{
-			name:     "Numeric column type",
+			name:     "pgFloat numeric type conversion",
 			input:    []uint8{49, 57, 49, 46, 56, 51},
 			typeSpec: pgFloat,
 			expected: 191.83,


### PR DESCRIPTION
# Description

When a column type is `NUMERIC` in Postgres, the SQL interface we have will return it as a `[]uint8` when we scan it in. This is because `NUMERIC` is arbitrary-precision. Previously, we didn't handle this case, and a panic was thrown when attempting to convert the value.

<!--- Please include a summary of the changes and the related issue. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type of change

### Does this correspond to an open issue?
<!--- Provide a link to the issue if not already associated -->

### Select type(s) of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that modifies some code)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have fixed any merge conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced handling of `pgFloat` column type for improved numeric value conversion from byte arrays.
- **Tests**
  - Added a test case for verifying the conversion of byte arrays to numeric values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->